### PR TITLE
Brand pivot to Pro skin + lead engine + community surfaces

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,13 @@ const nextConfig: NextConfig = {
         hostname: "*.supabase.co",
         pathname: "/storage/v1/object/public/**",
       },
+      // Unsplash — used for placeholder gallery photos during seed; remove
+      // once real meetup photos are uploaded to Supabase Storage.
+      {
+        protocol: "https",
+        hostname: "images.unsplash.com",
+        pathname: "/**",
+      },
     ],
     formats: ["image/avif", "image/webp"],
   },

--- a/prisma/migrations/20260521175245_add_gallery_newsletter_potw/migration.sql
+++ b/prisma/migrations/20260521175245_add_gallery_newsletter_potw/migration.sql
@@ -1,0 +1,67 @@
+-- CreateEnum
+CREATE TYPE "NewsletterStatus" AS ENUM ('DRAFT', 'PUBLISHED');
+
+-- AlterTable
+ALTER TABLE "projects" ADD COLUMN "potwAt" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "meetup_photos" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT,
+    "url" TEXT NOT NULL,
+    "thumbnailUrl" TEXT,
+    "alt" TEXT,
+    "caption" TEXT,
+    "photographer" TEXT,
+    "featured" BOOLEAN NOT NULL DEFAULT false,
+    "order" INTEGER NOT NULL DEFAULT 0,
+    "takenAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "meetup_photos_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "newsletter_issues" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "number" INTEGER NOT NULL,
+    "title" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "excerpt" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "publishedAt" TIMESTAMP(3) NOT NULL,
+    "status" "NewsletterStatus" NOT NULL DEFAULT 'DRAFT',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "newsletter_issues_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "projects_potwAt_idx" ON "projects"("potwAt");
+
+-- CreateIndex
+CREATE INDEX "meetup_photos_eventId_idx" ON "meetup_photos"("eventId");
+
+-- CreateIndex
+CREATE INDEX "meetup_photos_featured_idx" ON "meetup_photos"("featured");
+
+-- CreateIndex
+CREATE INDEX "meetup_photos_order_idx" ON "meetup_photos"("order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "newsletter_issues_slug_key" ON "newsletter_issues"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "newsletter_issues_number_key" ON "newsletter_issues"("number");
+
+-- CreateIndex
+CREATE INDEX "newsletter_issues_publishedAt_idx" ON "newsletter_issues"("publishedAt");
+
+-- CreateIndex
+CREATE INDEX "newsletter_issues_status_idx" ON "newsletter_issues"("status");
+
+-- AddForeignKey
+ALTER TABLE "meetup_photos" ADD CONSTRAINT "meetup_photos_eventId_fkey" FOREIGN KEY ("eventId") REFERENCES "events"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260521191943_team_spotlight_event_capacity/migration.sql
+++ b/prisma/migrations/20260521191943_team_spotlight_event_capacity/migration.sql
@@ -1,0 +1,18 @@
+-- AlterTable
+ALTER TABLE "events" ADD COLUMN "capacity" INTEGER;
+
+-- AlterTable
+ALTER TABLE "team_members" ADD COLUMN "slug" TEXT,
+ADD COLUMN "longBio" TEXT,
+ADD COLUMN "location" TEXT,
+ADD COLUMN "tagline" TEXT,
+ADD COLUMN "featured" BOOLEAN NOT NULL DEFAULT false;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "team_members_slug_key" ON "team_members"("slug");
+
+-- CreateIndex
+CREATE INDEX "team_members_active_idx" ON "team_members"("active");
+
+-- CreateIndex
+CREATE INDEX "team_members_featured_idx" ON "team_members"("featured");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -293,7 +293,38 @@ model Event {
   createdAt       DateTime    @default(now())
   updatedAt       DateTime    @updatedAt
 
+  photos          MeetupPhoto[]
+
   @@map("events")
+}
+
+// ─── Meetup Photos ───────────────────────────────────────────────────────────
+
+model MeetupPhoto {
+  id            String   @id @default(cuid())
+  // Optional FK — photos without an event are "community life" general shots
+  // surfaced on the /gallery aggregator landing.
+  eventId       String?
+  url           String
+  thumbnailUrl  String?
+  alt           String?  @db.Text
+  caption       String?  @db.Text
+  photographer  String?
+  /// Curated "best of" filter — shown first on /gallery and used for
+  /// the homepage social proof if we ever want a "wall of community".
+  featured      Boolean  @default(false)
+  /// Manual display order within an event album. Lower = earlier.
+  order         Int      @default(0)
+  takenAt       DateTime?
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+
+  event         Event?   @relation(fields: [eventId], references: [id], onDelete: SetNull)
+
+  @@index([eventId])
+  @@index([featured])
+  @@index([order])
+  @@map("meetup_photos")
 }
 
 // ─── Blog Posts ──────────────────────────────────────────────────────────────
@@ -322,6 +353,7 @@ model BlogPost {
 
 // ─── Projects ────────────────────────────────────────────────────────────────
 
+// TODO: admin UI for setting POTW
 model Project {
   id          String   @id @default(cuid())
   name        String
@@ -335,9 +367,13 @@ model Project {
   audiences    Audience[] @default([])
   contactName  String?
   contactEmail String?
+  /// When this project held the "Project of the Week" slot. NULL = never.
+  /// Latest non-null value across all projects is the current pick.
+  potwAt       DateTime?
   createdAt    DateTime   @default(now())
   updatedAt    DateTime   @updatedAt
 
+  @@index([potwAt])
   @@map("projects")
 }
 
@@ -553,4 +589,28 @@ model NewsletterSubscriber {
   createdAt DateTime @default(now())
 
   @@map("newsletter_subscribers")
+}
+
+enum NewsletterStatus {
+  DRAFT
+  PUBLISHED
+}
+
+model NewsletterIssue {
+  id          String           @id @default(cuid())
+  slug        String           @unique
+  number      Int              @unique // Issue #1, #2, ...
+  title       String
+  subject     String           // The email subject line we sent
+  excerpt     String           @db.Text
+  body        String           @db.Text // Markdown body
+  publishedAt DateTime
+  /// Soft-publish gate so drafts aren't visible.
+  status      NewsletterStatus @default(DRAFT)
+  createdAt   DateTime         @default(now())
+  updatedAt   DateTime         @updatedAt
+
+  @@index([publishedAt])
+  @@index([status])
+  @@map("newsletter_issues")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -281,6 +281,9 @@ model Event {
   highlights      Json?       // String[]
   agenda          Json?       // String[]
   attendeeCount   Int?
+  /// Manual seat cap for the venue. Pair with attendeeCount to render
+  /// "X / Y seats" progress on the event detail. NULL = no cap shown.
+  capacity        Int?
   posterUrl       String?
   photosUrl       String?
   recordingUrl    String?
@@ -381,9 +384,18 @@ model Project {
 
 model TeamMember {
   id        String   @id @default(cuid())
+  /// URL-safe identifier for /team/[slug] pages. Backfilled from name for
+  /// existing rows; required for new rows once admin form requires it.
+  slug      String?  @unique
   name      String
   role      String
   bio       String   @db.Text
+  /// Optional longer bio rendered on the detail page (Markdown).
+  longBio   String?  @db.Text
+  /// City + country, e.g. "Nairobi, Kenya". Surfaces on the team list.
+  location  String?
+  /// One-line headline for the spotlight card, e.g. "Built MkulimaOS".
+  tagline   String?
   linkedIn  String?
   github    String?
   twitter   String?
@@ -391,9 +403,13 @@ model TeamMember {
   avatar    String?
   order     Int      @default(0)
   active    Boolean  @default(true)
+  /// Surface this member at the top of the team list and on homepage spotlight.
+  featured  Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@index([active])
+  @@index([featured])
   @@map("team_members")
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -179,6 +179,85 @@ async function main() {
   }
   console.log(`✅ Events: ${eventsData.length} seeded`)
 
+  // ─── Meetup Photos ────────────────────────────────────────────────────────
+  // Placeholder photos using Unsplash community / tech imagery. Replace with
+  // real meetup photos by writing rows directly to the meetup_photos table or
+  // through the admin UI once the photos manager ships.
+  const firstMeetup = await prisma.event.findUnique({
+    where: { slug: "kenyas-first-claude-code-meetup" },
+    select: { id: true },
+  })
+  const secondMeetup = await prisma.event.findUnique({
+    where: { slug: "claude-for-everyone-nairobi" },
+    select: { id: true },
+  })
+
+  const photosData: Array<{
+    eventId: string | null
+    url: string
+    thumbnailUrl: string | null
+    alt: string
+    caption: string
+    photographer: string | null
+    featured: boolean
+    order: number
+  }> = []
+
+  if (firstMeetup) {
+    const meetupOnePhotos = [
+      { url: "https://images.unsplash.com/photo-1540575467063-178a50c2df87?auto=format&fit=crop&w=1600&q=80", caption: "Packed room at iHiT Events Space.", featured: true },
+      { url: "https://images.unsplash.com/photo-1591115765373-5207764f72e7?auto=format&fit=crop&w=1600&q=80", caption: "Demo time — Claude Code on the big screen.", featured: false },
+      { url: "https://images.unsplash.com/photo-1559223607-a43c990c692c?auto=format&fit=crop&w=1600&q=80", caption: "Pair-programming with Claude in the corner.", featured: false },
+      { url: "https://images.unsplash.com/photo-1556761175-5973dc0f32e7?auto=format&fit=crop&w=1600&q=80", caption: "First-meetup networking over chai.", featured: false },
+      { url: "https://images.unsplash.com/photo-1543269865-cbf427effbad?auto=format&fit=crop&w=1600&q=80", caption: "Q&A on agentic patterns.", featured: false },
+      { url: "https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=1600&q=80", caption: "Group photo after the closing demo.", featured: true },
+    ]
+    meetupOnePhotos.forEach((p, i) => {
+      photosData.push({
+        eventId: firstMeetup.id,
+        url: p.url,
+        thumbnailUrl: p.url.replace("w=1600", "w=600"),
+        alt: p.caption,
+        caption: p.caption,
+        photographer: "Peter Kibet",
+        featured: p.featured,
+        order: i,
+      })
+    })
+  }
+
+  if (secondMeetup) {
+    const meetupTwoPhotos = [
+      { url: "https://images.unsplash.com/photo-1515187029135-18ee286d815b?auto=format&fit=crop&w=1600&q=80", caption: "316 Kenyans registered. Rain couldn't stop us.", featured: true },
+      { url: "https://images.unsplash.com/photo-1551836022-deb4988cc6c0?auto=format&fit=crop&w=1600&q=80", caption: "Live demo: Claude Code shipping a real feature.", featured: false },
+      { url: "https://images.unsplash.com/photo-1573164713988-8665fc963095?auto=format&fit=crop&w=1600&q=80", caption: "Lightning talks from community builders.", featured: false },
+      { url: "https://images.unsplash.com/photo-1517048676732-d65bc937f952?auto=format&fit=crop&w=1600&q=80", caption: "Audience Q&A — sharp questions all night.", featured: false },
+    ]
+    meetupTwoPhotos.forEach((p, i) => {
+      photosData.push({
+        eventId: secondMeetup.id,
+        url: p.url,
+        thumbnailUrl: p.url.replace("w=1600", "w=600"),
+        alt: p.caption,
+        caption: p.caption,
+        photographer: "Community contributor",
+        featured: p.featured,
+        order: i,
+      })
+    })
+  }
+
+  // Wipe + re-seed photos so the sample set stays clean across re-runs. Safe
+  // until the admin photo manager ships and real photos start landing — at
+  // that point this block should switch to upserts keyed on url.
+  if (photosData.length > 0) {
+    await prisma.meetupPhoto.deleteMany({})
+    await prisma.meetupPhoto.createMany({ data: photosData })
+    console.log(`✅ Meetup photos: ${photosData.length} seeded`)
+  } else {
+    console.log(`⚠ No events found to attach sample photos to — skipped.`)
+  }
+
   // ─── Blog Posts ───────────────────────────────────────────────────────────
   const blogData = [
     {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -345,25 +345,37 @@ async function main() {
   console.log(`✅ Projects: ${projectsData.length} seeded`)
 
   // ─── Team Members ─────────────────────────────────────────────────────────
-  const existing = await prisma.teamMember.findFirst({
-    where: { name: "Peter Kibet" },
+  // Upsert by slug so re-runs backfill the spotlight fields (slug/tagline/
+  // location/featured) onto rows that pre-date Phase B.
+  await prisma.teamMember.upsert({
+    where: { slug: "peter-kibet" },
+    update: {
+      slug: "peter-kibet",
+      tagline: "Founder, Spidey Labs",
+      location: "Nairobi, Kenya",
+      featured: true,
+      longBio:
+        "Peter (Spidey) founded Claude Community Kenya in 2026 to give Kenyan developers a real seat at the AI table. He organised the country's first Claude Code meetup, runs Spidey Labs (the studio behind MkulimaOS), and ships production software with Claude every day. He cares about practical AI — workflows that ship, not slides that don't.",
+    },
+    create: {
+      slug: "peter-kibet",
+      name: "Peter Kibet",
+      role: "Founder & Lead Organizer",
+      tagline: "Founder, Spidey Labs",
+      location: "Nairobi, Kenya",
+      bio: "Founder and lead organizer of Claude Community Kenya. Organized Kenya's first Claude Code meetup and is passionate about bringing AI-powered development tools to every Kenyan developer.",
+      longBio:
+        "Peter (Spidey) founded Claude Community Kenya in 2026 to give Kenyan developers a real seat at the AI table. He organised the country's first Claude Code meetup, runs Spidey Labs (the studio behind MkulimaOS), and ships production software with Claude every day. He cares about practical AI — workflows that ship, not slides that don't.",
+      twitter: "https://twitter.com/spideyinc",
+      github: "https://github.com/Spidey-Acer",
+      linkedIn: "https://linkedin.com/in/peter-kibet",
+      website: "https://www.peterkibet.co.ke",
+      avatar: "/images/peter-professional.png",
+      order: 0,
+      active: true,
+      featured: true,
+    },
   })
-  if (!existing) {
-    await prisma.teamMember.create({
-      data: {
-        name: "Peter Kibet",
-        role: "Founder & Lead Organizer",
-        bio: "Founder and lead organizer of Claude Community Kenya. Organized Kenya's first Claude Code meetup and is passionate about bringing AI-powered development tools to every Kenyan developer.",
-        twitter: "https://twitter.com/spideyinc",
-        github: "https://github.com/Spidey-Acer",
-        linkedIn: "https://linkedin.com/in/peter-kibet",
-        website: "https://www.peterkibet.co.ke",
-        avatar: "/images/peter-professional.png",
-        order: 0,
-        active: true,
-      },
-    })
-  }
   console.log("✅ Team members seeded")
 
   console.log("\n🎉 Seed complete!")

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -61,6 +61,7 @@ interface EventData {
   posterUrl: string | null
   featured: boolean
   attendeeCount: number | null
+  capacity: number | null
   highlights: string[] | null
   agenda: string[] | null
   audiences: Audience[]
@@ -91,6 +92,7 @@ export default function EditEventPage() {
   const [lumaUrl, setLumaUrl] = useState("")
   const [featured, setFeatured] = useState(false)
   const [attendeeCount, setAttendeeCount] = useState("")
+  const [capacity, setCapacity] = useState("")
   const [posterUrl, setPosterUrl] = useState("")
   const [isUploading, setIsUploading] = useState(false)
   const [agenda, setAgenda] = useState<string[]>([])
@@ -121,6 +123,7 @@ export default function EditEventPage() {
         setPosterUrl(ev.posterUrl ?? "")
         setFeatured(ev.featured)
         setAttendeeCount(ev.attendeeCount !== null ? String(ev.attendeeCount) : "")
+        setCapacity(ev.capacity !== null ? String(ev.capacity) : "")
         setAgenda(ev.agenda ?? [])
         setHighlights(ev.highlights ?? [])
         setAudiences(ev.audiences ?? [])
@@ -168,6 +171,9 @@ export default function EditEventPage() {
 
         if (attendeeCount) {
           body.attendeeCount = parseInt(attendeeCount, 10)
+        }
+        if (capacity) {
+          body.capacity = parseInt(capacity, 10)
         }
 
         const res = await fetch(`/api/admin/events/${id}`, {
@@ -259,8 +265,9 @@ export default function EditEventPage() {
               <FieldSelect label="Type" value={type} onChange={setType} options={EVENT_TYPES.map(t => ({ value: t, label: TYPE_LABELS[t] }))} />
               <FieldSelect label="Status" value={status} onChange={setStatus} options={EVENT_STATUSES.map(s => ({ value: s, label: STATUS_LABELS[s] }))} />
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <FieldInput label="Attendee Count" type="number" value={attendeeCount} onChange={setAttendeeCount} placeholder="Optional" />
+            <div className="grid grid-cols-3 gap-4">
+              <FieldInput label="Attendee Count" type="number" value={attendeeCount} onChange={setAttendeeCount} placeholder="Signed up" />
+              <FieldInput label="Capacity" type="number" value={capacity} onChange={setCapacity} placeholder="Max seats" />
               <div className="flex items-center gap-3 pt-5">
                 <input
                   type="checkbox"

--- a/src/app/admin/events/new/page.tsx
+++ b/src/app/admin/events/new/page.tsx
@@ -64,6 +64,7 @@ export default function NewEventPage() {
   const [lumaUrl, setLumaUrl] = useState("")
   const [featured, setFeatured] = useState(false)
   const [attendeeCount, setAttendeeCount] = useState("")
+  const [capacity, setCapacity] = useState("")
   const [posterUrl, setPosterUrl] = useState("")
   const [isUploading, setIsUploading] = useState(false)
   const [agenda, setAgenda] = useState<string[]>([])
@@ -105,6 +106,9 @@ export default function NewEventPage() {
 
         if (attendeeCount) {
           body.attendeeCount = parseInt(attendeeCount, 10)
+        }
+        if (capacity) {
+          body.capacity = parseInt(capacity, 10)
         }
 
         const res = await fetch("/api/admin/events", {
@@ -184,8 +188,9 @@ export default function NewEventPage() {
               <FieldSelect label="Type" value={type} onChange={setType} options={EVENT_TYPES.map(t => ({ value: t, label: TYPE_LABELS[t] }))} />
               <FieldSelect label="Status" value={status} onChange={setStatus} options={EVENT_STATUSES.map(s => ({ value: s, label: STATUS_LABELS[s] }))} />
             </div>
-            <div className="grid grid-cols-2 gap-4">
-              <FieldInput label="Attendee Count" type="number" value={attendeeCount} onChange={setAttendeeCount} placeholder="Optional" />
+            <div className="grid grid-cols-3 gap-4">
+              <FieldInput label="Attendee Count" type="number" value={attendeeCount} onChange={setAttendeeCount} placeholder="Signed up" />
+              <FieldInput label="Capacity" type="number" value={capacity} onChange={setCapacity} placeholder="Max seats" />
               <div className="flex items-center gap-3 pt-5">
                 <input
                   type="checkbox"

--- a/src/app/admin/photos/[id]/PhotoEditForm.tsx
+++ b/src/app/admin/photos/[id]/PhotoEditForm.tsx
@@ -1,0 +1,172 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { AlertTriangle, Loader2, Trash2 } from "lucide-react"
+
+interface EventOption {
+  id: string
+  title: string
+}
+
+interface Photo {
+  id: string
+  url: string
+  thumbnailUrl: string | null
+  alt: string | null
+  caption: string | null
+  photographer: string | null
+  eventId: string | null
+  featured: boolean
+  order: number
+  takenAt: Date | null
+}
+
+/** Edit form for a single meetup photo. Reads-only the URL; all other fields are editable. */
+export function PhotoEditForm({ photo, events }: { photo: Photo; events: EventOption[] }) {
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const [isPending, startTransition] = useTransition()
+  const [isDeleting, startDelete] = useTransition()
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    const form = new FormData(e.currentTarget)
+
+    const takenAtRaw = form.get("takenAt") as string | null
+    const body = {
+      caption: (form.get("caption") as string) || null,
+      alt: (form.get("alt") as string) || null,
+      photographer: (form.get("photographer") as string) || null,
+      eventId: (form.get("eventId") as string) || null,
+      featured: form.get("featured") === "on",
+      order: Number(form.get("order") ?? 0),
+      takenAt: takenAtRaw ? new Date(takenAtRaw).toISOString() : null,
+    }
+
+    startTransition(async () => {
+      const res = await fetch(`/api/admin/photos/${photo.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      const json = await res.json()
+      if (!res.ok || !json.success) {
+        setError(json.error ?? "Failed to update.")
+        return
+      }
+      router.push("/admin/photos")
+    })
+  }
+
+  function handleDelete() {
+    if (!window.confirm("Delete this photo? This is permanent.")) return
+    startDelete(async () => {
+      await fetch(`/api/admin/photos/${photo.id}`, { method: "DELETE" })
+      router.push("/admin/photos")
+    })
+  }
+
+  // Format takenAt for datetime-local input (YYYY-MM-DDTHH:mm)
+  const takenAtValue = photo.takenAt
+    ? new Date(photo.takenAt).toISOString().slice(0, 16)
+    : ""
+
+  return (
+    <>
+      {/* Image preview */}
+      <div className="mb-4">
+        <img
+          src={photo.thumbnailUrl ?? photo.url}
+          alt={photo.alt ?? ""}
+          className="h-40 w-auto max-w-full rounded border border-[#1e1e1e] object-cover bg-[#111]"
+        />
+        <p className="mt-1 text-[11px] font-mono text-[#444] break-all">{photo.url}</p>
+      </div>
+
+      <div className="mb-4 flex justify-end">
+        <button onClick={handleDelete} disabled={isDeleting}
+          className="flex items-center gap-1.5 px-3 py-1.5 border border-red-900/40 rounded text-[11px] font-mono text-red-400 hover:bg-red-900/20 transition-colors disabled:opacity-50">
+          <Trash2 className="w-3 h-3" />
+          {isDeleting ? "Deleting…" : "Delete Photo"}
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-4 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-6">
+        {/* Event dropdown */}
+        <div>
+          <label className="block text-[11px] font-mono text-[#555] mb-1.5">Event</label>
+          <select
+            name="eventId"
+            defaultValue={photo.eventId ?? ""}
+            className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50 transition-colors"
+          >
+            <option value="">— general / no event —</option>
+            {events.map(ev => (
+              <option key={ev.id} value={ev.id}>{ev.title}</option>
+            ))}
+          </select>
+        </div>
+
+        <TextareaField label="Caption" name="caption" defaultValue={photo.caption ?? ""} rows={2} />
+        <TextareaField label="Alt text" name="alt" defaultValue={photo.alt ?? ""} rows={2} />
+        <Field label="Photographer" name="photographer" defaultValue={photo.photographer ?? ""} />
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label className="block text-[11px] font-mono text-[#555] mb-1.5">Display Order</label>
+            <input name="order" type="number" min={0} defaultValue={photo.order}
+              className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50" />
+          </div>
+          <div>
+            <label className="block text-[11px] font-mono text-[#555] mb-1.5">Taken At</label>
+            <input name="takenAt" type="datetime-local" defaultValue={takenAtValue}
+              className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50" />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input name="featured" id="featured-edit" type="checkbox" defaultChecked={photo.featured}
+            className="w-4 h-4 accent-green-500 cursor-pointer" />
+          <label htmlFor="featured-edit" className="text-[11px] font-mono text-[#555] cursor-pointer">Featured (shown first on gallery)</label>
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 p-3 bg-red-900/20 border border-red-900/40 rounded text-[11px] font-mono text-red-400">
+            <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        <button type="submit" disabled={isPending}
+          className="flex items-center gap-2 px-4 py-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-sm font-mono text-[#00ff41] hover:bg-[#00ff41]/20 transition-colors disabled:opacity-50">
+          {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+          {isPending ? "Saving…" : "Save Changes"}
+        </button>
+      </form>
+    </>
+  )
+}
+
+function Field({ label, name, defaultValue }: { label: string; name: string; defaultValue?: string }) {
+  return (
+    <div>
+      <label className="block text-[11px] font-mono text-[#555] mb-1.5">{label}</label>
+      <input name={name} type="text" defaultValue={defaultValue}
+        className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] placeholder:text-[#333] focus:outline-none focus:border-[#00ff41]/50 transition-colors" />
+    </div>
+  )
+}
+
+function TextareaField({ label, name, rows, defaultValue }: {
+  label: string; name: string; rows: number; defaultValue?: string
+}) {
+  return (
+    <div>
+      <label className="block text-[11px] font-mono text-[#555] mb-1.5">{label}</label>
+      <textarea name={name} rows={rows} defaultValue={defaultValue}
+        className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50 transition-colors resize-y" />
+    </div>
+  )
+}

--- a/src/app/admin/photos/[id]/page.tsx
+++ b/src/app/admin/photos/[id]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { prisma } from "@/lib/prisma"
+import { AdminHeader } from "@/components/admin/AdminHeader"
+import { PhotoEditForm } from "./PhotoEditForm"
+
+/**
+ * Admin edit page for a single meetup photo.
+ */
+export default async function EditPhotoPage({
+  params,
+}: {
+  params: Promise<{ id: string }>
+}) {
+  const { id } = await params
+  const [photo, events] = await Promise.all([
+    prisma.meetupPhoto.findUnique({ where: { id } }),
+    prisma.event.findMany({ orderBy: { date: "desc" }, select: { id: true, title: true } }),
+  ])
+  if (!photo) notFound()
+
+  return (
+    <div>
+      <AdminHeader title="Edit Photo" />
+      <div className="p-6 max-w-2xl">
+        <div className="mb-4">
+          <Link
+            href="/admin/photos"
+            className="flex items-center gap-1.5 text-xs font-mono text-[#555] hover:text-[#ccc] transition-colors"
+          >
+            ← Back to Photos
+          </Link>
+        </div>
+        <PhotoEditForm photo={photo} events={events} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/photos/new/PhotoUploadForm.tsx
+++ b/src/app/admin/photos/new/PhotoUploadForm.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { useRouter } from "next/navigation"
+import { AlertTriangle, Loader2, CheckCircle2 } from "lucide-react"
+
+interface EventOption {
+  id: string
+  title: string
+}
+
+interface UploadResult {
+  created: unknown[]
+  failures: string[]
+}
+
+/** Upload form for one or more meetup photos. Submits multipart to /api/admin/photos/upload. */
+export function PhotoUploadForm({ events }: { events: EventOption[] }) {
+  const router = useRouter()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+  const [failures, setFailures] = useState<string[]>([])
+  const [fileCount, setFileCount] = useState(0)
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    setFailures([])
+    const form = e.currentTarget
+    const data = new FormData(form)
+
+    startTransition(async () => {
+      const res = await fetch("/api/admin/photos/upload", {
+        method: "POST",
+        body: data,
+      })
+      const json = (await res.json()) as { success: boolean; error?: string; data?: UploadResult }
+
+      if (!res.ok || !json.success) {
+        setError(json.error ?? "Upload failed.")
+        return
+      }
+
+      const result = json.data!
+      if (result.failures.length > 0) {
+        setFailures(result.failures)
+        // If some succeeded, redirect; otherwise stay and show all failures
+        if (result.created.length > 0) {
+          router.push("/admin/photos")
+        }
+        return
+      }
+
+      router.push("/admin/photos")
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-6">
+      {/* File picker */}
+      <div>
+        <label className="block text-[11px] font-mono text-[#555] mb-1.5">
+          Photos * <span className="text-[#333]">(up to 10 images, max 5 MB each)</span>
+        </label>
+        <input
+          name="files"
+          type="file"
+          accept="image/*"
+          multiple
+          required
+          onChange={e => setFileCount(e.currentTarget.files?.length ?? 0)}
+          className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] file:mr-3 file:py-1 file:px-2 file:rounded file:border-0 file:text-[11px] file:font-mono file:bg-[#1e1e1e] file:text-[#888] hover:file:bg-[#2a2a2a] focus:outline-none focus:border-[#00ff41]/50 transition-colors"
+        />
+        {fileCount > 0 && (
+          <p className="mt-1 text-[11px] font-mono text-[#555]">{fileCount} file{fileCount !== 1 ? "s" : ""} selected</p>
+        )}
+      </div>
+
+      {/* Event dropdown */}
+      <div>
+        <label className="block text-[11px] font-mono text-[#555] mb-1.5">Event <span className="text-[#333]">(optional)</span></label>
+        <select
+          name="eventId"
+          className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50 transition-colors"
+        >
+          <option value="">— general / no event —</option>
+          {events.map(ev => (
+            <option key={ev.id} value={ev.id}>{ev.title}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Metadata (applied to all uploaded files) */}
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="Photographer" name="photographer" placeholder="e.g. John Doe" />
+        <div>
+          <label className="block text-[11px] font-mono text-[#555] mb-1.5">Featured</label>
+          <div className="flex items-center gap-2 pt-1">
+            <input name="featured" id="featured-upload" type="checkbox" value="true"
+              className="w-4 h-4 accent-green-500 cursor-pointer" />
+            <label htmlFor="featured-upload" className="text-[11px] font-mono text-[#555] cursor-pointer">Mark all as featured</label>
+          </div>
+        </div>
+      </div>
+      <Field label="Caption" name="caption" placeholder="Applies to all uploaded photos" />
+      <Field label="Alt text" name="alt" placeholder="Describes the image for screen readers" />
+
+      {/* Errors */}
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-900/20 border border-red-900/40 rounded text-[11px] font-mono text-red-400">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+          {error}
+        </div>
+      )}
+      {failures.length > 0 && (
+        <div className="p-3 bg-red-900/20 border border-red-900/40 rounded space-y-1">
+          <p className="text-[11px] font-mono text-red-400 font-semibold">Some files failed:</p>
+          {failures.map((f, i) => (
+            <p key={i} className="text-[11px] font-mono text-red-400">• {f}</p>
+          ))}
+        </div>
+      )}
+
+      <button type="submit" disabled={isPending}
+        className="flex items-center gap-2 px-4 py-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-sm font-mono text-[#00ff41] hover:bg-[#00ff41]/20 transition-colors disabled:opacity-50">
+        {isPending ? <Loader2 className="w-4 h-4 animate-spin" /> : <CheckCircle2 className="w-4 h-4" />}
+        {isPending ? `Uploading ${fileCount} file${fileCount !== 1 ? "s" : ""}…` : "Upload Photos"}
+      </button>
+    </form>
+  )
+}
+
+function Field({ label, name, placeholder }: { label: string; name: string; placeholder?: string }) {
+  return (
+    <div>
+      <label className="block text-[11px] font-mono text-[#555] mb-1.5">{label}</label>
+      <input name={name} type="text" placeholder={placeholder}
+        className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] placeholder:text-[#333] focus:outline-none focus:border-[#00ff41]/50 transition-colors" />
+    </div>
+  )
+}

--- a/src/app/admin/photos/new/page.tsx
+++ b/src/app/admin/photos/new/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import { prisma } from "@/lib/prisma"
+import { AdminHeader } from "@/components/admin/AdminHeader"
+import { PhotoUploadForm } from "./PhotoUploadForm"
+
+/**
+ * Admin page for uploading one or more meetup photos.
+ * Events list is fetched server-side and passed to the form.
+ */
+export default async function NewPhotoPage() {
+  const events = await prisma.event.findMany({
+    orderBy: { date: "desc" },
+    select: { id: true, title: true },
+  })
+
+  return (
+    <div>
+      <AdminHeader title="Upload Photos" />
+      <div className="p-6 max-w-2xl">
+        <div className="mb-4">
+          <Link href="/admin/photos" className="flex items-center gap-1.5 text-xs font-mono text-[#555] hover:text-[#ccc] transition-colors">
+            ← Back to Photos
+          </Link>
+        </div>
+        <PhotoUploadForm events={events} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -1,0 +1,147 @@
+import { prisma } from "@/lib/prisma"
+import { AdminHeader } from "@/components/admin/AdminHeader"
+import { Camera, Plus, CheckCircle2 } from "lucide-react"
+import Link from "next/link"
+
+export const dynamic = "force-dynamic"
+
+interface SearchParams {
+  event?: string
+}
+
+/**
+ * Admin listing page for meetup photos.
+ * Supports filtering by event via ?event=<eventId> query param.
+ */
+export default async function PhotosAdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const { event: eventFilter } = await searchParams
+
+  const [photos, events] = await Promise.all([
+    prisma.meetupPhoto.findMany({
+      orderBy: [{ order: "asc" }, { createdAt: "desc" }],
+      include: { event: { select: { id: true, title: true } } },
+    }),
+    prisma.event.findMany({
+      orderBy: { date: "desc" },
+      select: { id: true, title: true },
+    }),
+  ])
+
+  const filtered = eventFilter
+    ? photos.filter(p => p.eventId === eventFilter)
+    : photos
+
+  return (
+    <div>
+      <AdminHeader title="Meetup Photos" />
+      <div className="p-6 space-y-4">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-3">
+            <p className="text-xs font-mono text-[#555]">{filtered.length} photo{filtered.length !== 1 ? "s" : ""}</p>
+            {/* Event filter */}
+            <form method="GET" className="flex items-center gap-2">
+              <select
+                name="event"
+                defaultValue={eventFilter ?? ""}
+                onChange={(e) => {
+                  // Handled via form submit — this is a server component
+                  void e
+                }}
+                className="bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-[11px] font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50"
+              >
+                <option value="">All events</option>
+                {events.map(ev => (
+                  <option key={ev.id} value={ev.id}>{ev.title}</option>
+                ))}
+              </select>
+              <button
+                type="submit"
+                className="px-2 py-1.5 text-[11px] font-mono text-[#555] border border-[#1e1e1e] rounded hover:text-[#ccc] transition-colors"
+              >
+                Filter
+              </button>
+              {eventFilter && (
+                <Link href="/admin/photos" className="text-[11px] font-mono text-[#555] hover:text-[#ccc] transition-colors">
+                  Clear
+                </Link>
+              )}
+            </form>
+          </div>
+          <Link
+            href="/admin/photos/new"
+            className="flex items-center gap-2 px-3 py-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] hover:bg-[#00ff41]/20 transition-colors"
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Upload Photos
+          </Link>
+        </div>
+
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+          {filtered.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <Camera className="w-8 h-8 text-[#333] mb-3" />
+              <p className="text-sm font-mono text-[#555]">No photos yet</p>
+              <p className="text-xs font-mono text-[#333] mt-1">Upload photos from community meetups.</p>
+            </div>
+          ) : (
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#1e1e1e]">
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Photo</th>
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Event</th>
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Caption</th>
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Photographer</th>
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Featured</th>
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Order</th>
+                  <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider"></th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#1a1a1a]">
+                {filtered.map((photo) => (
+                  <tr key={photo.id} className="hover:bg-[#111] transition-colors">
+                    <td className="px-4 py-3">
+                      <img
+                        src={photo.thumbnailUrl ?? photo.url}
+                        alt={photo.alt ?? ""}
+                        className="h-[60px] w-[60px] object-cover rounded bg-[#1a1a1a]"
+                      />
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-[#888]">
+                      {photo.event ? photo.event.title : <span className="text-[#444]">— general —</span>}
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-[#888] max-w-[200px]">
+                      {photo.caption ? (
+                        <span className="truncate block" title={photo.caption}>{photo.caption.slice(0, 60)}{photo.caption.length > 60 ? "…" : ""}</span>
+                      ) : (
+                        <span className="text-[#444]">—</span>
+                      )}
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-[#888]">
+                      {photo.photographer ?? <span className="text-[#444]">—</span>}
+                    </td>
+                    <td className="px-4 py-3">
+                      {photo.featured && <CheckCircle2 className="w-4 h-4 text-[#00ff41]" />}
+                    </td>
+                    <td className="px-4 py-3 text-xs font-mono text-[#555]">{photo.order}</td>
+                    <td className="px-4 py-3 text-right">
+                      <Link
+                        href={`/admin/photos/${photo.id}`}
+                        className="text-[11px] font-mono text-[#00ff41] hover:underline"
+                      >
+                        Edit →
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/team/[id]/TeamMemberEditForm.tsx
+++ b/src/app/admin/team/[id]/TeamMemberEditForm.tsx
@@ -6,9 +6,13 @@ import { AlertTriangle, Loader2, Trash2 } from "lucide-react"
 
 interface TeamMember {
   id: string
+  slug: string | null
   name: string
   role: string
+  tagline: string | null
+  location: string | null
   bio: string
+  longBio: string | null
   linkedIn: string | null
   github: string | null
   twitter: string | null
@@ -16,6 +20,7 @@ interface TeamMember {
   avatar: string | null
   order: number
   active: boolean
+  featured: boolean
 }
 
 export function TeamMemberEditForm({ member }: { member: TeamMember }) {
@@ -30,9 +35,13 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
     const form = new FormData(e.currentTarget)
 
     const body = {
+      slug: (form.get("slug") as string)?.trim() || null,
       name: form.get("name"),
       role: form.get("role"),
+      tagline: (form.get("tagline") as string)?.trim() || null,
+      location: (form.get("location") as string)?.trim() || null,
       bio: form.get("bio"),
+      longBio: (form.get("longBio") as string)?.trim() || null,
       linkedIn: form.get("linkedIn") || null,
       github: form.get("github") || null,
       twitter: form.get("twitter") || null,
@@ -40,6 +49,7 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
       avatar: form.get("avatar") || null,
       order: Number(form.get("order") ?? 0),
       active: form.get("active") === "on",
+      featured: form.get("featured") === "on",
     }
 
     startTransition(async () => {
@@ -80,7 +90,13 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
           <Field label="Name *" name="name" defaultValue={member.name} required />
           <Field label="Role / Title *" name="role" defaultValue={member.role} required />
         </div>
-        <TextareaField label="Bio *" name="bio" defaultValue={member.bio} required rows={4} />
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="URL slug" name="slug" defaultValue={member.slug ?? ""} placeholder="e.g. peter-kibet" />
+          <Field label="Location" name="location" defaultValue={member.location ?? ""} placeholder="e.g. Nairobi, Kenya" />
+        </div>
+        <Field label="Tagline (short headline)" name="tagline" defaultValue={member.tagline ?? ""} placeholder="e.g. Founder, Spidey Labs" />
+        <TextareaField label="Short bio *" name="bio" defaultValue={member.bio} required rows={3} />
+        <TextareaField label="Long bio (for /team/[slug] detail page)" name="longBio" defaultValue={member.longBio ?? ""} rows={6} />
         <div className="grid gap-4 sm:grid-cols-2">
           <Field label="LinkedIn URL" name="linkedIn" type="url" defaultValue={member.linkedIn ?? ""} />
           <Field label="GitHub URL" name="github" type="url" defaultValue={member.github ?? ""} />
@@ -88,8 +104,8 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
           <Field label="Website URL" name="website" type="url" defaultValue={member.website ?? ""} />
         </div>
         <Field label="Avatar URL" name="avatar" type="url" defaultValue={member.avatar ?? ""} />
-        <div className="flex items-center gap-4">
-          <div className="flex-1">
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex-1 min-w-[140px]">
             <label className="block text-[11px] font-mono text-[#555] mb-1.5">Display Order</label>
             <input name="order" type="number" min={0} defaultValue={member.order}
               className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50" />
@@ -98,6 +114,11 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
             <input name="active" id="active-edit" type="checkbox" defaultChecked={member.active}
               className="w-4 h-4 accent-green-500 cursor-pointer" />
             <label htmlFor="active-edit" className="text-[11px] font-mono text-[#555] cursor-pointer">Active (visible on site)</label>
+          </div>
+          <div className="flex items-center gap-2 pt-5">
+            <input name="featured" id="featured-edit" type="checkbox" defaultChecked={member.featured}
+              className="w-4 h-4 accent-amber-500 cursor-pointer" />
+            <label htmlFor="featured-edit" className="text-[11px] font-mono text-[#555] cursor-pointer">Featured (top of /team list)</label>
           </div>
         </div>
 
@@ -118,13 +139,13 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
   )
 }
 
-function Field({ label, name, required, type = "text", defaultValue }: {
-  label: string; name: string; required?: boolean; type?: string; defaultValue?: string
+function Field({ label, name, required, type = "text", defaultValue, placeholder }: {
+  label: string; name: string; required?: boolean; type?: string; defaultValue?: string; placeholder?: string
 }) {
   return (
     <div>
       <label className="block text-[11px] font-mono text-[#555] mb-1.5">{label}</label>
-      <input name={name} type={type} required={required} defaultValue={defaultValue}
+      <input name={name} type={type} required={required} defaultValue={defaultValue} placeholder={placeholder}
         className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] placeholder:text-[#333] focus:outline-none focus:border-[#00ff41]/50 transition-colors" />
     </div>
   )

--- a/src/app/admin/team/new/TeamMemberNewForm.tsx
+++ b/src/app/admin/team/new/TeamMemberNewForm.tsx
@@ -15,9 +15,13 @@ export function TeamMemberNewForm() {
     const form = new FormData(e.currentTarget)
 
     const body = {
+      slug: (form.get("slug") as string)?.trim() || null,
       name: form.get("name"),
       role: form.get("role"),
+      tagline: (form.get("tagline") as string)?.trim() || null,
+      location: (form.get("location") as string)?.trim() || null,
       bio: form.get("bio"),
+      longBio: (form.get("longBio") as string)?.trim() || null,
       linkedIn: form.get("linkedIn") || null,
       github: form.get("github") || null,
       twitter: form.get("twitter") || null,
@@ -25,6 +29,7 @@ export function TeamMemberNewForm() {
       avatar: form.get("avatar") || null,
       order: Number(form.get("order") ?? 0),
       active: form.get("active") === "on",
+      featured: form.get("featured") === "on",
     }
 
     startTransition(async () => {
@@ -48,7 +53,13 @@ export function TeamMemberNewForm() {
         <Field label="Name *" name="name" required />
         <Field label="Role / Title *" name="role" required placeholder="e.g. Community Lead" />
       </div>
-      <TextareaField label="Bio *" name="bio" required rows={4} />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="URL slug" name="slug" placeholder="e.g. peter-kibet" />
+        <Field label="Location" name="location" placeholder="e.g. Nairobi, Kenya" />
+      </div>
+      <Field label="Tagline (short headline)" name="tagline" placeholder="e.g. Founder, Spidey Labs" />
+      <TextareaField label="Short bio *" name="bio" required rows={3} />
+      <TextareaField label="Long bio (for /team/[slug] detail page)" name="longBio" rows={6} />
       <div className="grid gap-4 sm:grid-cols-2">
         <Field label="LinkedIn URL" name="linkedIn" type="url" />
         <Field label="GitHub URL" name="github" type="url" />
@@ -56,8 +67,8 @@ export function TeamMemberNewForm() {
         <Field label="Website URL" name="website" type="url" />
       </div>
       <Field label="Avatar URL" name="avatar" type="url" placeholder="https://..." />
-      <div className="flex items-center gap-4">
-        <div className="flex-1">
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex-1 min-w-[140px]">
           <label className="block text-[11px] font-mono text-[#555] mb-1.5">Display Order</label>
           <input name="order" type="number" min={0} defaultValue={0}
             className="w-full bg-[#111] border border-[#1e1e1e] rounded px-3 py-2 text-sm font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50" />
@@ -66,6 +77,11 @@ export function TeamMemberNewForm() {
           <input name="active" id="active-new" type="checkbox" defaultChecked
             className="w-4 h-4 accent-green-500 cursor-pointer" />
           <label htmlFor="active-new" className="text-[11px] font-mono text-[#555] cursor-pointer">Active (visible on site)</label>
+        </div>
+        <div className="flex items-center gap-2 pt-5">
+          <input name="featured" id="featured-new" type="checkbox"
+            className="w-4 h-4 accent-amber-500 cursor-pointer" />
+          <label htmlFor="featured-new" className="text-[11px] font-mono text-[#555] cursor-pointer">Featured (top of /team list)</label>
         </div>
       </div>
 

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -37,6 +37,7 @@ const updateSchema = z.object({
   highlights: z.array(z.string().max(200)).optional(),
   agenda: z.array(z.string().max(200)).optional(),
   attendeeCount: z.number().int().min(0).optional(),
+  capacity: z.number().int().min(0).optional(),
   posterUrl: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : v),
   featured: z.boolean().optional(),
   audiences: z.array(z.nativeEnum(Audience)).optional(),

--- a/src/app/api/admin/events/route.ts
+++ b/src/app/api/admin/events/route.ts
@@ -24,6 +24,7 @@ const eventSchema = z.object({
   highlights: z.array(z.string().max(200).transform(zodSanitizeString)).optional(),
   agenda: z.array(z.string().max(200).transform(zodSanitizeString)).optional(),
   attendeeCount: z.number().int().min(0).optional(),
+  capacity: z.number().int().min(0).optional(),
   posterUrl: z.string().url().optional().transform(v => v ? zodSanitizeUrl(v) : undefined),
   photosUrl: z.string().url().optional().transform(v => v ? zodSanitizeUrl(v) : undefined),
   featured: z.boolean().optional().default(false),

--- a/src/app/api/admin/photos/[id]/route.ts
+++ b/src/app/api/admin/photos/[id]/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { deleteImage } from "@/lib/supabase"
+import { zodSanitizeString, zodSanitizeUrl, zodSanitizeMultilineText } from "@/lib/input-sanitization"
+
+const updateSchema = z.object({
+  url: z.string().url().transform(zodSanitizeUrl).optional(),
+  thumbnailUrl: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
+  alt: z.string().max(500).optional().nullable().transform(v => v ? zodSanitizeMultilineText(500)(v) : null),
+  caption: z.string().max(1000).optional().nullable().transform(v => v ? zodSanitizeMultilineText(1000)(v) : null),
+  photographer: z.string().max(100).optional().nullable().transform(v => v ? zodSanitizeString(v) : null),
+  eventId: z.string().optional().nullable(),
+  featured: z.boolean().optional(),
+  order: z.number().int().min(0).optional(),
+  takenAt: z.string().datetime().optional().nullable().transform(v => v ? new Date(v) : null),
+})
+
+/**
+ * GET /api/admin/photos/[id] — Fetch a single photo with its event relation.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const check = await checkApiPermission("photos", "view")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+  const photo = await prisma.meetupPhoto.findUnique({
+    where: { id },
+    include: { event: { select: { id: true, title: true } } },
+  })
+  if (!photo) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+
+  return NextResponse.json({ success: true, data: photo })
+}
+
+/**
+ * PATCH /api/admin/photos/[id] — Update photo metadata fields.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const check = await checkApiPermission("photos", "edit")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+
+  let body: unknown
+  try { body = await request.json() }
+  catch { return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 }) }
+
+  const parsed = updateSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ success: false, error: "Validation failed", details: parsed.error.issues }, { status: 400 })
+  }
+
+  const photo = await prisma.meetupPhoto.update({ where: { id }, data: parsed.data })
+  return NextResponse.json({ success: true, data: photo })
+}
+
+/**
+ * DELETE /api/admin/photos/[id] — Remove the photo from storage then delete the DB record.
+ * Storage cleanup failure is logged and does not block the DB delete.
+ */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const check = await checkApiPermission("photos", "delete")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+  const photo = await prisma.meetupPhoto.findUnique({ where: { id }, select: { url: true } })
+  if (!photo) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+
+  try {
+    await deleteImage(photo.url)
+  } catch (err) {
+    // Non-fatal: log and continue so the DB record is always cleaned up
+    process.stderr.write(`[photos/delete] storage cleanup failed for ${photo.url}: ${String(err)}\n`)
+  }
+
+  await prisma.meetupPhoto.delete({ where: { id } })
+  return NextResponse.json({ success: true })
+}

--- a/src/app/api/admin/photos/route.ts
+++ b/src/app/api/admin/photos/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { zodSanitizeString, zodSanitizeUrl, zodSanitizeMultilineText } from "@/lib/input-sanitization"
+
+const createSchema = z.object({
+  url: z.string().url().transform(zodSanitizeUrl),
+  thumbnailUrl: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
+  alt: z.string().max(500).optional().nullable().transform(v => v ? zodSanitizeMultilineText(500)(v) : null),
+  caption: z.string().max(1000).optional().nullable().transform(v => v ? zodSanitizeMultilineText(1000)(v) : null),
+  photographer: z.string().max(100).optional().nullable().transform(v => v ? zodSanitizeString(v) : null),
+  eventId: z.string().optional().nullable(),
+  featured: z.boolean().default(false),
+  order: z.number().int().min(0).default(0),
+  takenAt: z.string().datetime().optional().nullable().transform(v => v ? new Date(v) : null),
+})
+
+/**
+ * GET /api/admin/photos — List all photos with event relation, ordered by [order asc, createdAt desc].
+ */
+export async function GET() {
+  const check = await checkApiPermission("photos", "view")
+  if (!check.authorized) return check.response
+
+  const photos = await prisma.meetupPhoto.findMany({
+    orderBy: [{ order: "asc" }, { createdAt: "desc" }],
+    include: { event: { select: { id: true, title: true } } },
+  })
+  return NextResponse.json({ success: true, data: photos })
+}
+
+/**
+ * POST /api/admin/photos — Create a single photo record from JSON body.
+ */
+export async function POST(request: NextRequest) {
+  const check = await checkApiPermission("photos", "create")
+  if (!check.authorized) return check.response
+
+  let body: unknown
+  try { body = await request.json() }
+  catch { return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 }) }
+
+  const parsed = createSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ success: false, error: "Validation failed", details: parsed.error.issues }, { status: 400 })
+  }
+
+  const photo = await prisma.meetupPhoto.create({ data: parsed.data })
+  return NextResponse.json({ success: true, data: photo }, { status: 201 })
+}

--- a/src/app/api/admin/photos/upload/route.ts
+++ b/src/app/api/admin/photos/upload/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { uploadImage } from "@/lib/supabase"
+
+const MAX_FILES = 10
+const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5 MB
+
+/**
+ * POST /api/admin/photos/upload — Multipart file upload for one or more meetup photos.
+ * Accepts fields: files (File[]), eventId?, photographer?, caption?, alt?, featured?.
+ * Returns { success: true, data: { created: MeetupPhoto[], failures: string[] } }.
+ */
+export async function POST(request: NextRequest) {
+  const check = await checkApiPermission("photos", "create")
+  if (!check.authorized) return check.response
+
+  let formData: FormData
+  try {
+    formData = await request.formData()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid multipart body" }, { status: 400 })
+  }
+
+  const files = formData.getAll("files") as File[]
+  if (!files.length) {
+    return NextResponse.json({ success: false, error: "No files provided" }, { status: 400 })
+  }
+  if (files.length > MAX_FILES) {
+    return NextResponse.json({ success: false, error: `Maximum ${MAX_FILES} files per request` }, { status: 400 })
+  }
+
+  const eventId = (formData.get("eventId") as string | null) || null
+  const photographer = (formData.get("photographer") as string | null) || null
+  const caption = (formData.get("caption") as string | null) || null
+  const alt = (formData.get("alt") as string | null) || null
+  const featured = formData.get("featured") === "true"
+
+  const created = []
+  const failures: string[] = []
+
+  for (const file of files) {
+    if (!file.type.startsWith("image/")) {
+      failures.push(`${file.name}: not an image (got ${file.type})`)
+      continue
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      failures.push(`${file.name}: exceeds 5 MB limit`)
+      continue
+    }
+
+    try {
+      const buffer = Buffer.from(await file.arrayBuffer())
+      const publicUrl = await uploadImage(buffer, file.name, file.type, "meetup-photos")
+      const photo = await prisma.meetupPhoto.create({
+        data: {
+          url: publicUrl,
+          thumbnailUrl: publicUrl, // thumbnail generation deferred to follow-up
+          alt: alt ?? null,
+          caption: caption ?? null,
+          photographer: photographer ?? null,
+          eventId: eventId ?? null,
+          featured,
+        },
+      })
+      created.push(photo)
+    } catch (err) {
+      failures.push(`${file.name}: ${String(err)}`)
+    }
+  }
+
+  return NextResponse.json({ success: true, data: { created, failures } }, { status: 201 })
+}

--- a/src/app/api/admin/team/[id]/route.ts
+++ b/src/app/api/admin/team/[id]/route.ts
@@ -5,9 +5,13 @@ import { prisma } from "@/lib/prisma"
 import { zodSanitizeString, zodSanitizeUrl, zodSanitizeMultilineText } from "@/lib/input-sanitization"
 
 const updateSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9-]{2,60}$/, "Slug must be lowercase letters, numbers, and hyphens (2-60 chars)").optional().nullable(),
   name: z.string().min(2).max(100).transform(zodSanitizeString).optional(),
   role: z.string().min(2).max(100).transform(zodSanitizeString).optional(),
+  tagline: z.string().max(120).optional().nullable().transform(v => v ? zodSanitizeString(v) : null),
+  location: z.string().max(80).optional().nullable().transform(v => v ? zodSanitizeString(v) : null),
   bio: z.string().min(10).max(1000).transform(zodSanitizeMultilineText(1000)).optional(),
+  longBio: z.string().max(5000).optional().nullable().transform(v => v ? zodSanitizeMultilineText(5000)(v) : null),
   linkedIn: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
   github: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
   twitter: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
@@ -15,6 +19,7 @@ const updateSchema = z.object({
   avatar: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
   order: z.number().int().min(0).optional(),
   active: z.boolean().optional(),
+  featured: z.boolean().optional(),
 })
 
 export async function GET(

--- a/src/app/api/admin/team/route.ts
+++ b/src/app/api/admin/team/route.ts
@@ -5,9 +5,13 @@ import { prisma } from "@/lib/prisma"
 import { zodSanitizeString, zodSanitizeUrl, zodSanitizeMultilineText } from "@/lib/input-sanitization"
 
 const createSchema = z.object({
+  slug: z.string().regex(/^[a-z0-9-]{2,60}$/, "Slug must be lowercase letters, numbers, and hyphens (2-60 chars)").optional().nullable(),
   name: z.string().min(2).max(100).transform(zodSanitizeString),
   role: z.string().min(2).max(100).transform(zodSanitizeString),
+  tagline: z.string().max(120).optional().nullable().transform(v => v ? zodSanitizeString(v) : null),
+  location: z.string().max(80).optional().nullable().transform(v => v ? zodSanitizeString(v) : null),
   bio: z.string().min(10).max(1000).transform(zodSanitizeMultilineText(1000)),
+  longBio: z.string().max(5000).optional().nullable().transform(v => v ? zodSanitizeMultilineText(5000)(v) : null),
   linkedIn: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
   github: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
   twitter: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
@@ -15,6 +19,7 @@ const createSchema = z.object({
   avatar: z.string().url().optional().nullable().transform(v => v ? zodSanitizeUrl(v) : null),
   order: z.number().int().min(0).default(0),
   active: z.boolean().default(true),
+  featured: z.boolean().default(false),
 })
 
 export async function GET() {

--- a/src/app/blog/[slug]/opengraph-image.tsx
+++ b/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,265 @@
+import { ImageResponse } from "next/og";
+import { getBlogPostBySlug } from "@/lib/data";
+
+// Default Node.js runtime — Prisma data fetch uses node:path which the edge
+// runtime can't resolve. Node runtime still supports ImageResponse fine.
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "Claude Community Kenya — Blog Post";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const post = await getBlogPostBySlug(slug).catch(() => null);
+
+  if (!post) {
+    return null;
+  }
+
+  const formattedDate = post.date
+    ? new Date(post.date).toLocaleDateString("en-US", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : "";
+
+  // Truncate excerpt for OG display
+  const displayExcerpt =
+    post.excerpt.length > 140 ? post.excerpt.slice(0, 137) + "…" : post.excerpt;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "#141413",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          position: "relative",
+          overflow: "hidden",
+          fontFamily: "Georgia, serif",
+        }}
+      >
+        {/* Subtle grid pattern */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "linear-gradient(rgba(217,119,87,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(217,119,87,0.04) 1px, transparent 1px)",
+            backgroundSize: "60px 60px",
+            display: "flex",
+          }}
+        />
+
+        {/* Orange accent stripe at top */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "5px",
+            background: "linear-gradient(90deg, #d97757, #e8a882, #d97757)",
+            display: "flex",
+          }}
+        />
+
+        {/* Main content area */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            padding: "72px 80px 56px",
+            flex: 1,
+          }}
+        >
+          {/* Eyebrow label */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+              marginBottom: "28px",
+            }}
+          >
+            <div
+              style={{
+                background: "rgba(217,119,87,0.15)",
+                border: "1px solid rgba(217,119,87,0.35)",
+                borderRadius: "100px",
+                padding: "6px 18px",
+                color: "#d97757",
+                fontSize: "14px",
+                fontFamily: "system-ui, sans-serif",
+                fontWeight: "600",
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                display: "flex",
+              }}
+            >
+              ✦ BLOG
+            </div>
+          </div>
+
+          {/* Post title */}
+          <h1
+            style={{
+              color: "#faf9f5",
+              fontSize: post.title.length > 70 ? "42px" : "54px",
+              fontWeight: "600",
+              margin: "0 0 20px",
+              lineHeight: "1.2",
+              letterSpacing: "-0.025em",
+              maxWidth: "940px",
+              fontFamily: "Georgia, serif",
+              display: "flex",
+            }}
+          >
+            {post.title}
+          </h1>
+
+          {/* Excerpt */}
+          <p
+            style={{
+              color: "#b0aea5",
+              fontSize: "20px",
+              margin: "0 0 28px",
+              lineHeight: "1.55",
+              maxWidth: "820px",
+              fontFamily: "system-ui, sans-serif",
+              display: "flex",
+            }}
+          >
+            {displayExcerpt}
+          </p>
+
+          {/* Author + date */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "20px",
+            }}
+          >
+            <span
+              style={{
+                color: "#d97757",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                fontWeight: "600",
+                display: "flex",
+              }}
+            >
+              {post.author}
+            </span>
+            {formattedDate && (
+              <>
+                <span
+                  style={{
+                    color: "#3a3a37",
+                    fontSize: "16px",
+                    display: "flex",
+                  }}
+                >
+                  ·
+                </span>
+                <span
+                  style={{
+                    color: "#7a7870",
+                    fontSize: "16px",
+                    fontFamily: "system-ui, sans-serif",
+                    display: "flex",
+                  }}
+                >
+                  {formattedDate}
+                </span>
+              </>
+            )}
+            {post.readingTime && (
+              <>
+                <span
+                  style={{
+                    color: "#3a3a37",
+                    fontSize: "16px",
+                    display: "flex",
+                  }}
+                >
+                  ·
+                </span>
+                <span
+                  style={{
+                    color: "#7a7870",
+                    fontSize: "16px",
+                    fontFamily: "system-ui, sans-serif",
+                    display: "flex",
+                  }}
+                >
+                  {post.readingTime} min read
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "20px 80px",
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            background: "rgba(0,0,0,0.2)",
+          }}
+        >
+          <span
+            style={{
+              color: "#7a7870",
+              fontSize: "16px",
+              fontFamily: "system-ui, sans-serif",
+              display: "flex",
+            }}
+          >
+            claudekenya.org/blog
+          </span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <span
+              style={{
+                color: "#d97757",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              ✦
+            </span>
+            <span
+              style={{
+                color: "#9a9890",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              Claude Community Kenya
+            </span>
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/community/[slug]/opengraph-image.tsx
+++ b/src/app/community/[slug]/opengraph-image.tsx
@@ -1,0 +1,266 @@
+import { ImageResponse } from "next/og";
+import { getCommunitySubmissionBySlug } from "@/lib/data";
+
+// Default Node.js runtime — Prisma data fetch uses node:path which the edge
+// runtime can't resolve. Node runtime still supports ImageResponse fine.
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "Claude Community Kenya — Community Hub";
+
+/** Badge color per submission type */
+function typeBadgeColor(type: string): string {
+  switch (type) {
+    case "MCP":
+      return "#6a9bcc";
+    case "PROMPT":
+      return "#9b8fcc";
+    case "WORKFLOW":
+      return "#5cb88a";
+    case "TOOL":
+    default:
+      return "#d97757";
+  }
+}
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const submission = await getCommunitySubmissionBySlug(slug).catch(() => null);
+
+  if (!submission) {
+    return null;
+  }
+
+  const badgeColor = typeBadgeColor(submission.type);
+  const displayDesc =
+    submission.shortDescription.length > 140
+      ? submission.shortDescription.slice(0, 137) + "…"
+      : submission.shortDescription;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "#141413",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          position: "relative",
+          overflow: "hidden",
+          fontFamily: "Georgia, serif",
+        }}
+      >
+        {/* Subtle grid pattern */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "linear-gradient(rgba(217,119,87,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(217,119,87,0.04) 1px, transparent 1px)",
+            backgroundSize: "60px 60px",
+            display: "flex",
+          }}
+        />
+
+        {/* Orange accent stripe at top */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "5px",
+            background: "linear-gradient(90deg, #d97757, #e8a882, #d97757)",
+            display: "flex",
+          }}
+        />
+
+        {/* Main content area */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            padding: "72px 80px 56px",
+            flex: 1,
+          }}
+        >
+          {/* Eyebrow: type badge + "Community Hub" */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+              marginBottom: "28px",
+            }}
+          >
+            {/* Type badge */}
+            <div
+              style={{
+                background: `${badgeColor}22`,
+                border: `1px solid ${badgeColor}55`,
+                borderRadius: "100px",
+                padding: "6px 18px",
+                color: badgeColor,
+                fontSize: "14px",
+                fontFamily: "system-ui, sans-serif",
+                fontWeight: "700",
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                display: "flex",
+              }}
+            >
+              {submission.type}
+            </div>
+
+            {/* Divider dot */}
+            <span
+              style={{
+                color: "#3a3a37",
+                fontSize: "18px",
+                display: "flex",
+              }}
+            >
+              ·
+            </span>
+
+            {/* Community Hub label */}
+            <span
+              style={{
+                color: "#7a7870",
+                fontSize: "14px",
+                fontFamily: "system-ui, sans-serif",
+                letterSpacing: "0.06em",
+                textTransform: "uppercase",
+                display: "flex",
+              }}
+            >
+              Community Hub
+            </span>
+          </div>
+
+          {/* Submission title */}
+          <h1
+            style={{
+              color: "#faf9f5",
+              fontSize: submission.title.length > 70 ? "42px" : "54px",
+              fontWeight: "600",
+              margin: "0 0 20px",
+              lineHeight: "1.2",
+              letterSpacing: "-0.025em",
+              maxWidth: "940px",
+              fontFamily: "Georgia, serif",
+              display: "flex",
+            }}
+          >
+            {submission.title}
+          </h1>
+
+          {/* Short description */}
+          <p
+            style={{
+              color: "#b0aea5",
+              fontSize: "20px",
+              margin: "0 0 28px",
+              lineHeight: "1.55",
+              maxWidth: "820px",
+              fontFamily: "system-ui, sans-serif",
+              display: "flex",
+            }}
+          >
+            {displayDesc}
+          </p>
+
+          {/* Submitter */}
+          {submission.submitterName && (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "10px",
+              }}
+            >
+              <span
+                style={{
+                  color: "#7a7870",
+                  fontSize: "16px",
+                  fontFamily: "system-ui, sans-serif",
+                  display: "flex",
+                }}
+              >
+                Shared by
+              </span>
+              <span
+                style={{
+                  color: "#d97757",
+                  fontSize: "16px",
+                  fontFamily: "system-ui, sans-serif",
+                  fontWeight: "600",
+                  display: "flex",
+                }}
+              >
+                {submission.submitterName}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "20px 80px",
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            background: "rgba(0,0,0,0.2)",
+          }}
+        >
+          <span
+            style={{
+              color: "#7a7870",
+              fontSize: "16px",
+              fontFamily: "system-ui, sans-serif",
+              display: "flex",
+            }}
+          >
+            claudekenya.org/community
+          </span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <span
+              style={{
+                color: "#d97757",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              ✦
+            </span>
+            <span
+              style={{
+                color: "#9a9890",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              Claude Community Kenya
+            </span>
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/events/[slug]/EventDetailContent.tsx
+++ b/src/app/events/[slug]/EventDetailContent.tsx
@@ -9,7 +9,8 @@ import { TerminalWindow, ScrollReveal } from "@/components/terminal";
 import { useSkin } from "@/contexts/SkinContext";
 import { formatDate } from "@/lib/utils";
 import type { Event } from "@/lib/types";
-import type { DemoRequestView } from "@/lib/data";
+import type { DemoRequestView, PhotoView } from "@/lib/data";
+import { EventPhotoStrip } from "./EventPhotoStrip";
 import {
   Calendar,
   Clock,
@@ -66,6 +67,7 @@ interface EventDetailContentProps {
   eventUrl: string;
   twitterShareUrl: string;
   linkedInShareUrl: string;
+  photos?: PhotoView[];
 }
 
 export function EventDetailContent({
@@ -77,6 +79,7 @@ export function EventDetailContent({
   eventUrl,
   twitterShareUrl,
   linkedInShareUrl,
+  photos = [],
 }: EventDetailContentProps) {
   const { skin } = useSkin();
   const isPro = skin === "pro";
@@ -430,6 +433,15 @@ export function EventDetailContent({
             )}
           </section>
         )}
+
+      {/* Photos from this event */}
+      {photos.length > 0 && (
+        <ScrollReveal delay={120}>
+          <section className="mb-10" aria-labelledby="event-photos-heading">
+            <EventPhotoStrip photos={photos} eventSlug={event.slug} />
+          </section>
+        </ScrollReveal>
+      )}
 
       {/* Scheduled Demos */}
       {approvedDemos.length > 0 && (

--- a/src/app/events/[slug]/EventDetailContent.tsx
+++ b/src/app/events/[slug]/EventDetailContent.tsx
@@ -596,6 +596,67 @@ export function EventDetailContent({
         </ScrollReveal>
       )}
 
+      {/* Seat progress — only when both capacity and attendeeCount set on an upcoming event */}
+      {isActionable && event.capacity && event.attendeeCount !== undefined && event.attendeeCount !== null && (
+        <section className="mb-6" aria-label="Seat availability">
+          {(() => {
+            const taken = Math.min(event.attendeeCount!, event.capacity!)
+            const pct = Math.max(0, Math.min(100, Math.round((taken / event.capacity!) * 100)))
+            const remaining = Math.max(0, event.capacity! - taken)
+            const isFull = remaining === 0
+            const isAlmostFull = !isFull && pct >= 80
+            return isPro ? (
+              <div className="card-elevated rounded-2xl p-5">
+                <div className="mb-2 flex items-center justify-between text-[13px] text-[#b0aea5]">
+                  <span>
+                    <span className="text-[#faf9f5] tabular-nums">{taken}</span>
+                    <span className="text-[#7a7870]"> / </span>
+                    <span className="tabular-nums">{event.capacity}</span>{" "}
+                    seats taken
+                  </span>
+                  <span className={isFull ? "text-[#d97757]" : isAlmostFull ? "text-[#ffb000]" : "text-[#7a7870]"}>
+                    {isFull ? "Sold out" : `${remaining} left`}
+                  </span>
+                </div>
+                <div className="h-1.5 w-full overflow-hidden rounded-full bg-[#2a2a28]">
+                  <div
+                    className="h-full rounded-full bg-[#d97757] transition-all duration-500"
+                    style={{ width: `${pct}%` }}
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  />
+                </div>
+              </div>
+            ) : (
+              <div className="border border-border-default bg-bg-secondary/40 p-4 font-mono text-sm">
+                <div className="mb-2 flex items-center justify-between text-text-secondary">
+                  <span>
+                    <span className="text-green-primary tabular-nums">{taken}</span>
+                    <span className="text-text-dim"> / </span>
+                    <span className="tabular-nums">{event.capacity}</span> seats
+                  </span>
+                  <span className={isFull ? "text-red" : isAlmostFull ? "text-amber" : "text-text-dim"}>
+                    {isFull ? "// sold out" : `// ${remaining} left`}
+                  </span>
+                </div>
+                <div className="h-1 w-full bg-bg-elevated">
+                  <div
+                    className="h-full bg-green-primary"
+                    style={{ width: `${pct}%` }}
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                  />
+                </div>
+              </div>
+            )
+          })()}
+        </section>
+      )}
+
       {/* Registration CTA */}
       {isActionable && event.registrationUrl && (
         <section className="mb-10">

--- a/src/app/events/[slug]/EventPhotoStrip.tsx
+++ b/src/app/events/[slug]/EventPhotoStrip.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useSkin } from "@/contexts/SkinContext";
+import type { PhotoView } from "@/lib/data";
+import { PhotoLightbox } from "@/components/gallery/PhotoLightbox";
+
+interface EventPhotoStripProps {
+  photos: PhotoView[];
+  eventSlug: string;
+}
+
+/**
+ * Inline photo preview shown on an event detail page.
+ * Renders up to 9 photos in a grid with a "See all" link to the gallery
+ * pre-filtered to this event.
+ */
+export function EventPhotoStrip({ photos, eventSlug }: EventPhotoStripProps) {
+  const { skin } = useSkin();
+  const isPro = skin === "pro";
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const previewPhotos = photos.slice(0, 9);
+  const hasMore = photos.length > previewPhotos.length;
+
+  return (
+    <>
+      <div className="mb-5 flex items-end justify-between gap-4">
+        <div>
+          <h2
+            id="event-photos-heading"
+            className={
+              isPro
+                ? "text-[26px] font-medium text-[#faf9f5]"
+                : "font-mono text-[22px] font-bold text-green-primary"
+            }
+            style={
+              isPro
+                ? {
+                    fontFamily: "var(--font-display), ui-serif, Georgia, serif",
+                    letterSpacing: "-0.025em",
+                  }
+                : undefined
+            }
+          >
+            {isPro ? "Photos from this event" : "## photos"}
+          </h2>
+          {isPro && (
+            <p className="mt-1 text-[13px] text-[#9a9890]">
+              {photos.length} {photos.length === 1 ? "photo" : "photos"} from
+              the meetup.
+            </p>
+          )}
+        </div>
+        <Link
+          href={`/gallery?event=${encodeURIComponent(eventSlug)}`}
+          className={
+            isPro
+              ? "link-refined shrink-0 text-[13px] font-semibold text-[#d97757] hover:text-[#e89576]"
+              : "font-mono text-sm text-green-primary hover:text-amber transition-colors"
+          }
+        >
+          {isPro ? "See all →" : "> see_all"}
+        </Link>
+      </div>
+
+      <ul
+        className="grid grid-cols-3 gap-2 sm:grid-cols-3 md:gap-3 lg:grid-cols-3"
+        role="list"
+      >
+        {previewPhotos.map((photo, i) => {
+          const isLastSlotWithMore = hasMore && i === previewPhotos.length - 1;
+          return (
+            <li key={photo.id}>
+              <button
+                type="button"
+                onClick={() => setLightboxIndex(i)}
+                aria-label={photo.caption ?? `Open photo ${i + 1}`}
+                className="group relative block w-full overflow-hidden rounded-xl border border-[#2a2a28] bg-[#1e1e1d] transition-all duration-300 hover:border-[#3a3a37] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary"
+              >
+                <div className="relative aspect-square w-full overflow-hidden">
+                  <Image
+                    src={photo.thumbnailUrl ?? photo.url}
+                    alt={photo.alt ?? photo.caption ?? "Meetup photo"}
+                    fill
+                    sizes="(max-width: 640px) 33vw, (max-width: 1024px) 25vw, 200px"
+                    className="object-cover transition-transform duration-500 group-hover:scale-[1.05]"
+                  />
+                  {isLastSlotWithMore && (
+                    <div className="absolute inset-0 flex items-center justify-center bg-black/60 text-[15px] font-semibold text-[#faf9f5] backdrop-blur-sm">
+                      +{photos.length - previewPhotos.length} more
+                    </div>
+                  )}
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <PhotoLightbox
+        photos={photos}
+        currentIndex={lightboxIndex}
+        onClose={() => setLightboxIndex(null)}
+        onIndexChange={setLightboxIndex}
+      />
+    </>
+  );
+}

--- a/src/app/events/[slug]/opengraph-image.tsx
+++ b/src/app/events/[slug]/opengraph-image.tsx
@@ -1,0 +1,210 @@
+import { ImageResponse } from "next/og";
+import { getEventBySlug } from "@/lib/data";
+
+// Default Node.js runtime — Prisma data fetch uses node:path which the edge
+// runtime can't resolve. Node runtime still supports ImageResponse fine.
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+export const alt = "Claude Community Kenya — Event";
+
+export default async function Image({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const event = await getEventBySlug(slug).catch(() => null);
+
+  if (!event) {
+    return null;
+  }
+
+  const formattedDate = new Date(event.date).toLocaleDateString("en-US", {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "#141413",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          position: "relative",
+          overflow: "hidden",
+          fontFamily: "Georgia, serif",
+        }}
+      >
+        {/* Subtle grid pattern */}
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage:
+              "linear-gradient(rgba(217,119,87,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(217,119,87,0.04) 1px, transparent 1px)",
+            backgroundSize: "60px 60px",
+            display: "flex",
+          }}
+        />
+
+        {/* Orange accent stripe at top */}
+        <div
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            height: "5px",
+            background: "linear-gradient(90deg, #d97757, #e8a882, #d97757)",
+            display: "flex",
+          }}
+        />
+
+        {/* Main content area */}
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            padding: "72px 80px 64px",
+            flex: 1,
+          }}
+        >
+          {/* Eyebrow label */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "12px",
+              marginBottom: "28px",
+            }}
+          >
+            <div
+              style={{
+                background: "rgba(217,119,87,0.15)",
+                border: "1px solid rgba(217,119,87,0.35)",
+                borderRadius: "100px",
+                padding: "6px 18px",
+                color: "#d97757",
+                fontSize: "14px",
+                fontFamily: "system-ui, sans-serif",
+                fontWeight: "600",
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                display: "flex",
+              }}
+            >
+              ✦ EVENT
+            </div>
+          </div>
+
+          {/* Event title */}
+          <h1
+            style={{
+              color: "#faf9f5",
+              fontSize: event.title.length > 60 ? "44px" : "56px",
+              fontWeight: "600",
+              margin: "0 0 24px",
+              lineHeight: "1.15",
+              letterSpacing: "-0.025em",
+              maxWidth: "900px",
+              fontFamily: "Georgia, serif",
+              display: "flex",
+            }}
+          >
+            {event.title}
+          </h1>
+
+          {/* Date + venue */}
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: "8px",
+            }}
+          >
+            <p
+              style={{
+                color: "#b0aea5",
+                fontSize: "22px",
+                margin: 0,
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              {formattedDate}
+            </p>
+            <p
+              style={{
+                color: "#9a9890",
+                fontSize: "18px",
+                margin: 0,
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              {event.venue} · {event.city}, Kenya
+            </p>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            padding: "20px 80px",
+            borderTop: "1px solid rgba(255,255,255,0.06)",
+            background: "rgba(0,0,0,0.2)",
+          }}
+        >
+          <span
+            style={{
+              color: "#7a7870",
+              fontSize: "16px",
+              fontFamily: "system-ui, sans-serif",
+              display: "flex",
+            }}
+          >
+            claudekenya.org
+          </span>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <span
+              style={{
+                color: "#d97757",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              ✦
+            </span>
+            <span
+              style={{
+                color: "#9a9890",
+                fontSize: "16px",
+                fontFamily: "system-ui, sans-serif",
+                display: "flex",
+              }}
+            >
+              Claude Community Kenya
+            </span>
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/events/[slug]/page.tsx
+++ b/src/app/events/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema";
-import { getEvents, getEventBySlug, getApprovedDemosByEventId } from "@/lib/data";
+import { getEvents, getEventBySlug, getApprovedDemosByEventId, getEventPhotos } from "@/lib/data";
 import { formatDate } from "@/lib/utils";
 import { SITE_CONFIG } from "@/lib/constants";
 import { EventDetailContent } from "./EventDetailContent";
@@ -56,9 +56,12 @@ export default async function EventDetailPage({
     notFound();
   }
 
-  const approvedDemos = event.id
-    ? await getApprovedDemosByEventId(event.id).catch(() => [])
-    : [];
+  const [approvedDemos, eventPhotos] = await Promise.all([
+    event.id
+      ? getApprovedDemosByEventId(event.id).catch(() => [])
+      : Promise.resolve([]),
+    getEventPhotos(event.slug).catch(() => []),
+  ]);
 
   const relatedEvents = allEvents
     .filter((e) => e.slug !== event.slug)
@@ -143,6 +146,7 @@ export default async function EventDetailPage({
         eventUrl={eventUrl}
         twitterShareUrl={twitterShareUrl}
         linkedInShareUrl={linkedInShareUrl}
+        photos={eventPhotos}
       />
     </main>
   );

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -1,0 +1,120 @@
+import type { Metadata } from "next";
+import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema";
+import { getGalleryPhotos, getEventsWithPhotos } from "@/lib/data";
+import { GalleryGrid } from "@/components/gallery/GalleryGrid";
+
+export const revalidate = 1800;
+
+export const metadata: Metadata = {
+  title: "Gallery | Claude Community Kenya",
+  description:
+    "Photos from Claude Community Kenya meetups, workshops, and gatherings in Nairobi, Mombasa, and beyond.",
+  alternates: {
+    canonical: "https://www.claudekenya.org/gallery",
+  },
+  openGraph: {
+    title: "Gallery | Claude Community Kenya",
+    description:
+      "Photos from Claude Community Kenya meetups, workshops, and gatherings.",
+    url: "https://www.claudekenya.org/gallery",
+    siteName: "Claude Community Kenya",
+    type: "website",
+  },
+};
+
+interface GalleryPageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+export default async function GalleryPage({ searchParams }: GalleryPageProps) {
+  const params = await searchParams;
+  const eventFilter = typeof params.event === "string" ? params.event : null;
+
+  const [photos, eventChips] = await Promise.all([
+    getGalleryPhotos().catch(() => []),
+    getEventsWithPhotos().catch(() => []),
+  ]);
+
+  const totalCount = photos.length;
+  const cityList = Array.from(
+    new Set(eventChips.map((e) => e.city).filter(Boolean)),
+  );
+
+  return (
+    <main className="min-h-screen px-4 py-16 sm:px-6 lg:px-8">
+      <BreadcrumbSchema
+        items={[{ name: "Home", url: "/" }, { name: "Gallery" }]}
+      />
+
+      {/* Ambient gradient */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0"
+        style={{
+          background: `
+            radial-gradient(ellipse 60% 35% at 50% -10%, rgba(217, 119, 87, 0.08), transparent 60%),
+            radial-gradient(ellipse 50% 40% at 90% 60%, rgba(106, 155, 204, 0.05), transparent 65%)
+          `,
+        }}
+      />
+
+      <div className="relative mx-auto max-w-6xl">
+        {/* Hero */}
+        <section className="mb-12 text-center">
+          <div className="mb-6">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[#2a2a28] bg-[#1e1e1d]/60 px-3.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-[#b0aea5] backdrop-blur-sm">
+              <img src="/images/claude-sparkle.svg" alt="" className="h-3 w-3" />
+              <span>Community Gallery</span>
+            </span>
+          </div>
+
+          <h1
+            className="mb-5 text-[42px] font-medium text-[#faf9f5] sm:text-[56px] lg:text-[64px]"
+            style={{
+              fontFamily: 'var(--font-display), ui-serif, Georgia, serif',
+              letterSpacing: "-0.025em",
+            }}
+          >
+            Faces of the community
+          </h1>
+
+          <p className="mx-auto mb-8 max-w-xl text-[17px] leading-relaxed text-[#b0aea5]">
+            Real people, real meetups, real Kenya. Every shot here is from
+            one of our gatherings — across Nairobi, Mombasa, and beyond.
+          </p>
+
+          {totalCount > 0 && (
+            <div className="mx-auto flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[#7a7870]">
+              <span className="tabular-nums">
+                <span className="text-[#d97757]">{totalCount}</span> photos
+              </span>
+              {eventChips.length > 0 && (
+                <>
+                  <span className="text-[#3a3a37]">·</span>
+                  <span className="tabular-nums">
+                    <span className="text-[#6a9bcc]">{eventChips.length}</span> events
+                  </span>
+                </>
+              )}
+              {cityList.length > 0 && (
+                <>
+                  <span className="text-[#3a3a37]">·</span>
+                  <span>{cityList.join(" & ")}</span>
+                </>
+              )}
+            </div>
+          )}
+        </section>
+
+        {/* Grid */}
+        <section aria-label="Photo gallery">
+          <GalleryGrid
+            photos={photos}
+            eventChips={eventChips}
+            initialFilter={eventFilter}
+          />
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/newsletter/[slug]/page.tsx
+++ b/src/app/newsletter/[slug]/page.tsx
@@ -1,0 +1,308 @@
+import React from "react";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema";
+import { HeroEmailCapture } from "@/components/sections/HeroEmailCapture";
+import { getNewsletterIssues, getNewsletterIssueBySlug } from "@/lib/data";
+import { SITE_CONFIG } from "@/lib/constants";
+
+export const revalidate = 3600;
+
+export async function generateStaticParams() {
+  const issues = await getNewsletterIssues().catch(() => []);
+  return issues.map((issue) => ({ slug: issue.slug }));
+}
+
+interface NewsletterIssuePageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: NewsletterIssuePageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const issue = await getNewsletterIssueBySlug(slug);
+
+  if (!issue) {
+    return { title: `Issue Not Found | ${SITE_CONFIG.name}` };
+  }
+
+  return {
+    title: `${issue.title} | Newsletter | ${SITE_CONFIG.name}`,
+    description: issue.excerpt,
+    alternates: {
+      canonical: `${SITE_CONFIG.url}/newsletter/${issue.slug}`,
+    },
+    openGraph: {
+      title: issue.title,
+      description: issue.excerpt,
+      url: `${SITE_CONFIG.url}/newsletter/${issue.slug}`,
+      siteName: SITE_CONFIG.name,
+      type: "article",
+      publishedTime: issue.publishedAt,
+    },
+  };
+}
+
+/** Fraunces display-serif inline style */
+const FRAUNCES: React.CSSProperties = {
+  fontFamily: "var(--font-display), ui-serif, Georgia, serif",
+  letterSpacing: "-0.025em",
+};
+
+/** Formats a date string as "May 2026" */
+function formatIssueMonth(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+/** Pads an issue number to 2 digits: 3 → "03" */
+function padIssueNumber(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+// ─── Inline markdown renderer ────────────────────────────────────────────────
+
+function renderInlineMarkdown(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let remaining = text;
+  let keyIndex = 0;
+
+  while (remaining.length > 0) {
+    const boldMatch = remaining.match(/\*\*(.+?)\*\*/);
+    const codeMatch = remaining.match(/`([^`]+)`/);
+    const linkMatch = remaining.match(/\[([^\]]+)\]\(([^)]+)\)/);
+
+    const matches = [
+      boldMatch ? { type: "bold" as const, index: boldMatch.index!, match: boldMatch } : null,
+      codeMatch ? { type: "code" as const, index: codeMatch.index!, match: codeMatch } : null,
+      linkMatch ? { type: "link" as const, index: linkMatch.index!, match: linkMatch } : null,
+    ]
+      .filter(Boolean)
+      .sort((a, b) => a!.index - b!.index);
+
+    if (matches.length === 0) {
+      parts.push(remaining);
+      break;
+    }
+
+    const first = matches[0]!;
+
+    if (first.index > 0) {
+      parts.push(remaining.slice(0, first.index));
+    }
+
+    if (first.type === "bold") {
+      parts.push(
+        <strong key={keyIndex++} className="font-semibold text-[#faf9f5]">
+          {first.match[1]}
+        </strong>
+      );
+      remaining = remaining.slice(first.index + first.match[0].length);
+    } else if (first.type === "code") {
+      parts.push(
+        <code
+          key={keyIndex++}
+          className="rounded px-1.5 py-0.5 bg-[#252524] border border-[#2a2a28] text-[13px] font-mono text-[#e8e6dc]"
+        >
+          {first.match[1]}
+        </code>
+      );
+      remaining = remaining.slice(first.index + first.match[0].length);
+    } else if (first.type === "link") {
+      parts.push(
+        <a
+          key={keyIndex++}
+          href={first.match[2]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-[#d97757] underline underline-offset-4 transition-colors hover:text-[#c06848]"
+        >
+          {first.match[1]}
+        </a>
+      );
+      remaining = remaining.slice(first.index + first.match[0].length);
+    }
+  }
+
+  return parts.length === 1 && typeof parts[0] === "string" ? parts[0] : parts;
+}
+
+// ─── Block markdown renderer ─────────────────────────────────────────────────
+
+function renderBody(body: string): React.ReactNode[] {
+  const blocks = body.split("\n\n");
+
+  return blocks.map((block, index) => {
+    const trimmed = block.trim();
+    if (!trimmed) return null;
+
+    if (trimmed === "---") {
+      return <hr key={index} className="my-8 border-[#2a2a28]" />;
+    }
+
+    if (trimmed.startsWith("## ")) {
+      return (
+        <h2
+          key={index}
+          className="mb-4 mt-10 text-[26px] font-medium text-[#faf9f5]"
+          style={FRAUNCES}
+        >
+          {trimmed.slice(3)}
+        </h2>
+      );
+    }
+
+    if (trimmed.startsWith("### ")) {
+      return (
+        <h3 key={index} className="mb-3 mt-6 text-[20px] font-semibold text-[#faf9f5]">
+          {trimmed.slice(4)}
+        </h3>
+      );
+    }
+
+    if (trimmed.startsWith("```")) {
+      const lines = trimmed.split("\n");
+      const codeContent = lines.slice(1, -1).join("\n");
+      return (
+        <pre
+          key={index}
+          className="my-6 overflow-x-auto rounded-xl border border-[#2a2a28] bg-[#0f0f0e] p-5"
+        >
+          <code className="font-mono text-[13px] text-[#e8e6dc]">{codeContent}</code>
+        </pre>
+      );
+    }
+
+    const lines = trimmed.split("\n");
+    const isBulletList = lines.every((line) => /^-\s/.test(line.trim()) || line.trim() === "");
+    const isNumberedList = lines.every(
+      (line) => /^\d+\.\s/.test(line.trim()) || line.trim() === ""
+    );
+
+    if (isBulletList) {
+      return (
+        <ul key={index} className="my-4 space-y-2">
+          {lines
+            .filter((line) => line.trim())
+            .map((line, i) => (
+              <li key={i} className="flex gap-3 text-[#b0aea5]">
+                <span className="text-[#d97757]" aria-hidden="true">•</span>
+                {renderInlineMarkdown(line.replace(/^-\s*/, ""))}
+              </li>
+            ))}
+        </ul>
+      );
+    }
+
+    if (isNumberedList) {
+      return (
+        <ol key={index} className="my-4 space-y-2">
+          {lines
+            .filter((line) => line.trim())
+            .map((line, i) => (
+              <li key={i} className="flex gap-3 text-[#b0aea5]">
+                <span className="shrink-0 font-semibold text-[#d97757]">{i + 1}.</span>
+                {renderInlineMarkdown(line.replace(/^\d+\.\s*/, ""))}
+              </li>
+            ))}
+        </ol>
+      );
+    }
+
+    if (trimmed.startsWith("> ")) {
+      return (
+        <blockquote
+          key={index}
+          className="my-6 border-l-2 border-[#d97757]/50 pl-5 text-[#b0aea5] italic"
+        >
+          {renderInlineMarkdown(trimmed.slice(2))}
+        </blockquote>
+      );
+    }
+
+    return (
+      <p key={index} className="my-4 leading-[1.75] text-[#b0aea5]">
+        {renderInlineMarkdown(trimmed)}
+      </p>
+    );
+  });
+}
+
+// ─── Page component ──────────────────────────────────────────────────────────
+
+export default async function NewsletterIssuePage({ params }: NewsletterIssuePageProps) {
+  const { slug } = await params;
+  const issue = await getNewsletterIssueBySlug(slug);
+
+  if (!issue) {
+    notFound();
+  }
+
+  const eyebrow = `Issue ${padIssueNumber(issue.number)} · ${formatIssueMonth(issue.publishedAt)}`;
+
+  return (
+    <main className="min-h-screen bg-bg-primary px-4 py-16 sm:px-6 lg:px-8">
+      <BreadcrumbSchema
+        items={[
+          { name: "Home", url: "/" },
+          { name: "Newsletter", url: "/newsletter" },
+          { name: issue.title },
+        ]}
+      />
+
+      <div className="mx-auto max-w-2xl">
+        {/* Back link */}
+        <Link
+          href="/newsletter"
+          className="link-refined mb-8 inline-flex items-center gap-1.5 text-sm text-[#9a9890] transition-colors hover:text-[#faf9f5]"
+        >
+          <span aria-hidden="true">←</span> All issues
+        </Link>
+
+        {/* Issue header */}
+        <header className="mb-10">
+          <p className="mb-3 text-[11px] font-medium uppercase tracking-widest text-[#d97757]">
+            {eyebrow}
+          </p>
+          <h1
+            className="mb-4 text-4xl font-semibold text-[#faf9f5] sm:text-5xl"
+            style={FRAUNCES}
+          >
+            {issue.title}
+          </h1>
+          <p className="text-lg leading-relaxed text-[#b0aea5]">{issue.excerpt}</p>
+        </header>
+
+        {/* Divider */}
+        <div className="mb-10 h-px w-full bg-[#2a2a28]" aria-hidden="true" />
+
+        {/* Body */}
+        <article
+          className="prose-none"
+          aria-label={`Newsletter issue: ${issue.title}`}
+        >
+          {renderBody(issue.body)}
+        </article>
+
+        {/* Footer email capture */}
+        <div className="mt-16 rounded-2xl border border-[#2a2a28] bg-[#1e1e1d]/80 p-8 text-center">
+          <p
+            className="mb-2 text-lg font-medium text-[#faf9f5]"
+            style={FRAUNCES}
+          >
+            Enjoyed this issue?
+          </p>
+          <p className="mb-6 text-sm text-[#b0aea5]">
+            Get next month&apos;s digest straight to your inbox.
+          </p>
+          <HeroEmailCapture
+            label="Get next month's digest"
+            buttonLabel="Subscribe"
+            className="mx-auto max-w-sm"
+          />
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/newsletter/page.tsx
+++ b/src/app/newsletter/page.tsx
@@ -1,0 +1,134 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema";
+import { HeroEmailCapture } from "@/components/sections/HeroEmailCapture";
+import { getNewsletterIssues } from "@/lib/data";
+import { SITE_CONFIG } from "@/lib/constants";
+
+export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: `Newsletter | ${SITE_CONFIG.name}`,
+  description:
+    "Monthly digest from Claude Community Kenya — Claude tips, community projects, event recaps, and what's shipping in the Kenyan AI scene.",
+  alternates: {
+    canonical: `${SITE_CONFIG.url}/newsletter`,
+  },
+  openGraph: {
+    title: `Newsletter | ${SITE_CONFIG.name}`,
+    description:
+      "Monthly digest from Claude Community Kenya — Claude tips, community projects, event recaps, and what's shipping in the Kenyan AI scene.",
+    url: `${SITE_CONFIG.url}/newsletter`,
+    siteName: SITE_CONFIG.name,
+    type: "website",
+  },
+};
+
+/** Formats a date string as "May 2026" */
+function formatIssueMonth(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+}
+
+/** Pads an issue number to 2 digits: 3 → "03" */
+function padIssueNumber(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+/** Fraunces display-serif inline style */
+const FRAUNCES: React.CSSProperties = {
+  fontFamily: "var(--font-display), ui-serif, Georgia, serif",
+  letterSpacing: "-0.025em",
+};
+
+export default async function NewsletterPage() {
+  const issues = await getNewsletterIssues().catch(() => []);
+
+  return (
+    <main className="min-h-screen bg-bg-primary px-4 py-16 sm:px-6 lg:px-8">
+      <BreadcrumbSchema
+        items={[{ name: "Home", url: "/" }, { name: "Newsletter" }]}
+      />
+
+      <div className="mx-auto max-w-3xl">
+        {/* ─── Hero ─── */}
+        <section className="mb-14 text-center" aria-label="Newsletter hero">
+          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#2a2a28] bg-[#1e1e1d]/80 px-3 py-1.5 text-[11px] font-medium uppercase tracking-widest text-[#b0aea5]">
+            <span aria-hidden="true">✦</span>
+            Monthly Digest
+            {issues.length > 0 && (
+              <span className="rounded-full bg-[#d97757]/15 px-2 py-0.5 text-[10px] font-semibold text-[#d97757]">
+                {issues.length} issue{issues.length !== 1 ? "s" : ""}
+              </span>
+            )}
+          </div>
+
+          <h1
+            className="mb-4 text-4xl font-semibold text-[#faf9f5] sm:text-5xl"
+            style={FRAUNCES}
+          >
+            The CCK Newsletter
+          </h1>
+          <p className="mx-auto mb-10 max-w-xl text-[#b0aea5]">
+            Claude tips, community projects, event recaps, and what's
+            shipping in the Kenyan AI scene — delivered monthly.
+          </p>
+
+          {/* Email capture */}
+          <HeroEmailCapture
+            label="Subscribe · get the next issue in your inbox"
+            buttonLabel="Subscribe"
+            className="mx-auto max-w-md"
+          />
+        </section>
+
+        {/* ─── Issue list ─── */}
+        <section aria-label="Past issues">
+          <h2
+            className="mb-6 text-xs font-medium uppercase tracking-widest text-[#7a7870]"
+          >
+            Past Issues
+          </h2>
+
+          {issues.length === 0 ? (
+            <div className="card-elevated rounded-2xl p-10 text-center">
+              <p className="mb-2 text-[#faf9f5]">First issue ships soon.</p>
+              <p className="text-sm text-[#b0aea5]">
+                Subscribe above and you&apos;ll be the first to read it.
+              </p>
+            </div>
+          ) : (
+            <ul className="space-y-4" role="list">
+              {issues.map((issue) => (
+                <li key={issue.slug}>
+                  <Link
+                    href={`/newsletter/${issue.slug}`}
+                    className="card-elevated group flex flex-col gap-1.5 rounded-2xl p-6 transition-all duration-200 hover:border-[#3a3a37] sm:flex-row sm:items-start sm:justify-between sm:gap-4"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="mb-1.5 text-[11px] font-medium uppercase tracking-wider text-[#7a7870]">
+                        Issue {padIssueNumber(issue.number)} &middot;{" "}
+                        {formatIssueMonth(issue.publishedAt)}
+                      </p>
+                      <h3
+                        className="mb-2 text-lg font-semibold text-[#faf9f5] group-hover:text-[#d97757] transition-colors"
+                        style={FRAUNCES}
+                      >
+                        {issue.title}
+                      </h3>
+                      <p className="line-clamp-2 text-sm leading-relaxed text-[#b0aea5]">
+                        {issue.excerpt}
+                      </p>
+                    </div>
+                    <span className="mt-1 shrink-0 text-sm text-[#9a9890] transition-colors group-hover:text-[#d97757]">
+                      Read →
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import type { FeedItem } from "@/components/sections/HeroTerminal";
 import { HomeContent } from "@/components/sections/HomeContent";
-import { getUpcomingEvents, getFeaturedProjects, getBlogPosts, getCommunitySubmissions } from "@/lib/data";
+import { getUpcomingEvents, getFeaturedProjects, getBlogPosts, getCommunitySubmissions, getProjectOfTheWeek } from "@/lib/data";
 import { prisma } from "@/lib/prisma";
 import { ensureVisitorId, getAudienceCookie } from "@/lib/karibu/cookies";
 import type { AudienceState } from "@/contexts/AudienceContext";
@@ -32,12 +32,13 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 export default async function Home() {
-  const [upcomingEvents, featuredProjects, siteSettings, blogPosts, communityData] = await Promise.all([
+  const [upcomingEvents, featuredProjects, siteSettings, blogPosts, communityData, projectOfTheWeek] = await Promise.all([
     getUpcomingEvents().catch(() => []),
     getFeaturedProjects().catch(() => []),
     prisma.siteSettings.findUnique({ where: { id: "default" } }).catch(() => null),
     getBlogPosts().catch(() => []),
     getCommunitySubmissions({ limit: 5, sort: "recent" }).catch(() => ({ items: [], total: 0 })),
+    getProjectOfTheWeek().catch(() => null),
   ]);
 
   // Build activity feed for hero terminal — interleave blogs, community, projects
@@ -156,6 +157,7 @@ export default async function Home() {
       featuredProjects={featuredProjects}
       audienceState={audienceState}
       recommendables={recommendables}
+      projectOfTheWeek={projectOfTheWeek}
     />
   );
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,13 +1,15 @@
 import { MetadataRoute } from "next";
-import { getEvents, getBlogPosts, getCommunitySubmissions } from "@/lib/data";
+import { getEvents, getBlogPosts, getCommunitySubmissions, getGalleryPhotos, getNewsletterIssues } from "@/lib/data";
 
 const BASE_URL = "https://www.claudekenya.org";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [events, blogPosts, communityData] = await Promise.all([
+  const [events, blogPosts, communityData, galleryPhotos, newsletterIssues] = await Promise.all([
     getEvents().catch(() => []),
     getBlogPosts().catch(() => []),
     getCommunitySubmissions().catch(() => ({ items: [] })),
+    getGalleryPhotos({ limit: 1 }).catch(() => [] as { id: string }[]),
+    getNewsletterIssues().catch(() => []),
   ]);
 
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -16,6 +18,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/events`, changeFrequency: "weekly", priority: 0.9 },
     { url: `${BASE_URL}/blog`, changeFrequency: "weekly", priority: 0.8 },
     { url: `${BASE_URL}/projects`, changeFrequency: "weekly", priority: 0.8 },
+    // Only list /gallery if there are photos — otherwise it's a thin page.
+    ...(galleryPhotos.length > 0
+      ? [{ url: `${BASE_URL}/gallery`, changeFrequency: "weekly" as const, priority: 0.7 }]
+      : []),
     { url: `${BASE_URL}/community`, changeFrequency: "weekly", priority: 0.8 },
     { url: `${BASE_URL}/join`, changeFrequency: "monthly", priority: 0.9 },
     { url: `${BASE_URL}/resources`, changeFrequency: "monthly", priority: 0.8 },
@@ -34,6 +40,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/community/submit`, changeFrequency: "monthly", priority: 0.5 },
     { url: `${BASE_URL}/chat`, changeFrequency: "monthly", priority: 0.6 },
     { url: `${BASE_URL}/merch`, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${BASE_URL}/newsletter`, changeFrequency: "weekly", priority: 0.7 },
     { url: `${BASE_URL}/signup`, changeFrequency: "yearly", priority: 0.6 },
     { url: `${BASE_URL}/code-of-conduct`, changeFrequency: "yearly", priority: 0.4 },
     // NOTE: /login, /forgot-password, /reset-password, /verify-email,
@@ -61,5 +68,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  return [...staticRoutes, ...eventRoutes, ...blogRoutes, ...communityRoutes];
+  const newsletterRoutes: MetadataRoute.Sitemap = newsletterIssues.map((issue) => ({
+    url: `${BASE_URL}/newsletter/${issue.slug}`,
+    lastModified: issue.publishedAt,
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  return [...staticRoutes, ...eventRoutes, ...blogRoutes, ...communityRoutes, ...newsletterRoutes];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,15 +1,16 @@
 import { MetadataRoute } from "next";
-import { getEvents, getBlogPosts, getCommunitySubmissions, getGalleryPhotos, getNewsletterIssues } from "@/lib/data";
+import { getEvents, getBlogPosts, getCommunitySubmissions, getGalleryPhotos, getNewsletterIssues, getTeamMemberSlugs } from "@/lib/data";
 
 const BASE_URL = "https://www.claudekenya.org";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const [events, blogPosts, communityData, galleryPhotos, newsletterIssues] = await Promise.all([
+  const [events, blogPosts, communityData, galleryPhotos, newsletterIssues, teamSlugs] = await Promise.all([
     getEvents().catch(() => []),
     getBlogPosts().catch(() => []),
     getCommunitySubmissions().catch(() => ({ items: [] })),
     getGalleryPhotos({ limit: 1 }).catch(() => [] as { id: string }[]),
     getNewsletterIssues().catch(() => []),
+    getTeamMemberSlugs().catch(() => [] as string[]),
   ]);
 
   const staticRoutes: MetadataRoute.Sitemap = [
@@ -41,6 +42,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     { url: `${BASE_URL}/chat`, changeFrequency: "monthly", priority: 0.6 },
     { url: `${BASE_URL}/merch`, changeFrequency: "monthly", priority: 0.5 },
     { url: `${BASE_URL}/newsletter`, changeFrequency: "weekly", priority: 0.7 },
+    { url: `${BASE_URL}/team`, changeFrequency: "monthly", priority: 0.7 },
     { url: `${BASE_URL}/signup`, changeFrequency: "yearly", priority: 0.6 },
     { url: `${BASE_URL}/code-of-conduct`, changeFrequency: "yearly", priority: 0.4 },
     // NOTE: /login, /forgot-password, /reset-password, /verify-email,
@@ -75,5 +77,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  return [...staticRoutes, ...eventRoutes, ...blogRoutes, ...communityRoutes, ...newsletterRoutes];
+  const teamRoutes: MetadataRoute.Sitemap = teamSlugs.map((slug) => ({
+    url: `${BASE_URL}/team/${slug}`,
+    changeFrequency: "monthly" as const,
+    priority: 0.5,
+  }));
+
+  return [...staticRoutes, ...eventRoutes, ...blogRoutes, ...communityRoutes, ...newsletterRoutes, ...teamRoutes];
 }

--- a/src/app/team/[slug]/page.tsx
+++ b/src/app/team/[slug]/page.tsx
@@ -1,0 +1,202 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import Image from "next/image"
+import { notFound } from "next/navigation"
+import { ArrowLeft, Github, Linkedin, Twitter, Globe, MapPin } from "lucide-react"
+import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema"
+import { getTeamMemberBySlug, getTeamMemberSlugs } from "@/lib/data"
+
+export const revalidate = 1800
+
+export async function generateStaticParams() {
+  const slugs = await getTeamMemberSlugs().catch(() => [])
+  return slugs.map((slug) => ({ slug }))
+}
+
+interface PageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateMetadata(
+  { params }: PageProps,
+): Promise<Metadata> {
+  const { slug } = await params
+  const member = await getTeamMemberBySlug(slug)
+  if (!member) return { title: "Member not found" }
+
+  const title = `${member.name} — ${member.role} | Claude Community Kenya`
+  const description = member.tagline ?? member.bio.slice(0, 160)
+  const url = `https://www.claudekenya.org/team/${slug}`
+
+  return {
+    title,
+    description,
+    alternates: { canonical: url },
+    openGraph: {
+      title,
+      description,
+      url,
+      siteName: "Claude Community Kenya",
+      type: "profile",
+      images: member.avatar ? [{ url: member.avatar }] : undefined,
+    },
+  }
+}
+
+export default async function TeamMemberPage({ params }: PageProps) {
+  const { slug } = await params
+  const member = await getTeamMemberBySlug(slug)
+  if (!member) notFound()
+
+  const paragraphs = (member.longBio ?? member.bio).split(/\n{2,}/)
+
+  return (
+    <main className="min-h-screen px-4 py-16 sm:px-6 lg:px-8">
+      <BreadcrumbSchema
+        items={[
+          { name: "Home", url: "/" },
+          { name: "Team", url: "/team" },
+          { name: member.name },
+        ]}
+      />
+
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0"
+        style={{
+          background: `
+            radial-gradient(ellipse 60% 35% at 50% -10%, rgba(217, 119, 87, 0.08), transparent 60%),
+            radial-gradient(ellipse 50% 40% at 90% 60%, rgba(106, 155, 204, 0.05), transparent 65%)
+          `,
+        }}
+      />
+
+      <div className="relative mx-auto max-w-3xl">
+        <Link
+          href="/team"
+          className="mb-10 inline-flex items-center gap-2 text-[13px] font-medium uppercase tracking-[0.14em] text-[#b0aea5] transition-colors hover:text-[#faf9f5]"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          All team
+        </Link>
+
+        <header className="mb-10 flex flex-col items-center text-center sm:flex-row sm:items-start sm:text-left">
+          <div className="relative mb-6 h-28 w-28 shrink-0 overflow-hidden rounded-full border border-[#2a2a28] bg-[#1e1e1d] sm:mb-0 sm:mr-8 sm:h-32 sm:w-32">
+            {member.avatar ? (
+              <Image
+                src={member.avatar}
+                alt={member.name}
+                fill
+                sizes="128px"
+                className="object-cover"
+                priority
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center text-[28px] font-medium text-[#b0aea5]">
+                {initials(member.name)}
+              </div>
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <h1
+              className="mb-3 text-[36px] font-medium leading-tight text-[#faf9f5] sm:text-[44px]"
+              style={{
+                fontFamily: 'var(--font-display), ui-serif, Georgia, serif',
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {member.name}
+            </h1>
+
+            <p className="mb-3 text-[15px] text-[#d97757]">{member.role}</p>
+
+            {member.tagline && (
+              <p
+                className="mb-4 text-[17px] leading-snug text-[#faf9f5]"
+                style={{
+                  fontFamily: 'var(--font-display), ui-serif, Georgia, serif',
+                  fontStyle: "italic",
+                }}
+              >
+                "{member.tagline}"
+              </p>
+            )}
+
+            <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2 sm:justify-start">
+              {member.location && (
+                <span className="inline-flex items-center gap-1.5 text-[12px] uppercase tracking-[0.14em] text-[#7a7870]">
+                  <MapPin className="h-3 w-3" />
+                  {member.location}
+                </span>
+              )}
+              <Socials member={member} />
+            </div>
+          </div>
+        </header>
+
+        <section
+          aria-label="Biography"
+          className="card-elevated rounded-3xl p-8 sm:p-10"
+        >
+          {paragraphs.map((p, i) => (
+            <p
+              key={i}
+              className="mb-4 text-[16px] leading-relaxed text-[#b0aea5] last:mb-0"
+            >
+              {p}
+            </p>
+          ))}
+        </section>
+
+        <section className="mt-12 text-center">
+          <p className="mb-4 text-[12px] uppercase tracking-[0.14em] text-[#7a7870]">
+            Want to join the team?
+          </p>
+          <Link
+            href="/volunteer"
+            className="inline-flex items-center gap-2 rounded-full bg-[#d97757] px-6 py-3 text-[14px] font-medium text-[#faf9f5] transition-transform hover:-translate-y-0.5 btn-primary-shadow"
+          >
+            Volunteer with CCK
+          </Link>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+function Socials({ member }: { member: NonNullable<Awaited<ReturnType<typeof getTeamMemberBySlug>>> }) {
+  const links: Array<{ href: string; label: string; Icon: typeof Github }> = []
+  if (member.github) links.push({ href: member.github, label: "GitHub", Icon: Github })
+  if (member.linkedIn) links.push({ href: member.linkedIn, label: "LinkedIn", Icon: Linkedin })
+  if (member.twitter) links.push({ href: member.twitter, label: "Twitter / X", Icon: Twitter })
+  if (member.website) links.push({ href: member.website, label: "Website", Icon: Globe })
+  if (links.length === 0) return null
+
+  return (
+    <div className="flex items-center gap-1">
+      {links.map(({ href, label, Icon }) => (
+        <a
+          key={href}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${member.name} on ${label}`}
+          className="flex h-9 w-9 items-center justify-center rounded-full text-[#b0aea5] transition-colors hover:bg-[#2a2a28] hover:text-[#faf9f5]"
+        >
+          <Icon className="h-4 w-4" />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((p) => p[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import Image from "next/image"
+import { Github, Linkedin, Twitter, Globe } from "lucide-react"
+import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema"
+import { getTeamMembers, type TeamMemberView } from "@/lib/data"
+
+export const revalidate = 1800
+
+export const metadata: Metadata = {
+  title: "The team behind CCK | Claude Community Kenya",
+  description:
+    "Meet the organizers, ambassadors, and contributors who run Claude Community Kenya — Africa's first Claude developer community.",
+  alternates: { canonical: "https://www.claudekenya.org/team" },
+  openGraph: {
+    title: "The team behind CCK | Claude Community Kenya",
+    description:
+      "Meet the organizers and ambassadors running Africa's first Claude developer community.",
+    url: "https://www.claudekenya.org/team",
+    siteName: "Claude Community Kenya",
+    type: "website",
+  },
+}
+
+export default async function TeamPage() {
+  const members = await getTeamMembers().catch(() => [])
+
+  return (
+    <main className="min-h-screen px-4 py-16 sm:px-6 lg:px-8">
+      <BreadcrumbSchema items={[{ name: "Home", url: "/" }, { name: "Team" }]} />
+
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0"
+        style={{
+          background: `
+            radial-gradient(ellipse 60% 35% at 50% -10%, rgba(217, 119, 87, 0.08), transparent 60%),
+            radial-gradient(ellipse 50% 40% at 90% 60%, rgba(106, 155, 204, 0.05), transparent 65%)
+          `,
+        }}
+      />
+
+      <div className="relative mx-auto max-w-6xl">
+        <section className="mb-14 text-center">
+          <div className="mb-6">
+            <span className="inline-flex items-center gap-2 rounded-full border border-[#2a2a28] bg-[#1e1e1d]/60 px-3.5 py-1 text-[11px] font-medium uppercase tracking-[0.14em] text-[#b0aea5] backdrop-blur-sm">
+              <img src="/images/claude-sparkle.svg" alt="" className="h-3 w-3" />
+              <span>The Team</span>
+            </span>
+          </div>
+
+          <h1
+            className="mb-5 text-[42px] font-medium text-[#faf9f5] sm:text-[56px] lg:text-[64px]"
+            style={{
+              fontFamily: 'var(--font-display), ui-serif, Georgia, serif',
+              letterSpacing: "-0.025em",
+            }}
+          >
+            The people behind CCK
+          </h1>
+
+          <p className="mx-auto max-w-xl text-[17px] leading-relaxed text-[#b0aea5]">
+            Organisers, ambassadors, and contributors making Africa's first
+            Claude developer community real — one meetup at a time.
+          </p>
+        </section>
+
+        {members.length === 0 ? (
+          <EmptyState />
+        ) : (
+          <section
+            aria-label="Team members"
+            className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3"
+          >
+            {members.map((m) => (
+              <MemberCard key={m.slug ?? m.name} member={m} />
+            ))}
+          </section>
+        )}
+      </div>
+    </main>
+  )
+}
+
+function MemberCard({ member }: { member: TeamMemberView }) {
+  const inner = (
+    <article className="card-elevated group flex h-full flex-col gap-4 rounded-3xl p-6 transition-all duration-300 hover:-translate-y-0.5">
+      <div className="flex items-center gap-4">
+        <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-full border border-[#2a2a28] bg-[#1e1e1d]">
+          {member.avatar ? (
+            <Image
+              src={member.avatar}
+              alt={member.name}
+              fill
+              sizes="64px"
+              className="object-cover"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-[20px] font-medium text-[#b0aea5]">
+              {initials(member.name)}
+            </div>
+          )}
+        </div>
+        <div className="min-w-0">
+          <h2 className="truncate text-[17px] font-medium text-[#faf9f5]">
+            {member.name}
+          </h2>
+          <p className="truncate text-[13px] text-[#b0aea5]">{member.role}</p>
+        </div>
+      </div>
+
+      {member.tagline && (
+        <p
+          className="text-[15px] leading-snug text-[#faf9f5]"
+          style={{
+            fontFamily: 'var(--font-display), ui-serif, Georgia, serif',
+            fontStyle: "italic",
+          }}
+        >
+          "{member.tagline}"
+        </p>
+      )}
+
+      <p className="line-clamp-3 text-[14px] leading-relaxed text-[#b0aea5]">
+        {member.bio}
+      </p>
+
+      <div className="mt-auto flex items-center justify-between pt-2">
+        <SocialIcons member={member} />
+        {member.location && (
+          <span className="text-[11px] uppercase tracking-[0.14em] text-[#7a7870]">
+            {member.location}
+          </span>
+        )}
+      </div>
+    </article>
+  )
+
+  return member.slug ? (
+    <Link
+      href={`/team/${member.slug}`}
+      aria-label={`Read more about ${member.name}`}
+      className="rounded-3xl outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]"
+    >
+      {inner}
+    </Link>
+  ) : (
+    inner
+  )
+}
+
+function SocialIcons({ member }: { member: TeamMemberView }) {
+  const links: Array<{ href: string; label: string; Icon: typeof Github }> = []
+  if (member.github) links.push({ href: member.github, label: "GitHub", Icon: Github })
+  if (member.linkedIn) links.push({ href: member.linkedIn, label: "LinkedIn", Icon: Linkedin })
+  if (member.twitter) links.push({ href: member.twitter, label: "Twitter / X", Icon: Twitter })
+  if (member.website) links.push({ href: member.website, label: "Website", Icon: Globe })
+
+  if (links.length === 0) {
+    return <span className="text-[11px] uppercase tracking-[0.14em] text-[#3a3a37]">—</span>
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {links.map(({ href, label, Icon }) => (
+        <a
+          key={href}
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={`${member.name} on ${label}`}
+          onClick={(e) => e.stopPropagation()}
+          className="flex h-8 w-8 items-center justify-center rounded-full text-[#b0aea5] transition-colors hover:bg-[#2a2a28] hover:text-[#faf9f5]"
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </a>
+      ))}
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="mx-auto max-w-md rounded-3xl border border-[#2a2a28] bg-[#1e1e1d]/40 p-10 text-center">
+      <p className="text-[15px] text-[#b0aea5]">
+        Team profiles ship soon. In the meantime, follow along on{" "}
+        <a
+          href="https://discord.gg/CkD9QWjsHm"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="link-refined"
+        >
+          Discord
+        </a>
+        .
+      </p>
+    </div>
+  )
+}
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((p) => p[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -20,6 +20,7 @@ import {
   Library,
   UsersRound,
   Sparkles,
+  Camera,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -32,6 +33,7 @@ const navItems = [
   { href: "/admin/karibu", label: "Karibu", icon: Sparkles },
   { href: "/admin/volunteers", label: "Volunteers", icon: HandHeart },
   { href: "/admin/events", label: "Events", icon: Calendar },
+  { href: "/admin/photos", label: "Photos", icon: Camera },
   { href: "/admin/blog", label: "Blog Posts", icon: FileText },
   { href: "/admin/community", label: "Community Hub", icon: Library },
   { href: "/admin/contact", label: "Contact Messages", icon: MessageSquare },

--- a/src/components/gallery/GalleryGrid.tsx
+++ b/src/components/gallery/GalleryGrid.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Camera } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { PhotoView } from "@/lib/data";
+import { PhotoLightbox } from "./PhotoLightbox";
+
+interface EventChip {
+  slug: string;
+  title: string;
+  date: Date | string;
+  city: string;
+  count: number;
+}
+
+interface GalleryGridProps {
+  photos: PhotoView[];
+  eventChips?: EventChip[];
+  /**
+   * The slug of the currently-selected event filter, or null for "all".
+   * Passed as a URL search param so the filter survives a refresh.
+   */
+  initialFilter?: string | null;
+}
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+
+export function GalleryGrid({ photos, eventChips = [], initialFilter = null }: GalleryGridProps) {
+  const [activeFilter, setActiveFilter] = useState<string | null>(initialFilter);
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  const filteredPhotos = useMemo(() => {
+    if (!activeFilter) return photos;
+    return photos.filter((p) => p.event?.slug === activeFilter);
+  }, [photos, activeFilter]);
+
+  if (photos.length === 0) {
+    return (
+      <div className="card-elevated mx-auto max-w-2xl rounded-2xl p-12 text-center">
+        <Camera
+          className="mx-auto mb-4 h-10 w-10 text-[#7a7870]"
+          aria-hidden="true"
+        />
+        <h2
+          className="mb-3 text-[24px] font-medium text-[#faf9f5]"
+          style={{ fontFamily: 'var(--font-display), ui-serif, Georgia, serif' }}
+        >
+          Photos coming soon
+        </h2>
+        <p className="mx-auto max-w-md text-[14px] leading-relaxed text-[#b0aea5]">
+          We&apos;re curating photos from the first few meetups. Join the next
+          one in person — and you might end up here.
+        </p>
+        <Link
+          href="/events"
+          className="link-refined mt-5 inline-block text-[13px] font-semibold text-[#d97757] hover:text-[#e89576]"
+        >
+          See upcoming events →
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Filter chips — only if there are multiple events with photos */}
+      {eventChips.length > 1 && (
+        <div className="mb-8 flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => setActiveFilter(null)}
+            aria-pressed={activeFilter === null}
+            className={cn(
+              "rounded-full border px-4 py-1.5 text-[13px] font-medium transition-all duration-200",
+              activeFilter === null
+                ? "border-[#d97757] bg-[#d97757]/15 text-[#d97757]"
+                : "border-[#2a2a28] text-[#b0aea5] hover:border-[#3a3a37] hover:text-[#e8e6dc]",
+            )}
+          >
+            All ({photos.length})
+          </button>
+          {eventChips.map((chip) => (
+            <button
+              key={chip.slug}
+              type="button"
+              onClick={() => setActiveFilter(chip.slug)}
+              aria-pressed={activeFilter === chip.slug}
+              className={cn(
+                "rounded-full border px-4 py-1.5 text-[13px] font-medium transition-all duration-200",
+                activeFilter === chip.slug
+                  ? "border-[#d97757] bg-[#d97757]/15 text-[#d97757]"
+                  : "border-[#2a2a28] text-[#b0aea5] hover:border-[#3a3a37] hover:text-[#e8e6dc]",
+              )}
+            >
+              {chip.title} ({chip.count})
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Grid */}
+      <ul
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        role="list"
+      >
+        {filteredPhotos.map((photo, i) => (
+          <motion.li
+            key={photo.id}
+            initial={{ opacity: 0, y: 10 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, margin: "-40px" }}
+            transition={{ duration: 0.45, delay: Math.min(i * 0.03, 0.4), ease: EASE_OUT }}
+          >
+            <button
+              type="button"
+              onClick={() => setLightboxIndex(i)}
+              aria-label={photo.caption ?? `Open photo ${i + 1}`}
+              className="group relative block w-full overflow-hidden rounded-2xl border border-[#2a2a28] bg-[#1e1e1d] transition-all duration-300 hover:border-[#3a3a37] hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#d97757]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-bg-primary"
+            >
+              <div className="relative aspect-[4/3] w-full overflow-hidden">
+                <Image
+                  src={photo.thumbnailUrl ?? photo.url}
+                  alt={photo.alt ?? photo.caption ?? "Community photo"}
+                  fill
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+                  className="object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+                />
+                {/* Bottom-gradient overlay reveals caption on hover */}
+                <div
+                  aria-hidden="true"
+                  className="pointer-events-none absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/90 via-black/40 to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+                />
+              </div>
+              {(photo.caption || photo.event) && (
+                <div className="pointer-events-none absolute inset-x-0 bottom-0 translate-y-2 px-4 py-3 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100">
+                  {photo.caption && (
+                    <p className="line-clamp-2 text-[13px] leading-snug text-[#faf9f5]">
+                      {photo.caption}
+                    </p>
+                  )}
+                  {photo.event && (
+                    <p className="mt-0.5 text-[10.5px] font-medium uppercase tracking-[0.14em] text-[#d97757]">
+                      {photo.event.title}
+                    </p>
+                  )}
+                </div>
+              )}
+              {photo.featured && (
+                <span
+                  aria-label="Featured photo"
+                  className="absolute right-2 top-2 rounded-full border border-[#d97757]/40 bg-[#d97757]/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#faf9f5] backdrop-blur-sm"
+                >
+                  Featured
+                </span>
+              )}
+            </button>
+          </motion.li>
+        ))}
+      </ul>
+
+      {filteredPhotos.length === 0 && (
+        <div className="mt-6 text-center text-[14px] text-[#b0aea5]">
+          No photos from this event yet.
+        </div>
+      )}
+
+      <PhotoLightbox
+        photos={filteredPhotos}
+        currentIndex={lightboxIndex}
+        onClose={() => setLightboxIndex(null)}
+        onIndexChange={setLightboxIndex}
+      />
+    </>
+  );
+}

--- a/src/components/gallery/PhotoLightbox.tsx
+++ b/src/components/gallery/PhotoLightbox.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import Image from "next/image";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import type { PhotoView } from "@/lib/data";
+
+interface PhotoLightboxProps {
+  photos: PhotoView[];
+  currentIndex: number | null;
+  onClose: () => void;
+  onIndexChange: (i: number) => void;
+}
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+
+/**
+ * Accessible fullscreen photo viewer.
+ *
+ * Keyboard:
+ *  - Esc closes
+ *  - ← / → navigate
+ *  - Tab cycles inside the dialog (focus trap)
+ *
+ * Touch: swipe horizontally on the image to navigate.
+ */
+export function PhotoLightbox({
+  photos,
+  currentIndex,
+  onClose,
+  onIndexChange,
+}: PhotoLightboxProps) {
+  const reduce = useReducedMotion();
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const touchStartX = useRef<number | null>(null);
+  const open = currentIndex !== null;
+  const photo = open ? photos[currentIndex] : null;
+
+  const next = useCallback(() => {
+    if (currentIndex === null) return;
+    onIndexChange((currentIndex + 1) % photos.length);
+  }, [currentIndex, photos.length, onIndexChange]);
+
+  const prev = useCallback(() => {
+    if (currentIndex === null) return;
+    onIndexChange((currentIndex - 1 + photos.length) % photos.length);
+  }, [currentIndex, photos.length, onIndexChange]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        next();
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        prev();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    closeBtnRef.current?.focus();
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open, next, prev, onClose]);
+
+  function onTouchStart(e: React.TouchEvent) {
+    touchStartX.current = e.touches[0]?.clientX ?? null;
+  }
+  function onTouchEnd(e: React.TouchEvent) {
+    if (touchStartX.current === null) return;
+    const dx = (e.changedTouches[0]?.clientX ?? 0) - touchStartX.current;
+    if (Math.abs(dx) > 50) {
+      if (dx < 0) next();
+      else prev();
+    }
+    touchStartX.current = null;
+  }
+
+  return (
+    <AnimatePresence>
+      {open && photo && (
+        <motion.div
+          key="lightbox"
+          role="dialog"
+          aria-modal="true"
+          aria-label={photo.caption ?? "Photo viewer"}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: reduce ? 0 : 0.2, ease: EASE_OUT }}
+          className="fixed inset-0 z-[200] flex items-center justify-center bg-black/95 backdrop-blur-sm"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) onClose();
+          }}
+        >
+          {/* Close */}
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={onClose}
+            aria-label="Close photo viewer"
+            className="absolute right-4 top-4 z-10 flex h-11 w-11 items-center justify-center rounded-full border border-[#3a3a37] bg-[#1e1e1d]/80 text-[#e8e6dc] backdrop-blur-md transition-colors hover:bg-[#252524] hover:text-[#faf9f5]"
+          >
+            <X className="h-5 w-5" aria-hidden="true" />
+          </button>
+
+          {/* Prev */}
+          {photos.length > 1 && (
+            <button
+              type="button"
+              onClick={prev}
+              aria-label="Previous photo"
+              className="absolute left-2 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-[#3a3a37] bg-[#1e1e1d]/80 text-[#e8e6dc] backdrop-blur-md transition-colors hover:bg-[#252524] hover:text-[#faf9f5] sm:left-4"
+            >
+              <ChevronLeft className="h-6 w-6" aria-hidden="true" />
+            </button>
+          )}
+
+          {/* Next */}
+          {photos.length > 1 && (
+            <button
+              type="button"
+              onClick={next}
+              aria-label="Next photo"
+              className="absolute right-2 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full border border-[#3a3a37] bg-[#1e1e1d]/80 text-[#e8e6dc] backdrop-blur-md transition-colors hover:bg-[#252524] hover:text-[#faf9f5] sm:right-4"
+            >
+              <ChevronRight className="h-6 w-6" aria-hidden="true" />
+            </button>
+          )}
+
+          {/* Image + caption stack */}
+          <motion.div
+            key={photo.id}
+            initial={{ opacity: 0, scale: reduce ? 1 : 0.97 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: reduce ? 1 : 0.97 }}
+            transition={{ duration: reduce ? 0 : 0.25, ease: EASE_OUT }}
+            className="flex h-full w-full max-w-6xl flex-col items-center justify-center gap-4 px-4 py-16"
+            onTouchStart={onTouchStart}
+            onTouchEnd={onTouchEnd}
+          >
+            <div className="relative flex max-h-[calc(100dvh-180px)] w-full flex-1 items-center justify-center">
+              <Image
+                src={photo.url}
+                alt={photo.alt ?? photo.caption ?? "Community photo"}
+                width={1600}
+                height={1067}
+                sizes="(max-width: 1024px) 100vw, 1024px"
+                className="h-auto max-h-full w-auto max-w-full rounded-xl object-contain shadow-2xl"
+                priority
+              />
+            </div>
+
+            {(photo.caption || photo.photographer || photo.event) && (
+              <div className="w-full max-w-2xl text-center">
+                {photo.caption && (
+                  <p className="text-[14px] text-[#e8e6dc]">{photo.caption}</p>
+                )}
+                <p className="mt-1 text-[11px] font-medium uppercase tracking-[0.14em] text-[#7a7870]">
+                  {photo.event && (
+                    <span className="text-[#b0aea5]">{photo.event.title}</span>
+                  )}
+                  {photo.event && photo.photographer && (
+                    <span className="mx-2 text-[#3a3a37]">·</span>
+                  )}
+                  {photo.photographer && (
+                    <>Photo by {photo.photographer}</>
+                  )}
+                </p>
+              </div>
+            )}
+
+            {photos.length > 1 && (
+              <p className="text-[11px] font-medium text-[#7a7870] tabular-nums">
+                {currentIndex !== null ? currentIndex + 1 : 0} / {photos.length}
+              </p>
+            )}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/components/layout/MobileMenu.tsx
+++ b/src/components/layout/MobileMenu.tsx
@@ -106,10 +106,70 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
             </div>
           )}
 
-          {/* Navigation links */}
-          <nav className="flex flex-col gap-1 p-6" aria-label="Mobile navigation">
+          {/* Navigation links — flat for items without children, section + indented sub-items for grouped */}
+          <nav className="flex flex-col gap-1 overflow-y-auto p-6" aria-label="Mobile navigation">
             {NAV_LINKS.map((link, index) => {
-              const isActive = pathname === link.href;
+              const hasChildren = link.children && link.children.length > 0;
+              const isActive =
+                pathname === link.href ||
+                (hasChildren &&
+                  link.children!.some(
+                    (c) => pathname === c.href || pathname.startsWith(c.href + "/"),
+                  ));
+
+              if (hasChildren) {
+                return (
+                  <motion.div
+                    key={link.label}
+                    initial={{ opacity: 0, x: -20 }}
+                    animate={{ opacity: 1, x: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                    className="mb-2"
+                  >
+                    <div
+                      className={cn(
+                        "px-1 pt-3 pb-1 text-[11px] font-medium uppercase tracking-[0.16em]",
+                        isPro ? "text-[#9a9890]" : "font-mono text-text-dim",
+                      )}
+                    >
+                      {!isPro && <span className="text-green-dim" aria-hidden="true">{"// "}</span>}
+                      {link.label}
+                    </div>
+                    <ul className="flex flex-col">
+                      {link.children!.map((child) => {
+                        const childActive =
+                          pathname === child.href ||
+                          pathname.startsWith(child.href + "/");
+                        return (
+                          <li key={child.href}>
+                            <Link
+                              href={child.href}
+                              onClick={onClose}
+                              className={cn(
+                                "block py-2.5 pl-3 text-base transition-colors",
+                                isPro ? "font-medium" : "font-mono",
+                                childActive
+                                  ? isPro
+                                    ? "text-[#d97757]"
+                                    : "text-green-primary"
+                                  : "text-text-secondary hover:text-text-primary",
+                              )}
+                            >
+                              {!isPro && (
+                                <span className="text-green-dim" aria-hidden="true">
+                                  &gt;{" "}
+                                </span>
+                              )}
+                              {isPro ? child.label : child.label.toUpperCase()}
+                            </Link>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </motion.div>
+                );
+              }
+
               return (
                 <motion.div
                   key={link.href}
@@ -124,8 +184,10 @@ export function MobileMenu({ isOpen, onClose }: MobileMenuProps) {
                       "block py-3 text-lg transition-colors",
                       isPro ? "font-medium" : "font-mono",
                       isActive
-                        ? isPro ? "text-[#d97757]" : "text-green-primary"
-                        : "text-text-secondary hover:text-text-primary"
+                        ? isPro
+                          ? "text-[#d97757]"
+                          : "text-green-primary"
+                        : "text-text-secondary hover:text-text-primary",
                     )}
                   >
                     {!isPro && <span className="text-green-dim" aria-hidden="true">&gt; </span>}

--- a/src/components/layout/NavDropdown.tsx
+++ b/src/components/layout/NavDropdown.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useState, useRef, useEffect, useId } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { motion, AnimatePresence } from "framer-motion";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useSkin } from "@/contexts/SkinContext";
+import type { NavLink } from "@/lib/constants";
+
+interface NavDropdownProps {
+  item: NavLink;
+}
+
+const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+const HOVER_CLOSE_DELAY_MS = 120;
+
+export function NavDropdown({ item }: NavDropdownProps) {
+  const { skin } = useSkin();
+  const isPro = skin === "pro";
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const closeTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const menuId = useId();
+  const pathname = usePathname();
+
+  const children = item.children ?? [];
+  const isActive =
+    pathname === item.href ||
+    children.some((c) => pathname === c.href || pathname.startsWith(c.href + "/"));
+
+  function cancelClose() {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+      closeTimeout.current = null;
+    }
+  }
+
+  function scheduleClose() {
+    cancelClose();
+    closeTimeout.current = setTimeout(() => setOpen(false), HOVER_CLOSE_DELAY_MS);
+  }
+
+  // Close on click-outside
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  // Close on Escape, focus the trigger
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setOpen(false);
+        buttonRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      onMouseEnter={() => {
+        cancelClose();
+        setOpen(true);
+      }}
+      onMouseLeave={scheduleClose}
+    >
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowDown" && !open) {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={menuId}
+        className={cn(
+          "relative inline-flex items-center gap-1 px-3 py-2 text-sm transition-colors",
+          isPro ? "font-medium" : "font-mono",
+          isActive
+            ? isPro
+              ? "text-text-primary"
+              : "text-green-primary"
+            : "text-text-secondary hover:text-text-primary",
+        )}
+      >
+        {isActive && !isPro && (
+          <span className="text-green-dim" aria-hidden="true">&gt; </span>
+        )}
+        {isPro ? item.label : item.label.toUpperCase()}
+        <ChevronDown
+          className={cn(
+            "h-3 w-3 transition-transform duration-200",
+            open && "rotate-180",
+          )}
+          aria-hidden="true"
+        />
+        {isActive && (
+          <span
+            className={cn(
+              "absolute bottom-0 left-3 right-3 h-px",
+              isPro ? "bg-text-primary" : "bg-green-primary",
+            )}
+          />
+        )}
+      </button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            id={menuId}
+            role="menu"
+            aria-label={`${item.label} menu`}
+            initial={{ opacity: 0, y: 4, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 2, scale: 0.97 }}
+            transition={{ duration: 0.18, ease: EASE_OUT }}
+            className={cn(
+              "absolute left-0 top-full z-50 mt-2 min-w-[260px] overflow-hidden rounded-2xl border backdrop-blur-md",
+              isPro
+                ? "border-[#2a2a28] bg-[#1e1e1d]/95 shadow-[0_12px_40px_rgba(0,0,0,0.4),0_0_0_1px_rgba(217,119,87,0.05)]"
+                : "border-border-default bg-bg-card/95 shadow-[0_8px_30px_rgba(0,0,0,0.4),0_0_0_1px_rgba(0,255,65,0.05)]",
+            )}
+          >
+            <ul className="py-2" role="none">
+              {children.map((child) => {
+                const childActive =
+                  pathname === child.href ||
+                  pathname.startsWith(child.href + "/");
+                return (
+                  <li key={child.href} role="none">
+                    <Link
+                      href={child.href}
+                      role="menuitem"
+                      onClick={() => setOpen(false)}
+                      className={cn(
+                        "block px-4 py-2.5 transition-colors",
+                        isPro
+                          ? childActive
+                            ? "bg-[#252524] text-[#faf9f5]"
+                            : "text-[#e8e6dc] hover:bg-[#252524] hover:text-[#faf9f5]"
+                          : childActive
+                            ? "bg-green-primary/10 text-green-primary"
+                            : "font-mono text-text-secondary hover:bg-bg-elevated hover:text-text-primary",
+                      )}
+                    >
+                      <div className={cn(
+                        "text-[13.5px]",
+                        isPro ? "font-medium" : "font-mono",
+                      )}>
+                        {isPro ? child.label : child.label.toUpperCase()}
+                      </div>
+                      {child.description && isPro && (
+                        <div className="mt-0.5 text-[12px] text-[#7a7870]">
+                          {child.description}
+                        </div>
+                      )}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -9,6 +9,7 @@ import { NAV_LINKS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import dynamic from "next/dynamic";
 import { MobileMenu } from "./MobileMenu";
+import { NavDropdown } from "./NavDropdown";
 import { useSkin } from "@/contexts/SkinContext";
 
 const CommandPalette = dynamic(
@@ -125,6 +126,9 @@ export function Navbar() {
           {/* Desktop Navigation */}
           <div className="hidden items-center gap-1 md:flex">
             {NAV_LINKS.map((link) => {
+              if (link.children && link.children.length > 0) {
+                return <NavDropdown key={link.label} item={link} />;
+              }
               const isActive = pathname === link.href;
               return (
                 <Link

--- a/src/components/sections/HomeContent.tsx
+++ b/src/components/sections/HomeContent.tsx
@@ -10,6 +10,7 @@ import type { ProjectView } from "@/lib/data";
 import type { AudienceState } from "@/contexts/AudienceContext";
 import type { Recommendable } from "@/lib/recommendations";
 import { PersonalizedHero } from "@/components/sections/PersonalizedHero";
+import { ProjectOfTheWeek } from "@/components/sections/ProjectOfTheWeek";
 import { SocialProofRail } from "@/components/sections/SocialProofRail";
 import { MadeForYou } from "@/components/sections/MadeForYou";
 import { StatsBar } from "@/components/sections/StatsBar";
@@ -32,6 +33,7 @@ interface HomeContentProps {
   featuredProjects: ProjectView[];
   audienceState: AudienceState;
   recommendables: Recommendable[];
+  projectOfTheWeek?: ProjectView | null;
 }
 
 const whatWeDoItems = [
@@ -109,7 +111,7 @@ const joinPathways = [
   },
 ];
 
-export function HomeContent({ communityStats, feedItems, upcomingEvents, featuredProjects, audienceState, recommendables }: HomeContentProps) {
+export function HomeContent({ communityStats, feedItems, upcomingEvents, featuredProjects, audienceState, recommendables, projectOfTheWeek }: HomeContentProps) {
   const { skin } = useSkin();
   const isPro = skin === "pro";
 
@@ -119,6 +121,9 @@ export function HomeContent({ communityStats, feedItems, upcomingEvents, feature
       <section className="mx-auto max-w-6xl px-4 pt-8 md:pt-12 lg:pt-16 pb-4" aria-label="Hero">
         <PersonalizedHero stats={communityStats} feedItems={feedItems} />
       </section>
+
+      {/* ─── Project of the Week ─── Habit-forming weekly hero slot. */}
+      <ProjectOfTheWeek project={projectOfTheWeek ?? null} />
 
       {/* ─── Social Proof Rail ─── Trust signal right after the hero, before any other content. */}
       {isPro && <SocialProofRail />}

--- a/src/components/sections/ProjectOfTheWeek.tsx
+++ b/src/components/sections/ProjectOfTheWeek.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import Link from "next/link";
+import { motion } from "framer-motion";
+import { Sparkles, ExternalLink } from "lucide-react";
+import type { ProjectView } from "@/lib/data";
+
+interface ProjectOfTheWeekProps {
+  project: ProjectView | null;
+}
+
+/** Fraunces display-serif inline style */
+const FRAUNCES: React.CSSProperties = {
+  fontFamily: "var(--font-display), ui-serif, Georgia, serif",
+  letterSpacing: "-0.025em",
+};
+
+/**
+ * Hero-slot panel surfacing the current Project of the Week.
+ * Renders nothing when no project is designated.
+ */
+export function ProjectOfTheWeek({ project }: ProjectOfTheWeekProps) {
+  if (!project) return null;
+
+  const projectLink = project.demoUrl ?? project.repoUrl ?? "/projects";
+
+  return (
+    <section
+      className="mx-auto max-w-6xl px-4 pb-8 md:pb-10"
+      aria-label="Project of the Week"
+    >
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.55, ease: [0.16, 1, 0.3, 1] }}
+      >
+        <div className="card-featured rounded-2xl p-6 sm:p-8">
+          {/* Eyebrow */}
+          <div className="mb-4 flex items-center gap-2">
+            <Sparkles
+              className="h-3.5 w-3.5 text-[#d97757]"
+              aria-hidden="true"
+            />
+            <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-[#d97757]">
+              Project of the Week
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between">
+            {/* Left: project info */}
+            <div className="flex-1 min-w-0">
+              {/* Project name */}
+              <h2
+                className="mb-1 text-2xl font-semibold text-[#faf9f5] sm:text-3xl"
+                style={FRAUNCES}
+              >
+                {project.name}
+              </h2>
+
+              {/* Builder */}
+              <p className="mb-3 text-sm text-[#9a9890]">
+                by {project.builder}
+              </p>
+
+              {/* Description */}
+              <p className="mb-4 max-w-xl text-sm leading-relaxed text-[#b0aea5]">
+                {project.description.length > 160
+                  ? project.description.slice(0, 157) + "…"
+                  : project.description}
+              </p>
+
+              {/* Stack chips */}
+              {project.stack.length > 0 && (
+                <div
+                  className="flex flex-wrap gap-2"
+                  role="list"
+                  aria-label="Tech stack"
+                >
+                  {project.stack.slice(0, 6).map((tech) => (
+                    <span
+                      key={tech}
+                      role="listitem"
+                      className="inline-flex items-center rounded-full border border-[#2a2a28] bg-[#1e1e1d]/80 px-3 py-1 text-[12px] font-medium text-[#9a9890]"
+                    >
+                      {tech}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {/* Right: CTA */}
+            <div className="flex shrink-0 items-start sm:items-center">
+              {project.demoUrl || project.repoUrl ? (
+                <a
+                  href={projectLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[#d97757] px-5 py-2.5 text-sm font-semibold text-[#faf9f5] transition-colors hover:bg-[#c06848]"
+                  aria-label={`See ${project.name} project`}
+                >
+                  See project
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                </a>
+              ) : (
+                <Link
+                  href="/projects"
+                  className="inline-flex items-center gap-1.5 rounded-full bg-[#d97757] px-5 py-2.5 text-sm font-semibold text-[#faf9f5] transition-colors hover:bg-[#c06848]"
+                >
+                  See project →
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      </motion.div>
+    </section>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -44,6 +44,7 @@ export const NAV_LINKS: ReadonlyArray<NavLink> = [
     label: "Community",
     href: "/community",
     children: [
+      { label: "Team", href: "/team", description: "Organisers, ambassadors, and contributors." },
       { label: "Projects", href: "/projects", description: "What members are shipping with Claude." },
       { label: "Community Hub", href: "/community", description: "MCPs, prompts, workflows shared by the community." },
     ],
@@ -83,6 +84,7 @@ export const FOOTER_SECTIONS = [
     title: "Community",
     links: [
       { label: "About Us", href: "/about" },
+      { label: "Team", href: "/team" },
       { label: "Join", href: "/join" },
       { label: "Discord", href: SOCIAL_LINKS.discord },
       { label: "WhatsApp", href: SOCIAL_LINKS.whatsapp },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -12,14 +12,42 @@ export const SITE_CONFIG = {
 } as const;
 
 // ─── Navigation Links ───
-export const NAV_LINKS = [
+export interface NavLink {
+  label: string;
+  href: string;
+  description?: string;
+  children?: ReadonlyArray<NavLink>;
+}
+
+export const NAV_LINKS: ReadonlyArray<NavLink> = [
   { label: "Home", href: "/" },
   { label: "About", href: "/about" },
-  { label: "Events", href: "/events" },
-  { label: "Resources", href: "/resources" },
-  { label: "Projects", href: "/projects" },
-  { label: "Community", href: "/community" },
-  { label: "Blog", href: "/blog" },
+  {
+    label: "Events",
+    href: "/events",
+    children: [
+      { label: "All Events", href: "/events", description: "Upcoming meetups, workshops, and past recaps." },
+      { label: "Gallery", href: "/gallery", description: "Photos from every meetup we've hosted." },
+    ],
+  },
+  {
+    label: "Learn",
+    href: "/resources",
+    children: [
+      { label: "Resources", href: "/resources", description: "Guides for Claude Code, the API, and production." },
+      { label: "Blog", href: "/blog", description: "Posts from the community and organizers." },
+      { label: "Newsletter", href: "/newsletter", description: "Past digests + subscribe." },
+      { label: "FAQ", href: "/faq", description: "Common questions about CCK." },
+    ],
+  },
+  {
+    label: "Community",
+    href: "/community",
+    children: [
+      { label: "Projects", href: "/projects", description: "What members are shipping with Claude." },
+      { label: "Community Hub", href: "/community", description: "MCPs, prompts, workflows shared by the community." },
+    ],
+  },
 ] as const;
 
 // ─── Social Links ───
@@ -43,8 +71,10 @@ export const FOOTER_SECTIONS = [
     links: [
       { label: "Home", href: "/" },
       { label: "Events", href: "/events" },
+      { label: "Gallery", href: "/gallery" },
       { label: "Projects", href: "/projects" },
       { label: "Blog", href: "/blog" },
+      { label: "Newsletter", href: "/newsletter" },
       { label: "FAQ", href: "/faq" },
       { label: "Merch", href: "/merch" },
     ],

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -55,6 +55,7 @@ function mapPrismaEvent(e: PrismaEvent): Event {
     partnerOrg: e.partnerOrg ? decodeHtmlEntities(e.partnerOrg) : undefined,
     highlights: ((e.highlights as string[]) ?? undefined)?.map(decodeHtmlEntities),
     attendeeCount: e.attendeeCount ?? undefined,
+    capacity: e.capacity ?? undefined,
     posterUrl: e.posterUrl ?? undefined,
     photosUrl: e.photosUrl ?? undefined,
     recordingUrl: e.recordingUrl ?? undefined,
@@ -188,28 +189,38 @@ function mapPrismaProject(p: PrismaProject): ProjectView {
 // ─── Team Member Types ──────────────────────────────────────────────────────
 
 export interface TeamMemberView {
+  slug?: string
   name: string
   role: string
+  tagline?: string
+  location?: string
   bio: string
+  longBio?: string
   linkedIn?: string
   github?: string
   twitter?: string
   website?: string
   avatar?: string
   active: boolean
+  featured: boolean
 }
 
 function mapPrismaTeamMember(t: PrismaTeamMember): TeamMemberView {
   return {
+    slug: t.slug ?? undefined,
     name: t.name,
     role: t.role,
+    tagline: t.tagline ?? undefined,
+    location: t.location ?? undefined,
     bio: t.bio,
+    longBio: t.longBio ?? undefined,
     linkedIn: t.linkedIn ?? undefined,
     github: t.github ?? undefined,
     twitter: t.twitter ?? undefined,
     website: t.website ?? undefined,
     avatar: t.avatar ?? undefined,
     active: t.active,
+    featured: t.featured,
   }
 }
 
@@ -379,9 +390,33 @@ export async function getEventsWithPhotos(): Promise<
 export async function getTeamMembers(): Promise<TeamMemberView[]> {
   const rows = await prisma.teamMember.findMany({
     where: { active: true },
-    orderBy: { order: "asc" },
+    orderBy: [{ featured: "desc" }, { order: "asc" }, { name: "asc" }],
   })
   return rows.map(mapPrismaTeamMember)
+}
+
+/**
+ * Fetch a single active team member by slug for the /team/[slug] page.
+ * Returns null if the slug is unknown or the member is inactive.
+ */
+export async function getTeamMemberBySlug(
+  slug: string,
+): Promise<TeamMemberView | null> {
+  const row = await prisma.teamMember.findFirst({
+    where: { slug, active: true },
+  })
+  return row ? mapPrismaTeamMember(row) : null
+}
+
+/**
+ * All active slugs — used by /team/[slug] generateStaticParams + sitemap.
+ */
+export async function getTeamMemberSlugs(): Promise<string[]> {
+  const rows = await prisma.teamMember.findMany({
+    where: { active: true, slug: { not: null } },
+    select: { slug: true },
+  })
+  return rows.map((r) => r.slug!).filter(Boolean)
 }
 
 export async function getDashboardStats() {

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -14,6 +14,7 @@ import type {
   DemoRequest as PrismaDemoRequest,
   CommunitySubmission as PrismaCommunitySubmission,
   CommunityComment as PrismaCommunityComment,
+  NewsletterIssue as PrismaNewsletterIssue,
 } from "@/generated/prisma/client"
 
 // ─── Event Mappers ──────────────────────────────────────────────────────────
@@ -157,6 +158,7 @@ function mapPrismaBlog(p: PrismaBlogPost): BlogPostView {
 // ─── Project Types ──────────────────────────────────────────────────────────
 
 export interface ProjectView {
+  id: string
   name: string
   builder: string
   description: string
@@ -165,10 +167,12 @@ export interface ProjectView {
   demoUrl?: string
   repoUrl?: string
   featured: boolean
+  potwAt?: string
 }
 
 function mapPrismaProject(p: PrismaProject): ProjectView {
   return {
+    id: p.id,
     name: p.name,
     builder: p.builder,
     description: p.description,
@@ -177,6 +181,7 @@ function mapPrismaProject(p: PrismaProject): ProjectView {
     demoUrl: p.demoUrl ?? undefined,
     repoUrl: p.repoUrl ?? undefined,
     featured: p.featured,
+    potwAt: p.potwAt?.toISOString() ?? undefined,
   }
 }
 
@@ -258,6 +263,117 @@ export async function getFeaturedProjects(): Promise<ProjectView[]> {
     orderBy: { createdAt: "desc" },
   })
   return rows.map(mapPrismaProject)
+}
+
+/**
+ * Returns the most recent Project of the Week, or null if none has been set.
+ * The current POTW is whichever project has the latest non-null `potwAt` date.
+ */
+export async function getProjectOfTheWeek(): Promise<ProjectView | null> {
+  const row = await prisma.project.findFirst({
+    where: { potwAt: { not: null } },
+    orderBy: { potwAt: "desc" },
+  })
+  return row ? mapPrismaProject(row) : null
+}
+
+// ─── Gallery ────────────────────────────────────────────────────────────────
+
+export interface PhotoView {
+  id: string
+  url: string
+  thumbnailUrl: string | null
+  alt: string | null
+  caption: string | null
+  photographer: string | null
+  featured: boolean
+  takenAt: Date | null
+  event: { slug: string; title: string; date: Date; city: string } | null
+}
+
+interface GetGalleryOptions {
+  limit?: number
+  eventSlug?: string
+  featuredOnly?: boolean
+}
+
+/**
+ * Fetches photos for the gallery aggregator.
+ * Optionally filters by event slug or featured-only.
+ */
+export async function getGalleryPhotos(
+  options: GetGalleryOptions = {},
+): Promise<PhotoView[]> {
+  const { limit, eventSlug, featuredOnly } = options
+  const rows = await prisma.meetupPhoto.findMany({
+    where: {
+      ...(eventSlug ? { event: { slug: eventSlug } } : {}),
+      ...(featuredOnly ? { featured: true } : {}),
+    },
+    include: {
+      event: {
+        select: { slug: true, title: true, date: true, city: true },
+      },
+    },
+    orderBy: [{ featured: "desc" }, { order: "asc" }, { takenAt: "desc" }, { createdAt: "desc" }],
+    ...(limit ? { take: limit } : {}),
+  })
+
+  return rows.map((p) => ({
+    id: p.id,
+    url: p.url,
+    thumbnailUrl: p.thumbnailUrl,
+    alt: p.alt,
+    caption: p.caption,
+    photographer: p.photographer,
+    featured: p.featured,
+    takenAt: p.takenAt,
+    event: p.event
+      ? {
+          slug: p.event.slug,
+          title: p.event.title,
+          date: p.event.date,
+          city: p.event.city,
+        }
+      : null,
+  }))
+}
+
+/**
+ * Fetches all photos for a single event, ordered for the album view.
+ */
+export async function getEventPhotos(slug: string): Promise<PhotoView[]> {
+  return getGalleryPhotos({ eventSlug: slug })
+}
+
+/**
+ * Returns the list of events that currently have photos, so the gallery
+ * page can render filter chips without an extra round-trip.
+ */
+export async function getEventsWithPhotos(): Promise<
+  Array<{ slug: string; title: string; date: Date; city: string; count: number }>
+> {
+  const groups = await prisma.meetupPhoto.groupBy({
+    by: ["eventId"],
+    _count: { _all: true },
+    where: { eventId: { not: null } },
+  })
+  if (groups.length === 0) return []
+  const eventIds = groups.map((g) => g.eventId!).filter(Boolean)
+  const events = await prisma.event.findMany({
+    where: { id: { in: eventIds } },
+    select: { id: true, slug: true, title: true, date: true, city: true },
+  })
+  const countByEvent = new Map(groups.map((g) => [g.eventId!, g._count._all]))
+  return events
+    .map((e) => ({
+      slug: e.slug,
+      title: e.title,
+      date: e.date,
+      city: e.city,
+      count: countByEvent.get(e.id) ?? 0,
+    }))
+    .sort((a, b) => b.date.getTime() - a.date.getTime())
 }
 
 export async function getTeamMembers(): Promise<TeamMemberView[]> {
@@ -397,4 +513,52 @@ export async function getCommunityCommentsBySlug(
     orderBy: { createdAt: "asc" },
   })
   return comments.map(mapPrismaCommunityComment)
+}
+
+// ─── Newsletter Issues ─────────────────────────────────────────────────────
+
+export interface NewsletterIssueView {
+  id: string
+  slug: string
+  number: number
+  title: string
+  subject: string
+  excerpt: string
+  body: string
+  publishedAt: string
+}
+
+function mapPrismaNewsletterIssue(n: PrismaNewsletterIssue): NewsletterIssueView {
+  return {
+    id: n.id,
+    slug: n.slug,
+    number: n.number,
+    title: decodeHtmlEntities(n.title),
+    subject: decodeHtmlEntities(n.subject),
+    excerpt: decodeHtmlEntities(n.excerpt),
+    body: decodeHtmlEntities(n.body),
+    publishedAt: n.publishedAt.toISOString(),
+  }
+}
+
+/**
+ * Returns all published newsletter issues, newest first.
+ */
+export async function getNewsletterIssues(): Promise<NewsletterIssueView[]> {
+  const rows = await prisma.newsletterIssue.findMany({
+    where: { status: "PUBLISHED" },
+    orderBy: { publishedAt: "desc" },
+  })
+  return rows.map(mapPrismaNewsletterIssue)
+}
+
+/**
+ * Returns a single published newsletter issue by slug.
+ */
+export async function getNewsletterIssueBySlug(
+  slug: string
+): Promise<NewsletterIssueView | null> {
+  const row = await prisma.newsletterIssue.findUnique({ where: { slug } })
+  if (!row || row.status !== "PUBLISHED") return null
+  return mapPrismaNewsletterIssue(row)
 }

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -19,6 +19,7 @@ export type AdminResource =
   | "settings"
   | "community"
   | "team"
+  | "photos"
 
 export type Action = "view" | "create" | "edit" | "delete" | "approve"
 
@@ -41,6 +42,7 @@ const rolePermissions: Record<
     settings: ["view", "edit"],
     community: ["view", "create", "edit", "delete", "approve"],
     team: ["view", "create", "edit", "delete"],
+    photos: ["view", "create", "edit", "delete"],
   },
   ADMIN: {
     dashboard: ["view"],
@@ -57,6 +59,7 @@ const rolePermissions: Record<
     settings: [],
     community: ["view", "edit", "approve"],
     team: ["view", "edit"],
+    photos: ["view", "create", "edit", "delete"],
   },
   MODERATOR: {
     dashboard: ["view"],
@@ -73,6 +76,7 @@ const rolePermissions: Record<
     settings: [],
     community: ["view", "approve"],
     team: ["view"],
+    photos: ["view"],
   },
   MEMBER: {
     // "dashboard" here means the admin dashboard. MEMBER must not have access —
@@ -91,6 +95,7 @@ const rolePermissions: Record<
     settings: [],
     community: ["view"],
     team: [],
+    photos: [],
   },
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -26,6 +26,8 @@ export interface Event {
   partnerOrg?: string;
   highlights?: string[];
   attendeeCount?: number;
+  /** Manual seat cap. Pairs with attendeeCount to render "X / Y seats". */
+  capacity?: number;
   posterUrl?: string;
   photosUrl?: string;
   recordingUrl?: string;


### PR DESCRIPTION
## Summary

CCK transitions from a developer-themed terminal site to a premium, lead-generating community engine. Pro skin (Fraunces + Anthropic palette) is now the default; Dev (terminal) is opt-in via the footer toggle. Ships a complete set of new community surfaces: gallery, newsletter archive, team spotlight, project of the week, photo admin, and event capacity.

## What's in this PR

### Brand & conversion
- Default skin flipped from Dev to Pro at SSR (no FOUC); Dev becomes the opt-in easter egg
- New Pro hero with inline email capture, single primary CTA, activity ticker, social proof
- Sticky mobile CTA appears 30-85% scroll, dismissible
- Pro skin variants applied to all UI primitives (Button, Card, Badge) and filter components
- Auth pages (signup/login/forgot/reset/verify) redesigned with route layouts

### Security & a11y
- CSRF_SECRET required in production (throws if missing at runtime)
- Removed credential-leaking console.logs from auth flow
- Rate limit + CSRF protection on admin password change
- Email enumeration closed on /join (duplicates return success-shaped 200)
- text-dim contrast bumped to WCAG AA; tap targets enlarged; font fallbacks tuned
- Karibu route validates messages via Zod, caches prompt context, handles skip errors

### Community surfaces
- **Gallery** (\`/gallery\`) — meetup photos with lightbox (keyboard + swipe), event photo strips on event detail pages, MeetupPhoto schema with FK to Event
- **Newsletter** (\`/newsletter\`, \`/newsletter/[slug]\`) — SSG archive + markdown render with footer re-capture; NewsletterIssue schema
- **Team spotlight** (\`/team\`, \`/team/[slug]\`) — Fraunces hero, featured-first sort, premium cards; TeamMember schema gains slug/longBio/location/tagline/featured
- **Project of the Week** — home page panel; latest non-null \`Project.potwAt\` wins
- **Dynamic OG cards** — \`next/og\` ImageResponse for events, blog posts, community items (Node runtime — Prisma needs node:path)
- **Nav declutter** — 8 flat items collapsed to 5 with Events/Learn/Community dropdowns

### Event capacity
- \`Event.capacity\` field + admin form input
- Seat progress widget on upcoming events: X / Y seats with progress bar; amber tone past 80%; \"Sold out\" / \"N left\" hint

### Admin
- \`/admin/photos\` CRUD — multi-file upload (max 10 files, 5MB each, image/*), event filter, edit/delete with Storage cleanup
- \`/admin/team\` form extended with new spotlight fields
- \`/admin/events\` form gains capacity input
- New \`photos\` RBAC resource — Admin + Super Admin get full CRUD, Moderator view-only

## Schema migrations

Two new migration files in this branch:

1. \`20260521175245_add_gallery_newsletter_potw\` — meetup_photos table, newsletter_issues table, Project.potwAt, NewsletterStatus enum
2. \`20260521191943_team_spotlight_event_capacity\` — Event.capacity, TeamMember.{slug,longBio,location,tagline,featured} + indexes

Both already applied to the live Supabase DB via session pooler (port 5432 on \`pooler.supabase.com\` — the direct \`db.*.supabase.co:5432\` host is IPv6-only and unreachable from local on free tier).

**Pre-existing migration drift:** \`migrate status\` reports two older migrations (\`add_event_recording_slides_urls\`, \`add_demo_requests_table\`) as not-applied. Their tables exist in the DB (seed writes to them) — they were applied via \`db push\` historically and never recorded. Not introduced by this PR.

## Test plan

- [ ] Vercel preview builds clean
- [ ] \`/\` renders Pro hero with email capture and trust strip
- [ ] \`/gallery\` shows seeded photos; lightbox opens, keyboard nav works, Esc closes
- [ ] \`/team\` lists Peter with featured badge; \`/team/peter-kibet\` renders bio + socials
- [ ] \`/newsletter\` shows empty state copy; subscribe form posts to /api/newsletter
- [ ] Nav dropdowns open on hover and Esc closes; mobile menu renders nested children
- [ ] Event detail page shows seat progress widget when both \`attendeeCount\` and \`capacity\` are set on an upcoming event
- [ ] \`/admin/photos\` listing renders with seeded photos; upload form accepts multiple files; edit + delete work
- [ ] \`/admin/team/[id]\` edit form accepts new spotlight fields and persists
- [ ] Dynamic OG cards render at \`/events/[slug]/opengraph-image\`, \`/blog/[slug]/opengraph-image\`, \`/community/[slug]/opengraph-image\`
- [ ] Skin toggle in footer flips Pro ↔ Dev cleanly; choice persists across reloads

@Spidey-Acer