### PR TITLE
🔒 hotfix: stop /admin data leak — enforce auth in proxy

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -7,26 +7,49 @@ const { auth } = NextAuth(authConfig)
 
 const VISITOR_COOKIE = "cck-visitor"
 const ONE_YEAR_SECONDS = 60 * 60 * 24 * 365
+const ADMIN_ROLES = new Set(["SUPER_ADMIN", "ADMIN", "MODERATOR"])
 
 /**
  * Unified Next.js proxy (middleware).
  *
  * Responsibilities:
- *  1. **Admin/dashboard protection** — delegates to NextAuth's `auth()` wrapper,
- *     which calls `authConfig.callbacks.authorized`. Unauthenticated requests to
- *     `/admin` (non-login) are redirected to `/login` automatically by NextAuth v5.
- *  2. **Visitor cookie** — sets a `cck-visitor` UUID cookie on the first visit so
- *     the Karibu onboarding flow can link anonymous sessions across page loads
- *     before the user signs up. The cookie is httpOnly, SameSite=lax, 1-year TTL.
- *
- * The matcher intentionally excludes Next.js internals, static assets, and the
- * NextAuth API routes so those requests pass through unconditionally.
- *
- * @param req - The incoming NextAuth-augmented request (includes `req.auth` session).
- * @returns A NextResponse, either a redirect (from NextAuth) or NextResponse.next()
- *          with the visitor cookie set when it was absent.
+ *  1. **Admin protection** — unauthenticated or non-admin requests to /admin/*
+ *     (except /admin/login) are redirected to /admin/login. The redirect is
+ *     issued from the proxy callback directly rather than via the authorized
+ *     callback — relying on authorized alone proved unreliable in production
+ *     (the wrapper let unauthenticated requests fall through with 200).
+ *  2. **Dashboard protection** — unauthenticated /dashboard/* requests are
+ *     redirected to /login with a callbackUrl so the user lands back.
+ *  3. **Visitor cookie** — sets a `cck-visitor` UUID cookie on the first visit
+ *     so the Karibu onboarding flow can link anonymous sessions across page
+ *     loads before the user signs up. httpOnly, SameSite=lax, 1-year TTL.
  */
 export const proxy = auth((req) => {
+  const { nextUrl } = req
+  const pathname = nextUrl.pathname
+  const session = req.auth
+
+  // Admin gate — block at the network edge so the admin page's server code
+  // never executes for unauthenticated visitors.
+  const isOnAdmin = pathname.startsWith("/admin")
+  const isOnAdminLogin = pathname === "/admin/login"
+  if (isOnAdmin && !isOnAdminLogin) {
+    const role = (session?.user as { role?: string } | undefined)?.role
+    if (!session?.user || !role || !ADMIN_ROLES.has(role)) {
+      return NextResponse.redirect(new URL("/admin/login", nextUrl))
+    }
+  }
+
+  // Dashboard gate — any signed-in user is allowed.
+  if (pathname.startsWith("/dashboard")) {
+    if (!session?.user) {
+      const loginUrl = new URL("/login", nextUrl)
+      loginUrl.searchParams.set("callbackUrl", pathname)
+      return NextResponse.redirect(loginUrl)
+    }
+  }
+
+  // Visitor cookie — seed for anonymous Karibu attribution.
   const res = NextResponse.next()
   if (!req.cookies.get(VISITOR_COOKIE)) {
     res.cookies.set(VISITOR_COOKIE, randomUUID(), {


### PR DESCRIPTION
## ⚠️ Critical: production /admin/* was serving data unauthenticated

Anyone could GET https://www.claudekenya.org/admin/applications without cookies and receive a 200 with full HTML containing **30 real applicant emails** plus names, topics, and statuses. Same for /admin/speakers (PII confirmed in earlier screenshot) and presumably every other /admin/*/page.tsx that does a server-side Prisma query.

## Root cause

\`src/proxy.ts\` wrapped its visitor-cookie logic in NextAuth v5's \`auth()\` middleware wrapper and trusted the \`authorized\` callback in \`auth.config.ts\` to redirect on false. The callback's logic was correct (\`if (isOnAdmin && !isOnAdminLogin && !isLoggedIn) return false\`), but **the wrapper never issued the redirect** — Vercel edge-middleware logs show 200 on every unauthenticated /admin/* request. With the proxy not blocking, the admin layout's \`if (!session?.user) return <AdminProviders>{children}</AdminProviders>\` branch (designed only for /admin/login to render without a sidebar) ran for every admin page, allowing the page component's Prisma fetch to execute and ship results to anonymous visitors.

## Fix

Issue the redirect explicitly from the proxy callback using \`req.auth\` instead of depending on the authorized callback to short-circuit:

- \`/admin/*\` (non-login) without an admin-tier session → 307 to \`/admin/login\`
- \`/dashboard/*\` without any session → 307 to \`/login?callbackUrl=…\`
- Visitor cookie behaviour unchanged on every other path

## Verified locally

\`\`\`
GET /admin/speakers     → 307 /admin/login
GET /dashboard          → 307 /login?callbackUrl=/dashboard
GET /                   → 200, sets cck-visitor cookie
\`\`\`

## Follow-up (separate PR)

Defense-in-depth: add an inline \`await auth()\` guard with redirect at the top of every \`src/app/admin/*/page.tsx\` so the proxy isn't the single point of failure. The admin layout itself should also redirect (not just render children) when there's no session and the path isn't /admin/login.

## Test plan

- [ ] Vercel preview deploys clean
- [ ] After merge, \`curl https://www.claudekenya.org/admin/applications\` returns 307, not 200
- [ ] Signed-in admin can still reach /admin/* (no regression)
- [ ] Public pages still set \`cck-visitor\` cookie
- [ ] Member dashboard still requires sign-in

Recommend an immediate merge given the PII exposure window.

@Spidey-Acer