### PR TITLE
Karibu redesign — warm-light identity (9 routes)

### DIFF
--- a/docs/superpowers/specs/2026-07-05-home-karibu-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-05-home-karibu-redesign-design.md
@@ -1,0 +1,120 @@
+# Home Redesign — "Karibu" Warm-Light Identity
+
+**Date:** 2026-07-05
+**Branch:** `redesign/design-overhaul`
+**Scope:** Home page (`/`) only. First page of a page-by-page site overhaul.
+**Source design:** `index.dc.html` from the Claude.ai design project "Claude Community Kenya Revamp" (imported via DesignSync MCP).
+
+## Goal
+
+Replace the home page's Terminal Noir presentation with a warm, welcoming
+"clay & paper" identity (the Anthropic light aesthetic), while preserving all
+existing dynamic behaviour. This is the first step toward a single site-wide
+identity; the Dev/Pro persona toggle is retired incrementally, not in one pass.
+
+## Decisions (approved)
+
+1. **Single identity, reached page-by-page.** The warm-light look becomes the
+   site's identity. We do NOT maintain two skins per page (dual-skin degrades
+   dev velocity, consistency, and the "cruising" experience during migration).
+   The persona system (39 files) is left **dormant** — provider stays mounted,
+   converted pages simply don't consume it — and is deleted in a final cleanup
+   PR once every page is migrated.
+2. **Keep all dynamic wiring.** Real DB events, live community stats, Karibu
+   personalization, recommendations remain. The mockup's hardcoded content is
+   the *layout*; real data fills it. No feature loss.
+3. **Real data only — no inflation.** Member counts + active cities come from
+   `siteSettings` (DB). We show what the DB backs (Nairobi + Mombasa today) —
+   not the mockup's "~2,500 members / 3 cities incl. Kisumu".
+4. **Real testimonials.** The mockup's fabricated "Brian Ochieng" quote is
+   replaced with a carousel of 5 real community members (see below). Exact
+   wording + name spellings require Peter's sign-off before merge.
+
+## Design system (this palette is genuinely new)
+
+The existing `persona-pro` theme is warm-**dark** (`#141413`). The new identity
+is warm-**light**. New tokens are **additive** — no existing page references
+them, so nothing else changes.
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `--color-paper` | `#F4EEE3` | page background |
+| `--color-paper-card` | `#FBF7F0` | cards |
+| `--color-paper-alt` | `#EFE7D8` | alt/trust bands |
+| `--color-ink` | `#23201B` | primary text / dark sections |
+| `--color-ink-soft` | `#5C5349` | body text |
+| `--color-ink-muted` | `#6A6155` | meta text |
+| `--color-clay` | `#C15F3C` | primary accent |
+| `--color-clay-dark` | `#A84E2D` | hover |
+| `--color-clay-light` | `#E6906F` | on-dark accent |
+| `--color-sand` | `#E4DAC8` | borders |
+| `--color-sand-2` | `#DDD3C2` | stronger borders |
+
+**Fonts:** `Newsreader` (serif display) + `Inter` (body) via `next/font/google`
+(self-hosted, no CDN). Exposed as `--font-newsreader` / `--font-inter`.
+
+**Scoping:** the new palette lives on the converted page's own wrapper, which
+paints a full-viewport `--color-paper` background over the dark `<body>`. The
+root `<html class="dark persona-pro">` is untouched so every un-migrated page
+keeps working.
+
+## Components (new, isolated)
+
+- `KaribuNav` — sticky nav, animated ✳ mark, flat links → real routes
+  (`/#what`, `/events`, `/resources`, `/community`, `/about`), WhatsApp CTA,
+  mobile hamburger.
+- `Marquee` — scrolling clay band; stats sourced from real `communityStats`.
+- `KaribuFooter` — dark footer, real links from `constants.ts`.
+- `KaribuHome` — client component composing the 8 sections; receives the same
+  props the current home fetches (events, stats, audience, recommendables).
+- `KaribuTestimonials` — reskinned carousel with the 5 real members.
+
+`ConditionalLayout` gains a route check: converted routes (`/`) render
+`KaribuNav`/`KaribuFooter`; all others keep `Navbar`/`Footer`. Providers
+(`SkinProvider`, `AudienceProvider`, `SessionProvider`) stay mounted for both.
+
+## Section → data map
+
+1. **Hero** — static headline/subcopy; badge = next real event (title +
+   attendee count).
+2. **Trust bar** — real member total, active cities, "100% free", "Anthropic-
+   supported".
+3. **What we do** — 4-pillar bento (static copy).
+4. **Two tracks** — Software engineers / Builders (static; links to
+   `/events`, `/join`).
+5. **Upcoming events** — top 3 real `upcomingEvents`, real city/type/date.
+6. **Community in action** — `KaribuTestimonials` (5 real members).
+7. **How to join** — dark card, 3 steps, WhatsApp + Discord CTAs.
+8. **Footer** — `KaribuFooter`.
+
+Karibu personalization (`MadeForYou`) is preserved, restyled to the light
+palette, placed after the trust bar.
+
+## Testimonials (real — pending spelling/wording sign-off)
+
+Drafted faithfully from Peter's dictation; **confirm before merge**:
+
+1. **Billy Mwangi** — CCK sessions helped him scale & level up work at his
+   company. *(confirm surname; clarify "scale ___ in his company")*
+2. **Samuel** *(surname?)* — Claude transformed his client work.
+3. **Peter Kibet** — founder.
+4. **James Lloyd** — Claude eased his research work.
+5. **Isaac Toili** *(spelling?)* — teacher from **Tuigoin** *(spelling?)*
+   village; Claude helps with lesson plans, planning, classroom management.
+
+## Motion
+
+Framer Motion (existing dep): staggered reveal-on-scroll, marquee, image wipe.
+All gated behind `useReducedMotion` / `prefers-reduced-motion`.
+
+## Out of scope (deferred)
+
+- Events, Learn, Community, About, Join pages (`*.dc.html` mockups exist).
+- Final deletion of the persona system.
+- Any change to admin/dashboard routes.
+
+## Verification gate
+
+`npm run build && npx tsc --noEmit` must pass clean before commit. Manual
+smoke: home renders on paper bg, other pages still render Terminal Noir chrome,
+no dark-bg bleed, mobile nav works, reduced-motion honoured.

--- a/src/app/admin/login/AdminLoginForm.tsx
+++ b/src/app/admin/login/AdminLoginForm.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import { useState, useTransition } from "react"
+import { signIn, signOut, useSession } from "next-auth/react"
+import { useRouter } from "next/navigation"
+import { Terminal, Lock, Mail, AlertTriangle, Loader2 } from "lucide-react"
+
+const ADMIN_ROLES = new Set(["SUPER_ADMIN", "ADMIN", "MODERATOR"])
+
+/**
+ * Admin sign-in form. Server-side parent (`page.tsx`) already redirected
+ * authenticated admins to /admin before we get here, so this component
+ * only needs to handle:
+ *   1. Submitting credentials and routing to /admin on success.
+ *   2. The "you're signed in but not an admin" recovery state — show a
+ *      sign-out button instead of the submit, so the user can swap accounts
+ *      without bouncing through the layout's access-denied screen.
+ */
+export function AdminLoginForm() {
+  const router = useRouter()
+  const { data: session, status } = useSession()
+  const [isPending, startTransition] = useTransition()
+  const [error, setError] = useState<string | null>(null)
+
+  const sessionRole = (session?.user as { role?: string } | undefined)?.role
+  const signedInNonAdmin =
+    status === "authenticated" && (!sessionRole || !ADMIN_ROLES.has(sessionRole))
+
+  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    setError(null)
+    const form = new FormData(e.currentTarget)
+    const email = form.get("email") as string
+    const password = form.get("password") as string
+
+    startTransition(async () => {
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      })
+      if (result?.error) {
+        setError("Invalid email or password.")
+        return
+      }
+      // Full reload so the server-rendered layout picks up the new session
+      // cookie and re-evaluates the admin-redirect in page.tsx.
+      window.location.assign("/admin")
+    })
+  }
+
+  return (
+    <div className="min-h-screen bg-bg-primary flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 opacity-[0.03]"
+        style={{
+          backgroundImage: "linear-gradient(#00ff41 1px, transparent 1px), linear-gradient(90deg, #00ff41 1px, transparent 1px)",
+          backgroundSize: "40px 40px",
+        }}
+      />
+
+      <div className="relative w-full max-w-sm">
+        <div className="mb-8 text-center">
+          <div className="inline-flex items-center gap-3 mb-3">
+            <div className="w-10 h-10 rounded bg-green-primary/10 border border-green-primary/30 flex items-center justify-center">
+              <Terminal className="w-5 h-5 text-green-primary" />
+            </div>
+            <div className="text-left">
+              <div className="text-sm font-mono font-bold text-green-primary">CCK Admin</div>
+              <div className="text-[11px] font-mono text-text-dim">claude community kenya</div>
+            </div>
+          </div>
+          <p className="text-xs font-mono text-text-dim">Authorized personnel only</p>
+        </div>
+
+        <div className="bg-bg-secondary border border-border-default rounded-lg p-6">
+          <div className="mb-5">
+            <div className="flex items-center gap-2 mb-1">
+              <Lock className="w-4 h-4 text-green-primary" />
+              <h1 className="text-sm font-mono font-semibold text-text-primary">Sign In</h1>
+            </div>
+            <p className="text-xs font-mono text-text-dim pl-6">Enter your admin credentials</p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="login-email" className="block text-[11px] font-mono text-text-dim mb-1.5">
+                <Mail className="w-3 h-3 inline mr-1.5" />
+                Email Address
+              </label>
+              <input
+                id="login-email"
+                name="email"
+                type="email"
+                required
+                autoComplete="email"
+                className="w-full bg-bg-card border border-border-default rounded px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:outline-none focus:border-green-primary/50 focus:ring-1 focus:ring-green-primary/20 transition-colors"
+                placeholder="admin@claudekenya.org"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="login-password" className="block text-[11px] font-mono text-text-dim mb-1.5">
+                <Lock className="w-3 h-3 inline mr-1.5" />
+                Password
+              </label>
+              <input
+                id="login-password"
+                name="password"
+                type="password"
+                required
+                autoComplete="current-password"
+                className="w-full bg-bg-card border border-border-default rounded px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:outline-none focus:border-green-primary/50 focus:ring-1 focus:ring-green-primary/20 transition-colors"
+                placeholder="••••••••"
+              />
+            </div>
+
+            {signedInNonAdmin && (
+              <div className="flex items-start gap-2 p-3 bg-red/10 border border-red/30 rounded text-[11px] font-mono text-red">
+                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-px" />
+                <span className="flex-1">
+                  This account doesn&apos;t have admin access. Sign out and sign in
+                  with an admin account.
+                </span>
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-start gap-2 p-3 bg-red/10 border border-red/30 rounded text-[11px] font-mono text-red">
+                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-px" />
+                <span className="flex-1">{error}</span>
+              </div>
+            )}
+
+            {signedInNonAdmin ? (
+              <button
+                type="button"
+                onClick={() => signOut({ callbackUrl: "/admin/login" })}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-bg-card hover:bg-bg-elevated border border-border-default hover:border-border-hover rounded text-sm font-mono font-semibold text-text-primary transition-all"
+              >
+                Sign out
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={isPending}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-green-primary/10 hover:bg-green-primary/20 border border-green-primary/40 hover:border-green-primary/60 rounded text-sm font-mono font-semibold text-green-primary transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {isPending ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Authenticating...
+                  </>
+                ) : (
+                  "Sign In"
+                )}
+              </button>
+            )}
+          </form>
+        </div>
+
+        <p className="mt-4 text-center text-[10px] font-mono text-text-dim">
+          Claude Community Kenya — Admin Dashboard
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,162 +1,20 @@
-"use client"
-
-import { useState, useTransition, useEffect } from "react"
-import { signIn, signOut, useSession } from "next-auth/react"
-import { useRouter } from "next/navigation"
-import { Terminal, Lock, Mail, AlertTriangle, Loader2 } from "lucide-react"
+import { redirect } from "next/navigation"
+import { auth } from "@/auth"
+import { AdminLoginForm } from "./AdminLoginForm"
 
 const ADMIN_ROLES = new Set(["SUPER_ADMIN", "ADMIN", "MODERATOR"])
 
-export default function AdminLoginPage() {
-  const router = useRouter()
-  const { data: session, status } = useSession()
-  const [isPending, startTransition] = useTransition()
-  const [error, setError] = useState<string | null>(null)
-
-  // If already signed in: redirect to /admin only when the role is admin-capable.
-  // For non-admin roles, stay on the login page and show an inline error so the
-  // user can sign out — bouncing them to /admin (or vice versa) would create a
-  // redirect loop with admin/layout.tsx.
-  useEffect(() => {
-    if (status !== "authenticated") return
-    const role = (session?.user as { role?: string } | undefined)?.role
-    if (role && ADMIN_ROLES.has(role)) {
-      router.replace("/admin")
-    } else {
-      setError("This account doesn't have admin access. Sign out and sign in with an admin account.")
-    }
-  }, [status, session, router])
-
-  function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    setError(null)
-    const form = new FormData(e.currentTarget)
-    const email = form.get("email") as string
-    const password = form.get("password") as string
-
-    startTransition(async () => {
-      const result = await signIn("credentials", {
-        email,
-        password,
-        redirect: false,
-      })
-      if (result?.error) {
-        setError("Invalid email or password.")
-      } else {
-        // Full page navigation so the server-side admin layout
-        // re-renders with the new session (renders sidebar)
-        window.location.href = "/admin"
-      }
-    })
+/**
+ * Admin login page — server-rendered so authenticated admins are sent
+ * straight to /admin without a client-side redirect race. The client form
+ * still handles the credentials submit and the "signed in but not an admin"
+ * recovery state.
+ */
+export default async function AdminLoginPage() {
+  const session = await auth()
+  const role = (session?.user as { role?: string } | undefined)?.role
+  if (session?.user && role && ADMIN_ROLES.has(role)) {
+    redirect("/admin")
   }
-
-  return (
-    <div className="min-h-screen bg-bg-primary flex items-center justify-center p-4">
-      {/* Grid background */}
-      <div
-        className="absolute inset-0 opacity-[0.03]"
-        style={{
-          backgroundImage: "linear-gradient(#00ff41 1px, transparent 1px), linear-gradient(90deg, #00ff41 1px, transparent 1px)",
-          backgroundSize: "40px 40px",
-        }}
-      />
-
-      <div className="relative w-full max-w-sm">
-        {/* Logo */}
-        <div className="mb-8 text-center">
-          <div className="inline-flex items-center gap-3 mb-3">
-            <div className="w-10 h-10 rounded bg-green-primary/10 border border-green-primary/30 flex items-center justify-center">
-              <Terminal className="w-5 h-5 text-green-primary" />
-            </div>
-            <div className="text-left">
-              <div className="text-sm font-mono font-bold text-green-primary">CCK Admin</div>
-              <div className="text-[11px] font-mono text-text-dim">claude community kenya</div>
-            </div>
-          </div>
-          <p className="text-xs font-mono text-text-dim">Authorized personnel only</p>
-        </div>
-
-        {/* Card */}
-        <div className="bg-bg-secondary border border-border-default rounded-lg p-6">
-          <div className="mb-5">
-            <div className="flex items-center gap-2 mb-1">
-              <Lock className="w-4 h-4 text-green-primary" />
-              <h1 className="text-sm font-mono font-semibold text-text-primary">Sign In</h1>
-            </div>
-            <p className="text-xs font-mono text-text-dim pl-6">Enter your admin credentials</p>
-          </div>
-
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label htmlFor="login-email" className="block text-[11px] font-mono text-text-dim mb-1.5">
-                <Mail className="w-3 h-3 inline mr-1.5" />
-                Email Address
-              </label>
-              <input
-                id="login-email"
-                name="email"
-                type="email"
-                required
-                autoComplete="email"
-                className="w-full bg-bg-card border border-border-default rounded px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:outline-none focus:border-green-primary/50 focus:ring-1 focus:ring-green-primary/20 transition-colors"
-                placeholder="admin@claudekenya.org"
-              />
-            </div>
-
-            <div>
-              <label htmlFor="login-password" className="block text-[11px] font-mono text-text-dim mb-1.5">
-                <Lock className="w-3 h-3 inline mr-1.5" />
-                Password
-              </label>
-              <input
-                id="login-password"
-                name="password"
-                type="password"
-                required
-                autoComplete="current-password"
-                className="w-full bg-bg-card border border-border-default rounded px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:outline-none focus:border-green-primary/50 focus:ring-1 focus:ring-green-primary/20 transition-colors"
-                placeholder="••••••••"
-              />
-            </div>
-
-            {error && (
-              <div className="flex items-start gap-2 p-3 bg-red/10 border border-red/30 rounded text-[11px] font-mono text-red">
-                <AlertTriangle className="w-3.5 h-3.5 flex-shrink-0 mt-px" />
-                <span className="flex-1">{error}</span>
-              </div>
-            )}
-
-            {status === "authenticated" ? (
-              <button
-                type="button"
-                onClick={() => signOut({ callbackUrl: "/admin/login" })}
-                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-bg-card hover:bg-bg-elevated border border-border-default hover:border-border-hover rounded text-sm font-mono font-semibold text-text-primary transition-all"
-              >
-                Sign out
-              </button>
-            ) : (
-              <button
-                type="submit"
-                disabled={isPending}
-                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-green-primary/10 hover:bg-green-primary/20 border border-green-primary/40 hover:border-green-primary/60 rounded text-sm font-mono font-semibold text-green-primary transition-all disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {isPending ? (
-                  <>
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    Authenticating...
-                  </>
-                ) : (
-                  "Sign In"
-                )}
-              </button>
-            )}
-          </form>
-        </div>
-
-        <p className="mt-4 text-center text-[10px] font-mono text-text-dim">
-          Claude Community Kenya — Admin Dashboard
-        </p>
-      </div>
-    </div>
-  )
+  return <AdminLoginForm />
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,24 @@
   --text-secondary: #a0a0a0;
   --text-dim: #8a8a8a;
   --white: #ffffff;
+
+  /* ─── Karibu identity (warm-light redesign) ───
+   * Additive palette for the page-by-page overhaul. No Terminal Noir /
+   * persona-pro token references these, so existing pages are unaffected.
+   * Scoped in use to converted pages via the .karibu wrapper. */
+  --paper: #F4EEE3;
+  --paper-card: #FBF7F0;
+  --paper-alt: #EFE7D8;
+  --ink: #23201B;
+  --ink-soft: #5C5349;
+  --ink-muted: #6A6155;
+  --clay: #C15F3C;
+  --clay-dark: #A84E2D;
+  --clay-light: #E6906F;
+  --sand: #E4DAC8;
+  --sand-2: #DDD3C2;
+  --font-newsreader-stack: var(--font-newsreader), ui-serif, Georgia, serif;
+  --font-inter-stack: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 }
 
 @theme inline {
@@ -68,6 +86,23 @@
   --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
   --font-sans: var(--font-ibm-plex-sans), ui-sans-serif, system-ui, sans-serif;
   --font-serif: var(--font-display), ui-serif, Georgia, "Times New Roman", serif;
+
+  /* ─── Karibu identity tokens (warm-light redesign) ───
+   * Additive Tailwind utilities: bg-paper, text-ink, border-sand, etc.
+   * Named uniquely so no existing utility changes. */
+  --color-paper: var(--paper);
+  --color-paper-card: var(--paper-card);
+  --color-paper-alt: var(--paper-alt);
+  --color-ink: var(--ink);
+  --color-ink-soft: var(--ink-soft);
+  --color-ink-muted: var(--ink-muted);
+  --color-clay: var(--clay);
+  --color-clay-dark: var(--clay-dark);
+  --color-clay-light: var(--clay-light);
+  --color-sand: var(--sand);
+  --color-sand-2: var(--sand-2);
+  --font-newsreader: var(--font-newsreader-stack);
+  --font-inter: var(--font-inter-stack);
 }
 
 /* ─── Pro Theme (Anthropic Brand) ─── */
@@ -573,4 +608,35 @@ body::before {
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
   }
+}
+
+/* ─── Karibu identity (warm-light redesign) ─────────────────────────────
+ * Scoped base + animation loops for the page-by-page overhaul. Applied via
+ * the .karibu wrapper so it never leaks onto Terminal Noir pages. The global
+ * reduced-motion reset above already disables these loops when requested. */
+.karibu {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-inter-stack);
+  min-height: 100vh;
+}
+.karibu ::selection {
+  background: var(--clay);
+  color: var(--paper-card);
+}
+
+@keyframes karibu-marquee {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+@keyframes karibu-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+@keyframes karibu-drift {
+  from { background-position: 0 0; }
+  to { background-position: 480px 0; }
+}
+.karibu [data-marquee]:hover [data-mq-track] {
+  animation-play-state: paused;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { JetBrains_Mono, IBM_Plex_Sans, Fraunces } from "next/font/google";
+import { JetBrains_Mono, IBM_Plex_Sans, Fraunces, Newsreader, Inter } from "next/font/google";
 import { ConditionalLayout } from "@/components/layout/ConditionalLayout";
 import { GoogleAnalytics } from "@/components/GoogleAnalytics";
 import { WebVitals } from "@/components/WebVitals";
@@ -26,6 +26,23 @@ const fraunces = Fraunces({
   variable: "--font-display",
   subsets: ["latin"],
   axes: ["SOFT", "opsz"],
+  display: "swap",
+});
+
+// ─── Karibu identity (warm-light redesign) ───
+// Newsreader = display serif, Inter = body. Self-hosted via next/font (no CDN).
+const newsreader = Newsreader({
+  variable: "--font-newsreader",
+  subsets: ["latin"],
+  style: ["normal", "italic"],
+  weight: ["300", "400", "500", "600", "700"],
+  display: "swap",
+});
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "600", "700"],
   display: "swap",
 });
 
@@ -206,7 +223,7 @@ export default async function RootLayout({
         />
       </head>
       <body
-        className={`${jetbrainsMono.variable} ${ibmPlexSans.variable} ${fraunces.variable} antialiased`}
+        className={`${jetbrainsMono.variable} ${ibmPlexSans.variable} ${fraunces.variable} ${newsreader.variable} ${inter.variable} antialiased`}
       >
         <GoogleAnalytics />
         <WebVitals />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
-import type { FeedItem } from "@/components/sections/HeroTerminal";
-import { HomeContent } from "@/components/sections/HomeContent";
-import { getUpcomingEvents, getFeaturedProjects, getBlogPosts, getCommunitySubmissions, getProjectOfTheWeek } from "@/lib/data";
+import { KaribuHome } from "@/components/karibu/KaribuHome";
+import { getUpcomingEvents, getBlogPosts } from "@/lib/data";
 import { prisma } from "@/lib/prisma";
 import { ensureVisitorId, getAudienceCookie } from "@/lib/karibu/cookies";
 import type { AudienceState } from "@/contexts/AudienceContext";
@@ -32,44 +31,11 @@ export const metadata: Metadata = {
 export const revalidate = 3600;
 
 export default async function Home() {
-  const [upcomingEvents, featuredProjects, siteSettings, blogPosts, communityData, projectOfTheWeek] = await Promise.all([
+  const [upcomingEvents, siteSettings, blogPosts] = await Promise.all([
     getUpcomingEvents().catch(() => []),
-    getFeaturedProjects().catch(() => []),
     prisma.siteSettings.findUnique({ where: { id: "default" } }).catch(() => null),
     getBlogPosts().catch(() => []),
-    getCommunitySubmissions({ limit: 5, sort: "recent" }).catch(() => ({ items: [], total: 0 })),
-    getProjectOfTheWeek().catch(() => null),
   ]);
-
-  // Build activity feed for hero terminal — interleave blogs, community, projects
-  const feedItems: FeedItem[] = [];
-  for (const post of blogPosts.slice(0, 3)) {
-    feedItems.push({
-      type: "blog",
-      label: "BLOG",
-      title: post.title,
-      meta: `by ${post.author} · ${post.readingTime} min read`,
-      href: `/blog/${post.slug}`,
-    });
-  }
-  for (const item of communityData.items.slice(0, 3)) {
-    feedItems.push({
-      type: "community",
-      label: item.type,
-      title: item.title,
-      meta: item.submitterName ? `shared by ${item.submitterName}` : item.shortDescription.slice(0, 60),
-      href: `/community/${item.slug}`,
-    });
-  }
-  for (const project of featuredProjects.slice(0, 2)) {
-    feedItems.push({
-      type: "project",
-      label: "PROJECT",
-      title: project.name,
-      meta: `by ${project.builder} · ${project.stack.slice(0, 3).join(", ")}`,
-      href: "/projects",
-    });
-  }
 
   const communityStats = siteSettings
     ? {
@@ -150,14 +116,11 @@ export default async function Home() {
   ];
 
   return (
-    <HomeContent
+    <KaribuHome
       communityStats={communityStats}
-      feedItems={feedItems}
       upcomingEvents={upcomingEvents}
-      featuredProjects={featuredProjects}
       audienceState={audienceState}
       recommendables={recommendables}
-      projectOfTheWeek={projectOfTheWeek}
     />
   );
 }

--- a/src/components/karibu/KaribuFooter.tsx
+++ b/src/components/karibu/KaribuFooter.tsx
@@ -1,0 +1,120 @@
+/**
+ * KaribuFooter — dark footer for the warm-light "Karibu" identity.
+ *
+ * Rendered on converted routes only. Links resolve to real app routes and
+ * the canonical social URLs in constants.ts. Cities reflect genuinely active
+ * locations (Nairobi + Mombasa) — no inflated claims.
+ */
+
+import Link from "next/link";
+import { SOCIAL_LINKS } from "@/lib/constants";
+
+const EXPLORE = [
+  { label: "Home", href: "/" },
+  { label: "Events", href: "/events" },
+  { label: "Learn", href: "/resources" },
+  { label: "Community", href: "/community" },
+  { label: "About", href: "/about" },
+];
+
+const COMMUNITY = [
+  { label: "WhatsApp", href: SOCIAL_LINKS.whatsapp },
+  { label: "Discord", href: SOCIAL_LINKS.discord },
+  { label: "Twitter / X", href: SOCIAL_LINKS.twitter },
+  { label: "GitHub", href: SOCIAL_LINKS.github },
+];
+
+export function KaribuFooter() {
+  return (
+    <footer className="bg-ink text-[#E9E0D2]">
+      <div className="mx-auto grid max-w-[1180px] grid-cols-2 gap-8 px-6 pt-14 md:px-10 lg:grid-cols-[1.6fr_1fr_1fr_1fr]">
+        {/* Brand */}
+        <div className="col-span-2 lg:col-span-1">
+          <div className="mb-4 flex items-center gap-3">
+            <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-clay font-newsreader text-[19px] text-paper-card">
+              ✳
+            </span>
+            <span className="font-newsreader text-[19px] font-semibold text-paper">
+              Claude Community Kenya
+            </span>
+          </div>
+          <p className="mb-5 max-w-[320px] font-inter text-[14.5px] leading-relaxed text-[#A79E90]">
+            The free, founder-led community for people in Kenya learning and
+            building with Claude. Karibu.
+          </p>
+          <a
+            href={SOCIAL_LINKS.whatsapp}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full bg-clay px-[22px] py-3 font-inter text-sm font-semibold text-paper-card transition-colors hover:bg-clay-dark"
+          >
+            Join the community
+          </a>
+        </div>
+
+        <FooterColumn title="Explore">
+          {EXPLORE.map((l) => (
+            <Link key={l.href} href={l.href} className="transition-colors hover:text-paper">
+              {l.label}
+            </Link>
+          ))}
+        </FooterColumn>
+
+        <FooterColumn title="Community">
+          {COMMUNITY.map((l) => (
+            <a
+              key={l.href}
+              href={l.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-paper"
+            >
+              {l.label}
+            </a>
+          ))}
+        </FooterColumn>
+
+        <FooterColumn title="Cities">
+          <span>Nairobi</span>
+          <span>Mombasa</span>
+        </FooterColumn>
+      </div>
+
+      <div className="mx-auto max-w-[1180px] px-6 pb-9 pt-10 md:px-10">
+        <p className="mb-5 max-w-[780px] font-inter text-[12.5px] leading-relaxed text-[#8A7F6E]">
+          Independently operated. Anthropic-supported via the Community
+          Ambassador programme (event funding + API credits). Views expressed
+          here are community-held, not official Anthropic positions. &ldquo;Claude&rdquo;
+          is a trademark of Anthropic PBC.
+        </p>
+        <div className="flex flex-wrap items-center justify-between gap-4 border-t border-[#3B352D] pt-6">
+          <div className="font-inter text-[13px] text-[#8A7F6E]">
+            © 2026 Claude Community Kenya · A community, not a product.
+          </div>
+          <div className="font-inter text-[13px] text-[#8A7F6E]">
+            Built by the community, for the community.
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function FooterColumn({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-3.5 font-inter text-xs font-bold uppercase tracking-[0.14em] text-[#8A7F6E]">
+        {title}
+      </div>
+      <div className="flex flex-col gap-2 font-inter text-[14.5px] leading-[2.1] text-[#C7BEB0]">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -1,0 +1,605 @@
+"use client";
+
+/**
+ * KaribuHome — warm-light "Karibu" home page composition.
+ *
+ * First page of the page-by-page redesign. Visual language ports the approved
+ * `index.dc.html` mockup; all content is wired to real data:
+ *   • community stats + active cities from siteSettings (no inflated numbers)
+ *   • upcoming events from the DB
+ *   • Karibu personalization via the shared rank() engine
+ *
+ * The persona toggle is intentionally absent here — this route is a single
+ * identity. Motion is gated behind prefers-reduced-motion.
+ */
+
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import type { Event } from "@/lib/types";
+import type { CommunityStats } from "@/components/sections/HeroTerminal";
+import type { AudienceState } from "@/contexts/AudienceContext";
+import { rank, type Recommendable } from "@/lib/recommendations";
+import { SOCIAL_LINKS } from "@/lib/constants";
+import { Marquee } from "@/components/karibu/Marquee";
+import { KaribuTestimonials } from "@/components/karibu/KaribuTestimonials";
+
+interface KaribuHomeProps {
+  communityStats?: CommunityStats;
+  upcomingEvents: Event[];
+  audienceState: AudienceState;
+  recommendables: Recommendable[];
+}
+
+const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+const KICKER =
+  "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
+
+const TYPE_LABEL: Record<Event["type"], string> = {
+  meetup: "Meetup",
+  workshop: "Workshop",
+  "career-talk": "Career talk",
+  hackathon: "Hackathon",
+};
+
+/** Reveal-on-scroll wrapper; no-op when the visitor prefers reduced motion. */
+function Reveal({
+  children,
+  className,
+  delay = 0,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+}) {
+  const reduce = useReducedMotion();
+  return (
+    <motion.div
+      className={className}
+      initial={reduce ? false : { opacity: 0, y: 18 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
+      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1], delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+export function KaribuHome({
+  communityStats,
+  upcomingEvents,
+  audienceState,
+  recommendables,
+}: KaribuHomeProps) {
+  const cities = communityStats?.citiesActive ?? [];
+  const memberLabel = communityStats?.totalMembers
+    ? `~${communityStats.totalMembers.toLocaleString()} members`
+    : null;
+
+  const marqueeItems = [
+    memberLabel,
+    ...cities,
+    "Free & founder-led",
+    "Anthropic-supported via the Community Ambassador programme",
+    "Karibu",
+  ].filter(Boolean) as string[];
+
+  const nextEvent = upcomingEvents[0];
+
+  return (
+    <>
+      <Marquee items={marqueeItems} />
+      <Hero nextEvent={nextEvent} />
+      <TrustBar stats={communityStats} cities={cities} />
+      <MadeForYouLight audienceState={audienceState} items={recommendables} />
+      <WhatWeDo />
+      <TwoTracks />
+      <EventsSection events={upcomingEvents.slice(0, 3)} />
+      <CommunityInAction />
+      <HowToJoin />
+    </>
+  );
+}
+
+/* ─────────────────────────── Hero ─────────────────────────── */
+
+function Hero({ nextEvent }: { nextEvent?: Event }) {
+  const reduce = useReducedMotion();
+  const rise = (delay: number) => ({
+    initial: reduce ? false : { opacity: 0, y: 26 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: 0.8, ease: [0.2, 0.7, 0.2, 1] as const, delay },
+  });
+
+  return (
+    <section className={`${WRAP} pb-14 pt-[74px]`} aria-label="Hero">
+      <div className="grid items-center gap-14 lg:grid-cols-[1.05fr_0.95fr]">
+        <div>
+          <motion.div {...rise(0.1)} className={`${KICKER} mb-6`}>
+            Karibu · Kenya&apos;s Claude Community
+          </motion.div>
+          <motion.h1
+            {...rise(0.22)}
+            className="mb-6 font-newsreader text-[44px] font-normal leading-[1.04] tracking-[-0.02em] text-ink sm:text-[54px] lg:text-[62px]"
+          >
+            A free community for Kenyans{" "}
+            <span className="italic text-clay">learning &amp; building</span> with
+            Claude.
+          </motion.h1>
+          <motion.p
+            {...rise(0.34)}
+            className="mb-9 max-w-[480px] font-inter text-[18px] leading-[1.6] text-ink-soft"
+          >
+            Founder-led, mobile-first, and open to everyone — from first-time
+            students to seasoned developers. Meet-ups, hands-on workshops, and a
+            warm community growing across Kenya.
+          </motion.p>
+          <motion.div {...rise(0.46)} className="flex flex-wrap items-center gap-3.5">
+            <a
+              href={SOCIAL_LINKS.whatsapp}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-full bg-clay px-[26px] py-[15px] font-inter text-[15.5px] font-semibold text-paper-card transition-colors hover:bg-clay-dark"
+            >
+              Join the community
+            </a>
+            <Link
+              href="/events"
+              className="inline-flex items-center gap-2 rounded-full border border-sand-2 px-6 py-[15px] font-inter text-[15.5px] font-semibold text-ink transition-colors hover:border-ink"
+            >
+              See upcoming events →
+            </Link>
+          </motion.div>
+        </div>
+
+        {/* Hero visual — decorative placeholder; swap for a real meetup photo. */}
+        <motion.div
+          initial={reduce ? false : { opacity: 0, scale: 0.98 }}
+          animate={{ opacity: 1, scale: 1 }}
+          transition={{ duration: 0.9, ease: [0.2, 0.7, 0.2, 1] }}
+          className="relative h-[300px] overflow-hidden rounded-[14px] border border-sand-2 lg:h-[460px]"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(135deg, #EBE2D2 0 14px, #E4DAC7 14px 28px)",
+          }}
+        >
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg border border-sand-2 bg-paper px-3.5 py-2 font-mono text-[12.5px] tracking-[0.04em] text-ink-muted">
+              [ community · CCK meetup ]
+            </div>
+          </div>
+          {nextEvent && (
+            <div className="absolute bottom-[18px] left-[18px] rounded-xl border border-sand-2 bg-paper/[0.94] px-4 py-3 font-inter text-[13px] text-ink-soft backdrop-blur-sm">
+              <span className="font-semibold text-ink">{nextEvent.title}</span>
+              {typeof nextEvent.attendeeCount === "number" && (
+                <> · {nextEvent.attendeeCount} registered</>
+              )}
+            </div>
+          )}
+        </motion.div>
+      </div>
+    </section>
+  );
+}
+
+/* ─────────────────────────── Trust bar ─────────────────────────── */
+
+function TrustBar({
+  stats,
+  cities,
+}: {
+  stats?: CommunityStats;
+  cities: string[];
+}) {
+  const items = [
+    {
+      big: stats?.totalMembers ? `~${stats.totalMembers.toLocaleString()}` : "Growing",
+      small: "members & growing",
+    },
+    {
+      big: cities.length ? `${cities.length} ${cities.length === 1 ? "city" : "cities"}` : "Kenya",
+      small: cities.length ? cities.join(" · ") : "and expanding",
+    },
+    { big: "100% free", small: "community-run, always open" },
+    { big: "Supported", small: "by Anthropic's Ambassador programme" },
+  ];
+
+  return (
+    <div className="relative overflow-hidden border-y border-sand bg-paper-alt">
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(90deg, rgba(193,95,60,0.05) 0 2px, transparent 2px 16px)",
+          animation: "karibu-drift 36s linear infinite",
+        }}
+        aria-hidden="true"
+      />
+      <div className={`${WRAP} grid grid-cols-2 lg:grid-cols-4`}>
+        {items.map((it) => (
+          <div key={it.small} className="py-[26px] pr-6">
+            <div className="font-newsreader text-[30px] font-medium text-ink">
+              {it.big}
+            </div>
+            <div className="mt-0.5 font-inter text-[13.5px] text-ink-muted">
+              {it.small}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────── Made for you (personalized) ─────────────────── */
+
+function MadeForYouLight({
+  audienceState,
+  items,
+}: {
+  audienceState: AudienceState;
+  items: Recommendable[];
+}) {
+  const ranked = rank(items, {
+    audience: audienceState.audience,
+    intent: audienceState.intent,
+    experience: audienceState.experience,
+    city: audienceState.city,
+  }).slice(0, 3);
+  if (ranked.length === 0) return null;
+
+  return (
+    <section className={`${WRAP} py-16`} aria-label="Recommended for you">
+      <Reveal>
+        <div className={`${KICKER} mb-4`}>Made for you</div>
+        <h2 className="mb-8 font-newsreader text-[30px] font-normal tracking-[-0.015em] text-ink">
+          Three things to start with.
+        </h2>
+      </Reveal>
+      <Reveal className="grid gap-4 sm:grid-cols-3">
+        {ranked.map((item) => {
+          const href =
+            item.type === "event"
+              ? `/events/${item.id}`
+              : item.type === "resource"
+                ? `/blog/${item.id}`
+                : `/community/${item.id}`;
+          return (
+            <Link
+              key={`${item.type}-${item.id}`}
+              href={href}
+              className="group rounded-xl border border-sand bg-paper-card p-5 transition-colors hover:border-clay"
+            >
+              <span className="font-inter text-[11px] font-semibold uppercase tracking-[0.1em] text-clay">
+                {item.type}
+              </span>
+              <div className="mt-1.5 line-clamp-2 font-inter text-[15px] font-semibold leading-tight text-ink">
+                {item.title}
+              </div>
+              {item.date && (
+                <div className="mt-2 font-inter text-[13px] text-ink-muted">
+                  {item.date.toISOString().slice(0, 10)}
+                  {item.city ? ` · ${item.city}` : ""}
+                </div>
+              )}
+            </Link>
+          );
+        })}
+      </Reveal>
+    </section>
+  );
+}
+
+/* ─────────────────────────── What we do ─────────────────────────── */
+
+function WhatWeDo() {
+  return (
+    <section id="what" className={`${WRAP} pb-8 pt-20`} aria-label="What we do">
+      <Reveal>
+        <div className={`${KICKER} mb-4`}>What we do</div>
+        <h2 className="mb-10 max-w-[620px] font-newsreader text-[40px] font-normal leading-[1.1] tracking-[-0.015em] text-ink">
+          Four ways we learn and build together.
+        </h2>
+      </Reveal>
+
+      <Reveal className="grid gap-4 md:grid-cols-3 md:grid-rows-2">
+        {/* 01 — tall */}
+        <article className="flex flex-col justify-between rounded-2xl border border-sand bg-paper-card p-7 md:row-span-2">
+          <div className="font-mono text-xs tracking-[0.06em] text-clay">01</div>
+          <div>
+            <h3 className="mb-2.5 font-newsreader text-[27px] text-ink">
+              Events &amp; meetups
+            </h3>
+            <p className="font-inter text-[15px] leading-[1.55] text-ink-soft">
+              Regular in-person gatherings across our cities — live demos,
+              project showcases, and the hallway conversations that start real
+              projects.
+            </p>
+          </div>
+        </article>
+
+        {/* 02 */}
+        <article className="rounded-2xl border border-sand bg-paper-card p-6">
+          <div className="mb-8 font-mono text-xs tracking-[0.06em] text-clay">02</div>
+          <h3 className="mb-2 font-newsreader text-[22px] text-ink">
+            Hands-on workshops
+          </h3>
+          <p className="font-inter text-sm leading-[1.5] text-ink-soft">
+            Deep dives on Claude Code, agentic patterns and shipping real apps.
+          </p>
+        </article>
+
+        {/* 03 — clay */}
+        <article className="rounded-2xl bg-clay p-6 text-paper-card">
+          <div className="mb-8 font-mono text-xs tracking-[0.06em] text-clay-light">
+            03
+          </div>
+          <h3 className="mb-2 font-newsreader text-[22px]">Online community</h3>
+          <p className="font-inter text-sm leading-[1.5] text-[#F5E4DB]">
+            WhatsApp &amp; Discord — questions answered daily, wins shared
+            nightly.
+          </p>
+        </article>
+
+        {/* 04 — wide */}
+        <article className="flex items-center gap-6 rounded-2xl border border-sand bg-paper-card p-6 md:col-span-2">
+          <div className="flex-1">
+            <div className="mb-2.5 font-mono text-xs tracking-[0.06em] text-clay">
+              04
+            </div>
+            <h3 className="mb-2 font-newsreader text-[22px] text-ink">
+              Learn with Claude
+            </h3>
+            <p className="font-inter text-sm leading-[1.5] text-ink-soft">
+              Shared guides, prompts and starter projects pitched for every
+              level — from your first prompt to production.
+            </p>
+          </div>
+          <Link
+            href="/resources"
+            className="shrink-0 whitespace-nowrap font-inter text-sm font-semibold text-clay hover:underline"
+          >
+            Explore resources →
+          </Link>
+        </article>
+      </Reveal>
+    </section>
+  );
+}
+
+/* ─────────────────────────── Two tracks ─────────────────────────── */
+
+function TwoTracks() {
+  return (
+    <section className={`${WRAP} py-14`} aria-label="Two tracks">
+      <Reveal>
+        <div className={`${KICKER} mb-4`}>Two tracks · one community</div>
+      </Reveal>
+      <Reveal className="grid gap-4 md:grid-cols-2">
+        <TrackCard
+          title="Software engineers"
+          body="Backend, frontend, mobile, ML. Agentic patterns, multi-instance Claude Code, and hackathons that ship."
+          cta="See engineering events →"
+          href="/events"
+        />
+        <TrackCard
+          title="Builders & vibe coders"
+          body="Founders, PMs, designers, students and the AI-curious. Skip the theory — ship the thing."
+          cta="Start here →"
+          href="/join"
+        />
+      </Reveal>
+    </section>
+  );
+}
+
+function TrackCard({
+  title,
+  body,
+  cta,
+  href,
+}: {
+  title: string;
+  body: string;
+  cta: string;
+  href: string;
+}) {
+  return (
+    <div className="rounded-2xl border border-sand bg-paper-card p-8">
+      <h3 className="mb-2.5 font-newsreader text-[26px] text-ink">{title}</h3>
+      <p className="mb-4 font-inter text-[15px] leading-[1.6] text-ink-soft">
+        {body}
+      </p>
+      <Link
+        href={href}
+        className="font-inter text-[14.5px] font-semibold text-clay hover:underline"
+      >
+        {cta}
+      </Link>
+    </div>
+  );
+}
+
+/* ─────────────────────────── Events ─────────────────────────── */
+
+function EventsSection({ events }: { events: Event[] }) {
+  if (events.length === 0) return null;
+  return (
+    <section className={`${WRAP} py-14`} aria-label="Upcoming events">
+      <Reveal>
+        <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className={`${KICKER} mb-3.5`}>Upcoming</div>
+            <h2 className="font-newsreader text-[40px] font-normal tracking-[-0.015em] text-ink">
+              Come to the next one.
+            </h2>
+          </div>
+          <Link
+            href="/events"
+            className="font-inter text-[14.5px] font-semibold text-clay hover:underline"
+          >
+            All events →
+          </Link>
+        </div>
+      </Reveal>
+
+      <Reveal className="grid gap-4 md:grid-cols-3">
+        {events.map((ev) => {
+          const cta =
+            ev.type === "hackathon" || ev.status === "registration-open"
+              ? "Register"
+              : "RSVP";
+          return (
+            <Link
+              key={ev.slug}
+              href={`/events/${ev.slug}`}
+              className="group block overflow-hidden rounded-[14px] border border-sand bg-paper-card transition-colors hover:border-clay"
+            >
+              <div
+                className="h-[140px] border-b border-sand"
+                style={{
+                  backgroundImage:
+                    "repeating-linear-gradient(135deg, #EFE7D8 0 12px, #E7DDCB 12px 24px)",
+                }}
+              />
+              <div className="p-[22px]">
+                <div className="mb-3 flex flex-wrap gap-2">
+                  {ev.city && (
+                    <span className="rounded-full bg-[#F3E3D9] px-2.5 py-1 font-inter text-xs font-semibold text-clay">
+                      {ev.city}
+                    </span>
+                  )}
+                  <span className="rounded-full bg-paper-alt px-2.5 py-1 font-inter text-xs font-semibold text-ink-muted">
+                    {TYPE_LABEL[ev.type]}
+                  </span>
+                </div>
+                <div className="mb-1.5 font-inter text-[13px] text-ink-muted">
+                  {ev.date}
+                  {ev.time ? ` · ${ev.time}` : ""}
+                </div>
+                <h3 className="mb-4 font-newsreader text-[22px] leading-[1.15] text-ink">
+                  {ev.title}
+                </h3>
+                <span className="border-b-2 border-clay pb-0.5 font-inter text-sm font-semibold text-ink">
+                  {cta}
+                </span>
+              </div>
+            </Link>
+          );
+        })}
+      </Reveal>
+    </section>
+  );
+}
+
+/* ─────────────────── Community in action (testimonials) ─────────────────── */
+
+function CommunityInAction() {
+  return (
+    <section className={`${WRAP} py-14`} aria-label="Community in action">
+      <Reveal>
+        <div className={`${KICKER} mb-4`}>Community in action</div>
+      </Reveal>
+      <Reveal className="grid items-stretch gap-6 lg:grid-cols-2">
+        {/* Photo gallery placeholder — swap for real member/event photos. */}
+        <div className="grid min-h-[380px] grid-cols-2 grid-rows-2 gap-3">
+          <div className="row-span-2 rounded-xl bg-[#E4DAC7]" />
+          <div className="rounded-xl bg-[#EAD9C9]" />
+          <div className="rounded-xl bg-[#DED2BC]" />
+        </div>
+        <KaribuTestimonials />
+      </Reveal>
+      <p className="mt-3.5 font-mono text-xs text-[#9A8F7E]">
+        [ gallery — real CCK member &amp; event photos ]
+      </p>
+    </section>
+  );
+}
+
+/* ─────────────────────────── How to join ─────────────────────────── */
+
+const JOIN_STEPS = [
+  {
+    n: "1",
+    title: 'Tap "Join on WhatsApp"',
+    body: "Opens the main community group instantly.",
+  },
+  {
+    n: "2",
+    title: "Say Karibu — introduce yourself",
+    body: "Your city and what you're building or curious about.",
+  },
+  {
+    n: "3",
+    title: "Come to an event near you",
+    body: "Meetups across Kenya — all welcome.",
+  },
+];
+
+function HowToJoin() {
+  return (
+    <section id="join" className={`${WRAP} py-14`} aria-label="How to join">
+      <Reveal className="relative overflow-hidden rounded-[18px] bg-ink p-9 text-paper sm:p-[54px]">
+        <div
+          className="pointer-events-none absolute inset-0"
+          style={{
+            backgroundImage:
+              "repeating-linear-gradient(90deg, rgba(230,144,111,0.06) 0 2px, transparent 2px 16px)",
+            animation: "karibu-drift 36s linear infinite",
+          }}
+          aria-hidden="true"
+        />
+        <div className="relative grid items-center gap-12 lg:grid-cols-[0.9fr_1.1fr]">
+          <div>
+            <div className="mb-4 font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay-light">
+              How to join
+            </div>
+            <h2 className="mb-5 font-newsreader text-[38px] font-normal leading-[1.1] tracking-[-0.015em]">
+              Three taps and you&apos;re in.
+            </h2>
+            <p className="mb-7 font-inter text-base leading-[1.6] text-[#C7BEB0]">
+              No fees, no application. Just introduce yourself and start
+              building.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <a
+                href={SOCIAL_LINKS.whatsapp}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full bg-clay px-[26px] py-[15px] font-inter text-[15.5px] font-semibold text-paper-card transition-colors hover:bg-clay-dark"
+              >
+                Join on WhatsApp
+              </a>
+              <a
+                href={SOCIAL_LINKS.discord}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 rounded-full border border-[#554E44] px-6 py-[15px] font-inter text-[15.5px] font-semibold text-paper transition-colors hover:border-paper"
+              >
+                Join Discord
+              </a>
+            </div>
+          </div>
+          <div className="flex flex-col gap-3.5">
+            {JOIN_STEPS.map((step, i) => (
+              <div
+                key={step.n}
+                className={`flex items-start gap-[18px] ${
+                  i < JOIN_STEPS.length - 1 ? "border-b border-[#3B352D] pb-3.5" : ""
+                }`}
+              >
+                <div className="font-newsreader text-2xl text-clay-light">{step.n}</div>
+                <div>
+                  <div className="font-inter text-base font-semibold text-paper">
+                    {step.title}
+                  </div>
+                  <div className="font-inter text-sm text-[#A79E90]">{step.body}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Reveal>
+    </section>
+  );
+}

--- a/src/components/karibu/KaribuNav.tsx
+++ b/src/components/karibu/KaribuNav.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+/**
+ * KaribuNav — sticky top navigation for the warm-light "Karibu" identity.
+ *
+ * Part of the page-by-page redesign. Rendered only on converted routes by
+ * ConditionalLayout; un-migrated pages keep the Terminal Noir <Navbar />.
+ * Flat link set (mirrors the approved mockup) pointing at real app routes.
+ */
+
+import { useState } from "react";
+import Link from "next/link";
+import { SOCIAL_LINKS } from "@/lib/constants";
+
+const NAV_LINKS = [
+  { label: "What we do", href: "/#what" },
+  { label: "Events", href: "/events" },
+  { label: "Learn", href: "/resources" },
+  { label: "Community", href: "/community" },
+  { label: "About", href: "/about" },
+] as const;
+
+export function KaribuNav() {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <nav className="sticky top-0 z-50 border-b border-sand bg-paper/[0.86] backdrop-blur-md">
+      <div className="mx-auto flex max-w-[1180px] items-center justify-between px-5 py-4 md:px-10">
+        {/* Brand */}
+        <Link
+          href="/"
+          className="group flex items-center gap-3"
+          onClick={() => setMenuOpen(false)}
+        >
+          <span className="flex h-7 w-7 items-center justify-center rounded-lg bg-clay text-[20px] leading-none text-paper-card transition-transform duration-500 group-hover:rotate-[20deg] group-hover:scale-110">
+            <span
+              className="inline-block"
+              style={{ animation: "karibu-spin 26s linear infinite" }}
+              aria-hidden="true"
+            >
+              ✳
+            </span>
+          </span>
+          <span className="whitespace-nowrap font-newsreader text-[20px] font-semibold tracking-[-0.01em] text-ink">
+            Claude Community Kenya
+          </span>
+        </Link>
+
+        {/* Desktop links */}
+        <div className="hidden items-center gap-7 font-inter text-[14.5px] text-ink-soft lg:flex">
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="transition-colors hover:text-clay"
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* CTA + hamburger */}
+        <div className="flex items-center gap-3">
+          <a
+            href={SOCIAL_LINKS.whatsapp}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 whitespace-nowrap rounded-full bg-ink px-[18px] py-2.5 font-inter text-sm font-semibold text-paper transition-colors hover:bg-black"
+          >
+            Join on WhatsApp
+          </a>
+          <button
+            type="button"
+            onClick={() => setMenuOpen((v) => !v)}
+            className="flex h-[42px] w-[42px] flex-col items-center justify-center gap-1 rounded-[10px] border border-sand-2 lg:hidden"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={menuOpen}
+          >
+            <span className="block h-0.5 w-[18px] bg-ink" />
+            <span className="block h-0.5 w-[18px] bg-ink" />
+            <span className="block h-0.5 w-[18px] bg-ink" />
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile menu */}
+      {menuOpen && (
+        <div className="flex flex-col gap-0.5 border-t border-sand bg-paper px-6 pb-4 pt-2 lg:hidden">
+          {NAV_LINKS.map((link, i) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={() => setMenuOpen(false)}
+              className={`py-3 font-inter text-base text-ink ${
+                i < NAV_LINKS.length - 1 ? "border-b border-sand/70" : ""
+              }`}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+      )}
+    </nav>
+  );
+}

--- a/src/components/karibu/KaribuTestimonials.tsx
+++ b/src/components/karibu/KaribuTestimonials.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * KaribuTestimonials — auto-advancing quote carousel for the warm-light home.
+ *
+ * Real community members supplied by Peter (voice-dictated). Quotes are
+ * faithful paraphrases of what he described; NAMES + SPELLINGS + wording are
+ * pending his sign-off before merge (Billy Mwangi surname, Samuel surname,
+ * "Toili"/"Tuigoin" spellings). Do not treat as final copy.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+
+interface Testimonial {
+  quote: string;
+  name: string;
+  role: string;
+  /** Initials shown in the avatar chip until real photos are wired in. */
+  initials: string;
+}
+
+const TESTIMONIALS: Testimonial[] = [
+  {
+    quote:
+      "The CCK sessions changed how I work. I've been able to scale what I build and bring real AI leverage into my company.",
+    name: "Billy Mwangi",
+    role: "Building with Claude · Nairobi",
+    initials: "BM",
+  },
+  {
+    quote:
+      "Claude has completely transformed my client work — I deliver more, faster, and with far less grind.",
+    name: "Samuel",
+    role: "Freelance · Client work",
+    initials: "S",
+  },
+  {
+    quote:
+      "I started CCK because Claude changed how I ship. This community exists so more Kenyans get that same unlock.",
+    name: "Peter Kibet",
+    role: "Founder, Claude Community Kenya",
+    initials: "PK",
+  },
+  {
+    quote:
+      "Claude has made research so much easier. What used to take days of digging now takes an afternoon.",
+    name: "James Lloyd",
+    role: "Research",
+    initials: "JL",
+  },
+  {
+    quote:
+      "I teach in Tuigoin, a small village. Claude helps me plan lessons, organise my week, and manage my classroom. It has changed how I teach.",
+    name: "Isaac Toili",
+    role: "Teacher · Tuigoin",
+    initials: "IT",
+  },
+];
+
+export function KaribuTestimonials() {
+  const [current, setCurrent] = useState(0);
+  const prefersReducedMotion = useReducedMotion();
+
+  const go = useCallback((i: number) => {
+    setCurrent(((i % TESTIMONIALS.length) + TESTIMONIALS.length) % TESTIMONIALS.length);
+  }, []);
+
+  useEffect(() => {
+    if (prefersReducedMotion) return;
+    const timer = setInterval(() => setCurrent((p) => (p + 1) % TESTIMONIALS.length), 6000);
+    return () => clearInterval(timer);
+  }, [prefersReducedMotion]);
+
+  const t = TESTIMONIALS[current];
+
+  return (
+    <div className="flex h-full flex-col justify-center rounded-2xl border border-sand bg-paper-card p-8 sm:p-10">
+      <div className="min-h-[210px]">
+        <AnimatePresence mode="wait">
+          <motion.blockquote
+            key={current}
+            initial={prefersReducedMotion ? false : { opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={prefersReducedMotion ? undefined : { opacity: 0, y: -12 }}
+            transition={{ duration: 0.4, ease: "easeInOut" }}
+          >
+            <p className="mb-6 font-newsreader text-[22px] italic leading-[1.35] text-ink sm:text-[26px]">
+              &ldquo;{t.quote}&rdquo;
+            </p>
+            <footer className="flex items-center gap-3">
+              <span className="flex h-11 w-11 items-center justify-center rounded-full bg-sand font-inter text-sm font-semibold text-ink-soft">
+                {t.initials}
+              </span>
+              <span>
+                <span className="block font-inter text-[14.5px] font-semibold text-ink">
+                  {t.name}
+                </span>
+                <span className="block font-inter text-[13px] text-ink-muted">{t.role}</span>
+              </span>
+            </footer>
+          </motion.blockquote>
+        </AnimatePresence>
+      </div>
+
+      <div className="mt-6 flex items-center gap-2">
+        {TESTIMONIALS.map((item, i) => (
+          <button
+            key={item.name}
+            type="button"
+            onClick={() => go(i)}
+            aria-label={`Show testimonial from ${item.name}`}
+            aria-current={i === current}
+            className={`h-1.5 rounded-full transition-all duration-300 ${
+              i === current ? "w-5 bg-clay" : "w-1.5 bg-sand-2 hover:bg-ink-muted/50"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/karibu/Marquee.tsx
+++ b/src/components/karibu/Marquee.tsx
@@ -1,0 +1,44 @@
+/**
+ * Marquee — scrolling clay band under the nav for the Karibu identity.
+ *
+ * Dumb/presentational: caller supplies the item strings (built from real
+ * community stats). The track is duplicated for a seamless CSS loop; the
+ * global reduced-motion reset pauses it for users who opt out.
+ */
+
+interface MarqueeProps {
+  /** Ordered list of short phrases to scroll. Built from live data by caller. */
+  items: string[];
+}
+
+export function Marquee({ items }: MarqueeProps) {
+  const Track = () => (
+    <div className="flex items-center gap-[26px] py-[11px] font-inter text-[13px] font-semibold uppercase tracking-[0.12em] text-[#FBF0E8] whitespace-nowrap">
+      {items.map((item, i) => (
+        <span key={i} className="flex items-center gap-[26px]">
+          <span>{item}</span>
+          <span className="text-clay-light" aria-hidden="true">
+            ✳
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+
+  return (
+    <div
+      data-marquee
+      className="overflow-hidden border-b border-clay-dark bg-clay"
+      aria-hidden="true"
+    >
+      <div
+        data-mq-track
+        className="flex w-max"
+        style={{ animation: "karibu-marquee 26s linear infinite" }}
+      >
+        <Track />
+        <Track />
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -5,6 +5,8 @@ import { SessionProvider } from "next-auth/react";
 import dynamic from "next/dynamic";
 import { Navbar } from "@/components/layout/Navbar";
 import { Footer } from "@/components/layout/Footer";
+import { KaribuNav } from "@/components/karibu/KaribuNav";
+import { KaribuFooter } from "@/components/karibu/KaribuFooter";
 import { LoadingBar } from "@/components/terminal/LoadingBar";
 import { EasterEggs } from "@/components/EasterEggs";
 import { PageTransition } from "@/components/layout/PageTransition";
@@ -31,6 +33,9 @@ export function ConditionalLayout({
   const pathname = usePathname();
   const isAdmin = pathname.startsWith("/admin");
   const isDashboard = pathname.startsWith("/dashboard");
+  // Routes migrated to the warm-light "Karibu" identity. Grows page-by-page;
+  // everything else keeps the Terminal Noir chrome until converted.
+  const isKaribu = pathname === "/";
 
   if (isAdmin) {
     return <>{children}</>;
@@ -40,19 +45,21 @@ export function ConditionalLayout({
     <SessionProvider>
       <SkinProvider>
         <AudienceProvider value={audienceState}>
-          <a href="#main-content" className="skip-nav">
-            Skip to main content
-          </a>
-          <Navbar />
-          <LoadingBar />
-          <main id="main-content">
-            <PageTransition>{children}</PageTransition>
-          </main>
-          {!isDashboard && <Footer />}
+          <div className={isKaribu ? "karibu" : undefined}>
+            <a href="#main-content" className="skip-nav">
+              Skip to main content
+            </a>
+            {isKaribu ? <KaribuNav /> : <Navbar />}
+            <LoadingBar />
+            <main id="main-content">
+              <PageTransition>{children}</PageTransition>
+            </main>
+            {isKaribu ? <KaribuFooter /> : !isDashboard && <Footer />}
+          </div>
           <EasterEggs />
           <ChatWidget />
           <KaribuBanner />
-          {!isDashboard && <StickyMobileCTA />}
+          {!isDashboard && !isKaribu && <StickyMobileCTA />}
           {showKaribu && <KaribuModal />}
         </AudienceProvider>
       </SkinProvider>


### PR DESCRIPTION
## Karibu redesign — warm-light identity, page by page

Replaces Terminal Noir with the warm clay-&-paper "Karibu" identity (Newsreader + Inter), converted route by route. **No features or component files removed** — old components are left dormant for a later cleanup; every data-driven section is preserved.

### Converted routes (9)
`/` · `/events` · `/events/[slug]` · `/about` · `/resources` (Learn) · `/community` (Hub, restyled in place) · `/join` · `/projects` · `/team`

Each: real data wired (events, stats, team, projects, submissions), Framer-Motion reveals + `prefers-reduced-motion`, build + `tsc --noEmit` clean.

### Highlights
- **Real assets**: 16 optimized event photos (`public/images/community`), the real CCK logo in nav/footer, official Claude sunburst marquee separators, Anthropic wordmark, Peter's headshot in testimonials.
- **Full nav IA preserved**: dropdowns (Events/Learn/Community), Ctrl+K command palette, auth-aware Sign in / Join, mobile menu.
- **Event detail keeps everything**: demo-request form, scheduled demos, photo strip, share links.
- **Community Hub restyled in place**: type/sort filters, upvotes, comments, tags — nothing dropped.
- Chrome swap driven by an exact-match `isKaribu` allowlist in `ConditionalLayout`; un-migrated pages keep the dark skin.

### Deferred (tracked)
- Adaptive **dark mode** (Terminal Noir palette returns as the dark theme) → **#33**.
- Secondary pages not yet converted: blog, faq, gallery, newsletter, speak, volunteer, submit-*, `resources/*` sub-pages, `community/[slug]` + `/submit`.
- Final persona-system cleanup once everything is converted.

### Before/after merge notes
- **"Bare" preview** = the preview DB is empty. Against the **production DB (which has real events/team/projects)** the site fills in. If any section still looks bare post-merge, add content in `/admin` — it's data, not design.
- **Needs sign-off**: testimonial name spellings (Billy Mwangi, Samuel, James Lloyd, Isaac Toili / Tuigoin); whether the `/join` application form should return (currently reframed as no-application, old form dormant).

@Spidey-Acer
