### PR TITLE
feat(karibu): motion layer — degrade-safe reveal + restrained through-line

### DIFF
--- a/docs/superpowers/plans/2026-07-09-karibu-motion-layer.md
+++ b/docs/superpowers/plans/2026-07-09-karibu-motion-layer.md
@@ -1,0 +1,525 @@
+# Karibu Motion Layer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a restrained, degrade-safe motion layer across the warm-light "Karibu" pages, and eliminate the reveal-degradation bug so animation enhances an already-legible page instead of gating legibility behind a trigger that can fail.
+
+**Architecture:** CSS-first hybrid. The reveal is rebuilt CSS-first — content is fully visible by default; a before-paint `.js` class on `<html>` *introduces* the hidden→visible transition, and a single shared IntersectionObserver singleton adds `.in-view` once per element. Framer Motion is kept **only** for genuine layout/orchestration work: Events FLIP filter, Home hero stagger, About timeline scroll-draw. All 17 local `Reveal` copies collapse into one shared `Reveal` component. `CountUp` is reused unchanged.
+
+**Tech Stack:** Next.js 16 (App Router, RSC), TypeScript strict, Tailwind CSS v4 (`@theme inline` + CSS variables), Framer Motion, `next/font`.
+
+## Global Constraints
+
+Copied verbatim from the spec — every task implicitly includes these:
+
+- **Gate:** `npm run build && npx tsc --noEmit` must **both** be clean before **every** commit. `next build` runs ESLint (no `ignoreDuringBuilds`); `@typescript-eslint/no-unused-vars` is an error, so **every now-unused import must be removed** or the build fails.
+- **Conventional commits.** Never commit to `main`. Stay on `redesign/karibu-motion`. Auto-commit at logical checkpoints; **ask before opening/merging any PR.**
+- **`prefers-reduced-motion: reduce` → instant.** Replace all movement with opacity/instant; the marquee stops entirely.
+- **Animate only `transform` / `opacity`** (GPU-friendly). No animating layout properties (width/height/top/left), except Framer `layout` FLIP which is transform-based under the hood.
+- **Scroll reveals are one-time** — `unobserve` after first fire.
+- **Never gate legibility behind an entrance.** Empty / error / read-quickly states appear **instantly** — never animate attention onto "nothing here".
+- **No hero parallax.** No looping attention motion except the single marquee.
+- **Do not animate body paragraphs / long text.**
+- **No live DB locally** (Supabase host unreachable) → the build gate is necessary but **not sufficient**; motion must be verified visually on the **Vercel preview** of the PR.
+- **Delegation:** P1's mechanical 20-file swap → parallel Sonnet subagents on **disjoint files**. The lead (Opus) owns `globals.css`, the shared util, `layout.tsx`, the build gate, and **all commits**.
+
+**Testing note (intentional TDD deviation, per Iron Rules "state it when a default doesn't fit"):** This repo has no DOM/component test runner wired for CSS-driven motion, and the deliverable is inherently visual with no live DB locally. So per-task verification is: (1) `npm run build && npx tsc --noEmit` clean, (2) targeted DOM/CSS assertions where cheap (grep for the class/attribute), and (3) visual confirmation on the Vercel preview at the PR gate. Where a genuine unit is testable (the observer's one-time semantics), a lightweight assertion is included.
+
+---
+
+## File Structure
+
+**New files:**
+- `src/components/karibu/motion/observer.ts` — module-level singleton `IntersectionObserver` + `register(el)` / `unregister(el)`. One-time: adds `.in-view` on first intersect, then unobserves.
+- `src/components/karibu/motion/Reveal.tsx` — thin `"use client"` wrapper rendering `<div data-reveal>`, visible by default. Registers with the observer on mount, unregisters on unmount. Optional `index` prop sets `--i` for stagger.
+
+**Modified (foundation — lead only):**
+- `src/app/globals.css` — motion tokens in the existing `:root` (line 6); degrade-safe reveal CSS + reduced-motion block (new section).
+- `src/app/layout.tsx` — extend the existing before-paint `<head>` IIFE (lines 228–233) to add `.js` to `<html>`.
+
+**Modified (P1 mechanical swap — 17 files, delegated on disjoint sets):**
+`KaribuAbout, KaribuBlog, KaribuCommunity, KaribuEventDetail, KaribuEvents, KaribuFaq, KaribuGallery, KaribuHome, KaribuJoin, KaribuLearn, KaribuNewsletter, KaribuProjects, KaribuProjectsPage, KaribuSubmitIdea, KaribuSubmitProject, KaribuTeam, KaribuVolunteer` — each: delete local `Reveal`, import shared, fix imports.
+(`KaribuBanner, KaribuModal, KaribuTestimonials` have **no** `Reveal` — untouched in P1.)
+
+**Modified (P2/P3 craft — lead + frontend-design):**
+- `KaribuHome.tsx` (hero stagger already Framer; wire `CountUp` into TrustBar; stagger the 4 "what we do" cards; card hover lift).
+- `KaribuNav.tsx` (sticky-shrink on scroll; "Join" hover scale).
+- `KaribuEvents.tsx` (FLIP filter transition).
+- `KaribuLearn.tsx`, `KaribuCommunity.tsx` (card hover lift + "Open →" arrow nudge).
+- `KaribuAbout.tsx` (timeline scroll-draw), `KaribuTeam.tsx` (grid reveal only once populated).
+
+---
+
+## Interfaces (shared contract used across tasks)
+
+```ts
+// src/components/karibu/motion/observer.ts
+export function register(el: Element): void;   // observe; on first intersect add "in-view" + unobserve
+export function unregister(el: Element): void; // stop observing (cleanup)
+
+// src/components/karibu/motion/Reveal.tsx
+export function Reveal(props: {
+  children: React.ReactNode;
+  className?: string;
+  index?: number;   // optional stagger index (0-based); CSS caps delay at 6 steps
+}): React.JSX.Element;   // renders <div data-reveal ...>
+```
+
+Import path everywhere: `import { Reveal } from "@/components/karibu/motion/Reveal";`
+
+**CSS contract (globals.css):** `[data-reveal]` visible by default; `.js [data-reveal]` hidden + transitioned; `.js [data-reveal].in-view` visible; stagger via inline `--i` (`transition-delay: calc(min(var(--i,0),5) * 60ms)`).
+
+---
+
+# Phase P0 — Foundation
+
+## Task 1: Motion tokens + degrade-safe reveal CSS
+
+**Files:**
+- Modify: `src/app/globals.css` (add tokens to existing `:root` block at line 6; add reveal CSS as a new section)
+
+**Interfaces:**
+- Produces: the CSS custom properties `--ease-entrance`, `--ease-reversible`, `--dur-micro`, `--dur-reveal`, `--dur-hero`, `--reveal-shift`; the `[data-reveal]` / `.js [data-reveal]` / `.in-view` rules that `Reveal.tsx` (Task 3) and every P1 swap rely on.
+
+- [ ] **Step 1: Add motion tokens to the existing `:root` block.**
+
+In `src/app/globals.css`, inside the existing `:root { ... }` that starts at line 6 (which holds font stacks), append before its closing brace:
+
+```css
+  /* ─── Motion tokens (Karibu motion layer) ─── */
+  --ease-entrance: cubic-bezier(0.16, 1, 0.3, 1);   /* confident ease-out for entrances */
+  --ease-reversible: cubic-bezier(0.4, 0, 0.2, 1);  /* symmetric, for hovers/reversible states */
+  --dur-micro: 150ms;   /* hover / press */
+  --dur-reveal: 320ms;  /* entrances / reveals */
+  --dur-hero: 500ms;    /* large hero / page */
+  --reveal-shift: 18px;
+```
+
+- [ ] **Step 2: Add the degrade-safe reveal section.**
+
+Add a new section immediately **after** the existing `/* ─── Reduced Motion ─── */` block (ends at line 611, the `@media (prefers-reduced-motion: reduce)` global reset) and **before** the `/* ─── Karibu identity ─── */` block:
+
+```css
+/* ─── Karibu degrade-safe reveal ──────────────────────────────────────────
+ * Content is fully visible by default. The before-paint `.js` class (set in
+ * layout.tsx) introduces the hidden→visible transition; a shared observer
+ * adds `.in-view` once per element. No JS → no `.js` → content stays visible.
+ * Only opacity/transform animate. Reduced-motion → instant + always visible. */
+[data-reveal] {
+  opacity: 1;
+}
+.js [data-reveal] {
+  opacity: 0;
+  transform: translateY(var(--reveal-shift));
+  transition:
+    opacity var(--dur-reveal) var(--ease-entrance),
+    transform var(--dur-reveal) var(--ease-entrance);
+  transition-delay: calc(min(var(--i, 0), 5) * 60ms); /* stagger, capped at 6 steps */
+  will-change: opacity, transform;
+}
+.js [data-reveal].in-view {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .js [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
+    transition-delay: 0ms;
+  }
+}
+```
+
+- [ ] **Step 3: Verify the gate.**
+
+Run: `npx tsc --noEmit`
+Expected: clean (CSS changes don't affect types, but confirms nothing broke).
+
+Run: `npm run build`
+Expected: builds clean. Then grep the built/updated source to confirm the rules exist:
+Run: `grep -n "data-reveal\|--ease-entrance\|--dur-reveal" src/app/globals.css`
+Expected: shows the token defs and all three `[data-reveal]` rules + the reduced-motion override.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/app/globals.css
+git commit -m "feat(karibu-motion): motion tokens + degrade-safe reveal CSS"
+```
+
+---
+
+## Task 2: `.js` before-paint bootstrap
+
+**Files:**
+- Modify: `src/app/layout.tsx` (the existing theme-init `<script>` IIFE, lines 228–233)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `document.documentElement` carries class `js` before first paint. This is the switch that activates `.js [data-reveal]` from Task 1.
+
+- [ ] **Step 1: Extend the existing IIFE to add the `js` class first.**
+
+In `src/app/layout.tsx`, the current script (lines 228–233) is:
+
+```tsx
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var t=localStorage.getItem('cck-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}})();",
+          }}
+        />
+```
+
+Replace the `__html` string so `.js` is added **before** the `try` (so it runs even if `localStorage` throws):
+
+```tsx
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){document.documentElement.classList.add('js');try{var t=localStorage.getItem('cck-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}})();",
+          }}
+        />
+```
+
+Update the adjacent comment (lines 224–227) to mention it also sets `.js` for the motion layer.
+
+- [ ] **Step 2: Verify the gate.**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+Run: `npm run build`
+Expected: builds clean.
+
+Run: `grep -n "classList.add('js')" src/app/layout.tsx`
+Expected: one match inside the before-paint IIFE.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add src/app/layout.tsx
+git commit -m "feat(karibu-motion): add before-paint .js class for degrade-safe reveals"
+```
+
+---
+
+## Task 3: Shared `observer` singleton + `Reveal` component
+
+**Files:**
+- Create: `src/components/karibu/motion/observer.ts`
+- Create: `src/components/karibu/motion/Reveal.tsx`
+
+**Interfaces:**
+- Consumes: the CSS `data-reveal` / `.in-view` contract from Task 1.
+- Produces: `register(el)`, `unregister(el)` (observer.ts); `Reveal` component (Reveal.tsx) — the single import every P1 file will use.
+
+- [ ] **Step 1: Write `observer.ts`.**
+
+Create `src/components/karibu/motion/observer.ts`:
+
+```ts
+/**
+ * Shared IntersectionObserver singleton for the Karibu degrade-safe reveal.
+ *
+ * One observer instance for the whole page (not one per element). On an
+ * element's first intersection it adds `.in-view` and unobserves it, so every
+ * reveal fires exactly once. Constructed lazily on first `register` — which is
+ * only ever called from a client `useEffect`, so `IntersectionObserver` is
+ * always defined by then.
+ */
+
+let observer: IntersectionObserver | null = null;
+
+function getObserver(): IntersectionObserver {
+  if (observer) return observer;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("in-view");
+          observer?.unobserve(entry.target); // one-time
+        }
+      }
+    },
+    { rootMargin: "0px 0px -6% 0px", threshold: 0 },
+  );
+  return observer;
+}
+
+export function register(el: Element): void {
+  getObserver().observe(el);
+}
+
+export function unregister(el: Element): void {
+  observer?.unobserve(el);
+}
+```
+
+- [ ] **Step 2: Write `Reveal.tsx`.**
+
+Create `src/components/karibu/motion/Reveal.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
+import { register, unregister } from "./observer";
+
+interface RevealProps {
+  children: ReactNode;
+  className?: string;
+  /** Optional stagger index (0-based). CSS caps the delay at 6 steps. */
+  index?: number;
+}
+
+/**
+ * Degrade-safe reveal wrapper. Renders a visible `<div data-reveal>`; the
+ * before-paint `.js` class (layout.tsx) + globals.css turn that into an
+ * opacity/transform entrance, and the shared observer adds `.in-view` once on
+ * scroll. No JS → content stays fully visible. Reduced-motion → instant.
+ */
+export function Reveal({ children, className, index }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    register(el);
+    return () => unregister(el);
+  }, []);
+
+  const style =
+    index != null ? ({ "--i": index } as CSSProperties) : undefined;
+
+  return (
+    <div ref={ref} data-reveal="" className={className} style={style}>
+      {children}
+    </div>
+  );
+}
+```
+
+Note: `as`/`stagger` props from the spec sketch are dropped per YAGNI — **no** current call site passes them (verified: every usage passes only `className` / `key`). Stagger is delivered via the `index` prop + CSS `--i`, which P2 uses. If a later phase needs a semantic tag, add `as` then.
+
+- [ ] **Step 3: Verify types + build.**
+
+Run: `npx tsc --noEmit`
+Expected: clean (the `--i` custom property needs the `as CSSProperties` cast — confirm no TS error there).
+
+Run: `npm run build`
+Expected: clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add src/components/karibu/motion/observer.ts src/components/karibu/motion/Reveal.tsx
+git commit -m "feat(karibu-motion): shared degrade-safe Reveal + observer singleton"
+```
+
+---
+
+# Phase P1 — Unify (swap all 17 local `Reveal` defs → shared)
+
+**This is the central bug fix.** Mechanical and identical across files. **Delegate to Sonnet subagents on disjoint file sets** (see "Delegation" below). The lead owns commits and the gate.
+
+**The swap recipe (identical for every file):**
+
+1. Add the import near the other `@/components/karibu/...` imports:
+   `import { Reveal } from "@/components/karibu/motion/Reveal";`
+2. **Delete** the entire local `function Reveal({ ... }) { ... }` block (the `useReducedMotion` + `motion.div` version). Call sites stay unchanged — they already pass only `className`/`key`, which the shared `Reveal` accepts. (Two files — `KaribuHome`, `KaribuEvents` — have a `delay` **prop** in their local def, but **no call site passes `delay`**, so dropping it is safe.)
+3. **Fix the `framer-motion` import** so nothing is unused (ESLint `no-unused-vars` is a build error):
+   - If the file's **only** Framer usage was the deleted `Reveal` (i.e. `motion` and `useReducedMotion` are now unreferenced), **delete the whole `import { ... } from "framer-motion";` line.**
+   - If the file keeps other Framer usage (`AnimatePresence`, a `motion.*` element, a `rise()` helper), **remove only the now-unused names** from that import, keeping the rest.
+4. **Self-check before handing back:** grep the file for `motion`, `useReducedMotion`, `AnimatePresence`, `framer-motion`, and `function Reveal` — confirm no dangling references and no leftover local `Reveal`. Then `npx tsc --noEmit` on the file's project must be clean.
+
+**Per-file map (from the verified inventory):**
+
+| File | Local Reveal usages | Other Framer kept? | framer-motion import after swap |
+|---|---|---|---|
+| KaribuAbout | 9 | none | **delete line** |
+| KaribuBlog | 4 | none | **delete line** |
+| KaribuCommunity | 2 | none | **delete line** |
+| KaribuEventDetail | 4 | none | **delete line** |
+| KaribuEvents | 4 | none | **delete line** |
+| KaribuJoin | 4 | none | **delete line** |
+| KaribuLearn | 3 | none | **delete line** |
+| KaribuProjects | 3 | none | **delete line** |
+| KaribuProjectsPage | 3 | none | **delete line** |
+| KaribuSubmitIdea | 2 | none | **delete line** |
+| KaribuSubmitProject | 2 | none | **delete line** |
+| KaribuTeam | 2 | none | **delete line** |
+| KaribuVolunteer | 3 | none | **delete line** |
+| KaribuFaq | 5 | `AnimatePresence` + accordion `motion.div` | keep `motion, AnimatePresence`; drop `useReducedMotion` **only if** unreferenced after swap — verify |
+| KaribuGallery | 4 | `motion.li` grid item | keep `motion`; drop `useReducedMotion` **only if** unreferenced — verify |
+| KaribuNewsletter | 2 | `AnimatePresence` swap | keep `motion, AnimatePresence`; drop `useReducedMotion` **only if** unreferenced — verify |
+| KaribuHome | 12 | hero `rise()` + scale `motion.div` | keep `motion, useReducedMotion` (both used by hero) |
+
+> For the four "keeps other Framer" files, **do not assume** — grep for `useReducedMotion(` and each `motion.`/`AnimatePresence` name after deleting `Reveal`, and keep exactly what's still referenced. The gate (`no-unused-vars`) will catch a miss.
+
+**Do NOT touch:** `KaribuBanner`, `KaribuModal`, `KaribuTestimonials` (no `Reveal`; keep their Framer imports).
+
+## Task 4: P1 batch A — subagent set 1 (6 files, no other Framer)
+
+**Files (Modify):** `KaribuAbout.tsx`, `KaribuBlog.tsx`, `KaribuCommunity.tsx`, `KaribuEventDetail.tsx`, `KaribuJoin.tsx`, `KaribuLearn.tsx`
+
+- [ ] **Step 1: Dispatch a Sonnet subagent** with the swap recipe above, scoped to exactly these 6 files. Each: add shared import, delete local `Reveal`, **delete** the `framer-motion` import line (all six have no other Framer usage). Subagent self-checks per file (grep + no dangling refs).
+- [ ] **Step 2: Lead reviews the diff** — confirm each file has the shared import, no local `Reveal`, no `framer-motion` import remaining, call sites unchanged.
+- [ ] **Step 3: Run the gate.** `npx tsc --noEmit` clean, then `npm run build` clean.
+- [ ] **Step 4: Commit.**
+```bash
+git add src/components/karibu/KaribuAbout.tsx src/components/karibu/KaribuBlog.tsx src/components/karibu/KaribuCommunity.tsx src/components/karibu/KaribuEventDetail.tsx src/components/karibu/KaribuJoin.tsx src/components/karibu/KaribuLearn.tsx
+git commit -m "refactor(karibu-motion): unify Reveal in about/blog/community/event-detail/join/learn"
+```
+
+## Task 5: P1 batch B — subagent set 2 (7 files, no other Framer)
+
+**Files (Modify):** `KaribuEvents.tsx`, `KaribuProjects.tsx`, `KaribuProjectsPage.tsx`, `KaribuSubmitIdea.tsx`, `KaribuSubmitProject.tsx`, `KaribuTeam.tsx`, `KaribuVolunteer.tsx`
+
+- [ ] **Step 1: Dispatch a Sonnet subagent** with the swap recipe, scoped to exactly these 7 files. All have no other Framer usage → **delete** the `framer-motion` import line in each. (`KaribuEvents` has the `delay` prop in its local def — dropping it is safe; no call site passes `delay`. Its FLIP work is a later P2 task, not here.)
+- [ ] **Step 2: Lead reviews the diff.**
+- [ ] **Step 3: Run the gate.** `npx tsc --noEmit` then `npm run build`, both clean.
+- [ ] **Step 4: Commit.**
+```bash
+git add src/components/karibu/KaribuEvents.tsx src/components/karibu/KaribuProjects.tsx src/components/karibu/KaribuProjectsPage.tsx src/components/karibu/KaribuSubmitIdea.tsx src/components/karibu/KaribuSubmitProject.tsx src/components/karibu/KaribuTeam.tsx src/components/karibu/KaribuVolunteer.tsx
+git commit -m "refactor(karibu-motion): unify Reveal in events/projects/projects-page/submit-idea/submit-project/team/volunteer"
+```
+
+## Task 6: P1 batch C — the 4 "keeps other Framer" files (lead-owned, careful)
+
+**Files (Modify):** `KaribuFaq.tsx`, `KaribuGallery.tsx`, `KaribuNewsletter.tsx`, `KaribuHome.tsx`
+
+These retain non-Reveal Framer usage; the import trim is per-file, not a blanket delete. **Lead does these directly** (not delegated) because the import surgery needs care.
+
+- [ ] **Step 1: `KaribuFaq.tsx`** — add shared import; delete local `Reveal`; keep the `AnimatePresence` + accordion `motion.div`. Import line becomes `import { motion, AnimatePresence } from "framer-motion";` **iff** `useReducedMotion(` no longer appears in the file (grep to confirm; if it's still used elsewhere, keep it).
+- [ ] **Step 2: `KaribuGallery.tsx`** — add shared import; delete local `Reveal`; keep `motion` (used by `motion.li`). Drop `useReducedMotion` from the import **iff** unreferenced after the swap (grep to confirm).
+- [ ] **Step 3: `KaribuNewsletter.tsx`** — add shared import; delete local `Reveal`; keep the `AnimatePresence` form/success swap. Import becomes `import { motion, AnimatePresence } from "framer-motion";` **iff** `useReducedMotion(` is gone (grep to confirm).
+- [ ] **Step 4: `KaribuHome.tsx`** — add shared import; delete **only** the local `Reveal` function (lines ~51–72). **Keep** `import { motion, useReducedMotion } from "framer-motion";` — both are still used by the hero `rise()` helper and the hero-visual scale `motion.div`. Leave the hero code untouched (it's a P2 concern).
+- [ ] **Step 5: Run the gate.** `npx tsc --noEmit` then `npm run build`, both clean. Grep each file: `grep -n "function Reveal\|framer-motion\|useReducedMotion" src/components/karibu/KaribuFaq.tsx src/components/karibu/KaribuGallery.tsx src/components/karibu/KaribuNewsletter.tsx src/components/karibu/KaribuHome.tsx` — confirm no local `Reveal` remains and every kept import is genuinely referenced.
+- [ ] **Step 6: Commit.**
+```bash
+git add src/components/karibu/KaribuFaq.tsx src/components/karibu/KaribuGallery.tsx src/components/karibu/KaribuNewsletter.tsx src/components/karibu/KaribuHome.tsx
+git commit -m "refactor(karibu-motion): unify Reveal in faq/gallery/newsletter/home (keep other Framer usage)"
+```
+
+## Task 7: P1 verification checkpoint
+
+- [ ] **Step 1: Confirm zero local Reveal defs remain.**
+Run: `grep -rn "function Reveal" src/components/karibu/`
+Expected: **no matches.**
+- [ ] **Step 2: Confirm every Reveal usage resolves to the shared import.**
+Run: `grep -rln "<Reveal" src/components/karibu/` then for each hit `grep -L "motion/Reveal" <file>` — expected: every file using `<Reveal` also imports from `@/components/karibu/motion/Reveal`.
+- [ ] **Step 3: Full gate.** `npm run build && npx tsc --noEmit` — both clean.
+- [ ] **Step 4: Push branch** (no PR yet) so a Vercel preview builds; note the preview URL for the P1 visual check (reveals fire once on scroll; content is visible with JS disabled — the degradation fix).
+
+---
+
+# Phase P2 — Through-line (highest-value motion)
+
+**Consult `frontend-design` before implementing the craft in this phase** (hover lifts, stagger timing, nav shrink feel). All motion here obeys the Global Constraints (transform/opacity only, reduced-motion instant, empty states never animate).
+
+## Task 8: Home — wire `CountUp` into the TrustBar
+
+**Files:** Modify `src/components/karibu/KaribuHome.tsx` (the `TrustBar` component, lines ~227–272).
+
+- [ ] **Step 1:** Import `CountUp`: `import { CountUp } from "@/components/ui/CountUp";`
+- [ ] **Step 2:** In `TrustBar`, for the numeric stat(s) that are currently plain strings (e.g. `~${stats.totalMembers}` and the city count), render the number via `<CountUp target={n} .../>` **only when a real number exists**; keep the "Growing"/"Kenya"/"100% free"/"Supported" fallbacks as plain text (never count up a non-number). `CountUp` already fires once on scroll (threshold 0.3) and respects reduced-motion — reuse as-is. Preserve the exact prefix (`~`) and the `font-newsreader text-[30px]` styling by passing `className`/`prefix`.
+- [ ] **Step 3: Gate.** `npx tsc --noEmit` + `npm run build` clean.
+- [ ] **Step 4: Commit** `feat(karibu-motion): count-up the home trust-bar stats`.
+
+## Task 9: Home — stagger the "four ways we learn" cards + hover lift
+
+**Files:** Modify `src/components/karibu/KaribuHome.tsx` (`WhatWeDo`, lines ~335–408).
+
+- [ ] **Step 1:** Currently the 4 `<article>` cards sit inside a single `<Reveal className="grid ...">`. Change so each card reveals with a staggered delay: either wrap each `<article>` in `<Reveal index={i}>` inside the grid, or keep the grid `<Reveal>` and give each article `data-reveal` + inline `--i`. Prefer per-card `<Reveal index={i}>` so the shared CSS stagger (`--i`, capped at 6) applies. Keep the grid layout classes on the container.
+- [ ] **Step 2:** Add a hover lift to each card via CSS utility classes only (`transition-transform duration-150 hover:-translate-y-1` with the existing `--ease-reversible` feel; use `motion-reduce:hover:translate-y-0` or rely on the global reduced-motion reset). Transform/opacity only — no shadow-size animation of layout.
+- [ ] **Step 3: Gate + commit** `feat(karibu-motion): stagger + hover-lift the home "what we do" cards`.
+
+## Task 10: Nav — sticky-shrink on scroll + "Join" hover scale
+
+**Files:** Modify `src/components/karibu/KaribuNav.tsx`.
+
+Note: the **dropdown fade-and-slide-down** (`translate-y-1 → 0`, opacity, `duration-150`) and **marquee pause-on-hover + reduced-motion stop** already exist and satisfy the spec — do **not** rebuild them; verify they still work.
+
+- [ ] **Step 1:** Add a `scrolled` boolean state driven by a passive `scroll` listener (past ~64px / hero). On scroll, toggle a class on the `<nav>` that (a) reduces height (`h-16` → `h-14`) and (b) strengthens the bg/blur/shadow — transition via `transition-[height,background-color,box-shadow] duration-200`. Use `useEffect` with `{ passive: true }` and clean up the listener.
+- [ ] **Step 2:** Add `hover:scale-[1.03]` (+ existing `hover:bg-clay-dark` tone shift) with `transition-transform duration-150` to the "Join" CTA(s) (desktop `/signup`). Keep the reduced-motion global reset in charge of disabling it.
+- [ ] **Step 3: Gate + commit** `feat(karibu-motion): sticky-shrink nav on scroll + join hover`.
+
+## Task 11: Events — FLIP filter transition (Framer `layout` + `AnimatePresence`)
+
+**Files:** Modify `src/components/karibu/KaribuEvents.tsx`.
+
+Re-introduces Framer here (removed in Task 5) — legitimate: this is the FLIP layout case Framer is kept for.
+
+- [ ] **Step 1:** Re-add `import { motion, AnimatePresence } from "framer-motion";`
+- [ ] **Step 2:** Wrap the filterable collections (the upcoming `ListRow` list and the `past` grid) so that when `active` changes, items animate position instead of hard-cutting: give each row/card a stable `layout` + `layoutId={ev.slug}`, wrap the mapped lists in `<AnimatePresence mode="popLayout">`, and convert the row/card wrapper to `motion.*`. Enter/exit = opacity + small y; reorder = `layout`. Respect reduced-motion (Framer honors it globally; also guard with `useReducedMotion` to pass `initial={false}` when reduced).
+- [ ] **Step 3:** The **empty-state** block (`upcoming.length === 0 && past.length === 0`) must **not** animate — render it instantly, outside any `AnimatePresence` entrance. Verify.
+- [ ] **Step 4: Gate + commit** `feat(karibu-motion): FLIP filter transitions on events`.
+
+## Task 12: Learn + Community — card hover lift + "Open →" arrow nudge
+
+**Files:** Modify `src/components/karibu/KaribuLearn.tsx`, `src/components/karibu/KaribuCommunity.tsx`.
+
+- [ ] **Step 1:** On the resource/community cards, add a hover lift (`hover:-translate-y-1`, `transition-transform duration-150`) and nudge the trailing "Open →" / arrow a few px right on card hover using a `group`/`group-hover:translate-x-1` on the arrow span with `transition-transform`. Transform/opacity only.
+- [ ] **Step 2: Gate + commit** `feat(karibu-motion): card hover-lift + arrow nudge on learn/community`.
+
+---
+
+# Phase P3 — Craft
+
+**Consult `frontend-design` before implementing.** Same Global Constraints.
+
+## Task 13: About — timeline scroll-linked line-draw + per-milestone reveal
+
+**Files:** Modify `src/components/karibu/KaribuAbout.tsx`.
+
+- [ ] **Step 1:** For the timeline, use Framer `useScroll` (target = the timeline container, `offset` start/end) to drive a vertical line's `scaleY` (transform-origin top) as the section scrolls through the viewport — scroll-linked draw. Per-milestone dots/labels reveal via the shared `Reveal` (or `useInView`) once. Add `import { motion, useScroll, useTransform } from "framer-motion";` Guard with `useReducedMotion` → render the line fully drawn, no scroll link, when reduced.
+- [ ] **Step 2:** Story blocks keep simple `Reveal` fade-up (already there). Organiser faces: soft hover `scale` **inside a fixed frame** (`overflow-hidden` wrapper so layout doesn't shift) — `group-hover:scale-105` on the image, `transition-transform`.
+- [ ] **Step 3: Gate + commit** `feat(karibu-motion): about timeline scroll-draw + milestone reveals`.
+
+## Task 14: Learn — "Suggested Path" sequential 1-2-3 reveal + progress indicator
+
+**Files:** Modify `src/components/karibu/KaribuLearn.tsx`.
+
+- [ ] **Step 1:** The "Suggested Path" steps reveal sequentially using the shared `Reveal index={i}` stagger. Add a progress indicator (a line/track) that animates its `scaleX`/`scaleY` on scroll-into-view (CSS `.in-view`-driven transform or a small `useInView`), one-time. Transform/opacity only; reduced-motion → fully shown instantly.
+- [ ] **Step 2: Gate + commit** `feat(karibu-motion): learn suggested-path sequential reveal + progress`.
+
+## Task 15: Community — upvote scale-pop + copy-confirm checkmark + "Share something" CTA hover
+
+**Files:** Modify `src/components/karibu/KaribuCommunity.tsx` (and, if the upvote/copy controls live in `src/components/community/UpvoteButton.tsx` / `CopyButton.tsx`, confirm scope first — those are shared with Terminal Noir; only touch the Karibu surface unless the interaction is Karibu-only).
+
+- [ ] **Step 1:** Upvote → quick `scale` pop on activation (CSS `:active`/state-driven `scale(1.15)` back to `1`, `transition-transform var(--dur-micro)`). Copy-confirmation → checkmark morph (swap icon with a short opacity/scale transition on the confirmed state). "Share something" primary CTA mirrors the primary-CTA hover from Task 10 (`hover:scale-[1.03]` + tone shift).
+- [ ] **Step 2:** Verify these are Karibu-scoped; if a shared component is edited, re-run the gate against both identities and note it at the PR.
+- [ ] **Step 3: Gate + commit** `feat(karibu-motion): community upvote/copy micro-interactions + CTA hover`.
+
+## Task 16: Team — grid reveal only once populated (no animation while "coming soon")
+
+**Files:** Modify `src/components/karibu/KaribuTeam.tsx`.
+
+- [ ] **Step 1:** While the team is empty / "coming soon", render that state **instantly** — no reveal, no stagger (Global Constraint: never animate attention onto "nothing here"). Once populated, apply a gentle staggered grid reveal (`Reveal index={i}`) + per-card hover (`hover:-translate-y-1`, and face `scale` inside a fixed frame). Gate the animation on `members.length > 0`.
+- [ ] **Step 2: Gate + commit** `feat(karibu-motion): team grid reveal + hover once populated`.
+
+---
+
+# Final: PR gate
+
+## Task 17: Full verification + PR (ASK first)
+
+- [ ] **Step 1: Full build gate.** `npm run build && npx tsc --noEmit` — both clean.
+- [ ] **Step 2: Invoke `superpowers:verification-before-completion`** — do not claim done without evidence.
+- [ ] **Step 3: Visual verification on the Vercel preview** (no live DB locally): reveals fire once on scroll and content is visible with JS disabled; reduced-motion path is instant and marquee stops; hero stagger; count-up; nav shrink + dropdowns + Join hover; Events FLIP with the empty state instant; hover lifts + arrow nudges; About timeline draw; Team "coming soon" does not animate.
+- [ ] **Step 4: ASK the user before opening the PR.** When opening it, **flag the carried-forward sign-offs** (not blockers): (1) testimonial name spellings in `KaribuTestimonials.tsx` — Billy Mwangi, Samuel, James Lloyd, Isaac Toili / Tuigoin; (2) `/join` application-form decision (WhatsApp-first vs form returns). Also flag any shared `community/*` component touched in Task 15.
+
+---
+
+## Self-Review (author checklist — done)
+
+**Spec coverage:** §2 bug → Tasks 1–7 (CSS-first reveal + `.js` + observer + full swap). §3.1 tokens/bootstrap → Tasks 1–2. §3.2 shared util/observer/stagger → Task 3 (+ stagger CSS in Task 1, `index` prop). §3.3 swap 20/17 → Tasks 4–7. §4 P2 Home/Nav/Events/Learn/Community → Tasks 8–12. §4 P3 About/Learn/Community/Team → Tasks 13–16. §5 non-negotiables → Global Constraints + per-task empty-state guards. §6 Framer-kept surfaces → Tasks 11 (Events FLIP), 6/9 (Home hero kept), 13 (About). §7 gate/preview → Global Constraints + Task 17. §8 sign-offs → Task 17 Step 4.
+
+**Placeholder scan:** foundation/P1 tasks carry exact code and exact import surgery per file. P2/P3 tasks specify exact files, exact spec values (durations, transforms, which states must stay instant), and the concrete mechanism — with `frontend-design` consultation for feel, as the spec intends ("craft"). No "add error handling"/"TBD" left.
+
+**Type consistency:** `register`/`unregister`/`Reveal({children,className,index})` names are identical across the Interfaces block, Task 3, and every consumer. Import path `@/components/karibu/motion/Reveal` is uniform.
+
+**Known scope note:** spec §3.3 lists 20 files but only **17** define a local `Reveal` (Banner/Modal/Testimonials use Framer for other things and have no `Reveal`). The plan swaps the real 17 and explicitly leaves the other 3 untouched — matching the verified inventory, not the spec's round number.

--- a/docs/superpowers/specs/2026-07-09-karibu-motion-layer-design.md
+++ b/docs/superpowers/specs/2026-07-09-karibu-motion-layer-design.md
@@ -1,0 +1,101 @@
+# Karibu Motion Layer — Design Spec
+
+**Date:** 2026-07-09
+**Repo:** `Claude-Community-Kenya` (Next.js 16 App Router, TS strict, Tailwind v4, Framer Motion)
+**Branch:** `redesign/karibu-motion` (cut off `redesign/karibu-darkmode` / PR #36; rebase onto `main` after #36 merges)
+**Status:** Approved design → next step is `writing-plans`.
+
+---
+
+## 1. Goal
+
+Add a restrained, premium motion layer across the warm-light "Karibu" pages, and — the central fix — **eliminate the reveal-degradation bug** so animation *enhances an already-legible page* instead of gating legibility behind a trigger that can fail.
+
+Guiding rule (from Peter's spec): motion must either **clarify** (show relationships, state, hierarchy) or **reward** (a small delight on a key action) — never decorate. On a content-thin site, restrained motion reads premium; busy motion reads like it's hiding emptiness.
+
+## 2. The bug being fixed
+
+Every Karibu component defines its own local `Reveal` using Framer Motion `whileInView` with `initial={{ opacity: 0, y: 18 }}` (20 files, 77 occurrences). The `initial`-hidden state is baked into the rendered output, so **if hydration/JS fails, content is stuck invisible** (the old `ScrollReveal` variant stuck at ~30% opacity on Resources). Reduced-motion is already handled per-component (`initial={reduce ? false : ...}`), but the normal path is the degradation surface.
+
+**Fix:** rebuild the reveal **CSS-first** — content is fully visible by default; a JS-added class *introduces* the hidden→visible transition. No JS → no class → content stays visible. Degrade-safe by construction.
+
+## 3. Architecture — CSS-first hybrid (approved)
+
+Framer Motion is kept **only** where it genuinely earns it (FLIP layout, hero orchestration, scroll-linked timeline). Everything else is CSS-first. `CountUp` is reused as-is.
+
+### 3.1 Foundation — `globals.css` + one bootstrap line
+
+**Motion tokens** (`:root`):
+- `--ease-entrance: cubic-bezier(.16, 1, .3, 1)` — confident ease-out for entrances
+- `--ease-reversible: cubic-bezier(.4, 0, .2, 1)` — symmetric, for hovers/reversible states
+- `--dur-micro: 150ms` (hover/press), `--dur-reveal: 320ms` (entrances/reveals), `--dur-hero: 500ms` (large hero/page)
+- `--reveal-shift: 18px`
+
+**`.js` bootstrap:** extend the **existing** before-paint `<head>` IIFE in `src/app/layout.tsx` (currently sets `data-theme`) with `document.documentElement.classList.add('js')`. Runs before first paint → no flash. This class is the switch that makes reveals degrade-safe.
+
+### 3.2 Shared reveal utility → `src/components/karibu/motion/`
+
+- **`Reveal.tsx`** — thin client wrapper rendering `<div data-reveal>` (props: `as`, `className`, `children`, optional `stagger`). Visible by default. On mount, registers the element with a **single shared IntersectionObserver singleton** (`observer.ts`) — not one observer per element. On first intersect: add `.in-view`, then unobserve (one-time). Honors reduced-motion via CSS (no JS branch needed).
+- **`observer.ts`** — module-level singleton IntersectionObserver + a `register(el)` / `unregister(el)` API. `viewport` margin `0px 0px -6% 0px`, threshold ~0.
+
+**CSS (the degrade-safe core, in `globals.css`):**
+```css
+[data-reveal] { opacity: 1; }                       /* default: fully visible */
+.js [data-reveal] {
+  opacity: 0;
+  transform: translateY(var(--reveal-shift));
+  transition: opacity var(--dur-reveal) var(--ease-entrance),
+              transform var(--dur-reveal) var(--ease-entrance);
+  will-change: opacity, transform;
+}
+.js [data-reveal].in-view { opacity: 1; transform: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .js [data-reveal] { opacity: 1; transform: none; transition: none; }  /* instant */
+}
+```
+
+**Stagger:** a `data-reveal-stagger` parent sets each child's `transition-delay: calc(var(--i, 0) * 60ms)`, **capped at 6 steps** (`--i` clamped) so long lists don't cascade forever. Applied via a small `RevealGroup` helper or inline `--i` on children.
+
+### 3.3 Replace all 20 local `Reveal` defs with the shared one (DRY)
+
+Single swap fixes the degradation bug site-wide and removes duplication. Files:
+`KaribuAbout, KaribuBanner, KaribuBlog, KaribuCommunity, KaribuEventDetail, KaribuEvents, KaribuFaq, KaribuHome, KaribuGallery, KaribuJoin, KaribuLearn, KaribuModal, KaribuNewsletter, KaribuProjects, KaribuProjectsPage, KaribuSubmitIdea, KaribuTeam, KaribuTestimonials, KaribuSubmitProject, KaribuVolunteer`.
+
+## 4. Build phases
+
+| Phase | Scope |
+|---|---|
+| **P0 Foundation** | Motion tokens, `.js` bootstrap, shared `Reveal` + `observer` singleton + CSS + stagger helper. |
+| **P1 Unify** | Swap all 20 local `Reveal` defs → shared. Fixes the degradation bug everywhere. Mechanical → delegate to Sonnet subagents on **disjoint files**; lead owns `globals.css`, the shared util, and the build gate. |
+| **P2 Through-line** | Highest-value motion: <br>• **Home** — hero stagger (eyebrow→headline→subhead→buttons, ~400ms), wire existing `CountUp` to the stat row (once-on-scroll), 4 "ways we learn" cards staggered fade-up + hover lift. <br>• **Nav** — sticky-header shrink + soft bg/blur past hero (~200ms); dropdowns fade-and-slide-down 4–8px (150–200ms); "Join" hover (scale ~1.03 + tone shift); marquee pause-on-hover + reduced-motion stop. <br>• **Events** — filter transitions as **FLIP** layout animation (Framer `layout` + `AnimatePresence`) instead of hard-cut; card hover lift + date-badge accent. <br>• **Learn/Community** — card hover lift + **"Open →" arrow nudge** a few px right. |
+| **P3 Craft** | • **About** — timeline scroll-linked line-draw + per-milestone reveal (Framer `useScroll`/`useInView`); story blocks simple fade-up; organiser faces soft hover (scale inside fixed frame). <br>• **Learn** — "Suggested Path" 1-2-3 steps reveal sequentially + progress indicator animating on scroll. <br>• **Community** — upvote quick scale-pop; copy-confirmation checkmark-morph; "Share something" mirrors primary-CTA hover. <br>• **Team** — **not animated** while "coming soon"; gentle staggered grid reveal + per-card hover only once populated. |
+
+## 5. Non-negotiables (baked into every phase)
+
+- **`prefers-reduced-motion`** → replace all movement with instant/opacity; marquee stops entirely.
+- Animate **only `transform` / `opacity`** (GPU-friendly).
+- Scroll reveals are **one-time** (unobserve after first fire).
+- **Never gate legibility** behind an entrance. Empty / error / read-quickly states appear **instantly** — never animate attention onto "nothing here".
+- **No hero parallax** (mobile-first community). No looping attention motion except the single marquee.
+- Do **not** animate body paragraphs / long text.
+
+## 6. What Framer Motion is kept for
+
+FLIP filter transitions (Events), hero stagger orchestration (Home), scroll-linked timeline draw (About). All other reveals/hovers/micro-interactions are CSS-first. `src/components/ui/CountUp.tsx` reused unchanged.
+
+## 7. Workflow / logistics
+
+- **Branch:** `redesign/karibu-motion` off `redesign/karibu-darkmode`. Rebase onto `main` after PR #36 merges.
+- **Gate:** `npm run build && npx tsc --noEmit` must both be clean before every commit. Conventional commits. Never commit to `main`. Auto-commit at logical checkpoints; **ask before opening/merging PRs**.
+- **Verification:** no live DB locally (Supabase host unreachable) → verify motion visually on the **Vercel preview** of the PR, not just build/tsc.
+- **Delegation:** P1 file swap → parallel Sonnet subagents on disjoint files. Lead (Opus) owns foundation, shared util, `globals.css`, build, and commits.
+
+## 8. Open sign-offs carried forward (not blockers for motion, but flag at PR)
+
+1. Testimonial name spellings in `KaribuTestimonials.tsx` (Billy Mwangi, Samuel, James Lloyd, Isaac Toili / Tuigoin).
+2. `/join` application-form decision (WhatsApp-first vs form returns).
+
+## 9. Out of scope
+
+Un-converted dark sub-pages (`resources/*` guides, `community/[slug]`, `community/submit`, `blog/[slug]`, `newsletter/[slug]`) — a later conversion batch, not part of the motion layer.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,6 +55,14 @@
   --sand-2: #DDD3C2;
   --font-newsreader-stack: var(--font-newsreader), ui-serif, Georgia, serif;
   --font-inter-stack: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+
+  /* ─── Motion tokens (Karibu motion layer) ─── */
+  --ease-entrance: cubic-bezier(0.16, 1, 0.3, 1); /* confident ease-out for entrances */
+  --ease-reversible: cubic-bezier(0.4, 0, 0.2, 1); /* symmetric, for hovers/reversible states */
+  --dur-micro: 150ms; /* hover / press */
+  --dur-reveal: 320ms; /* entrances / reveals */
+  --dur-hero: 500ms; /* large hero / page */
+  --reveal-shift: 18px;
 }
 
 @theme inline {
@@ -607,6 +615,37 @@ body::before {
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+}
+
+/* ─── Karibu degrade-safe reveal ──────────────────────────────────────────
+ * Content is fully visible by default. The before-paint `.js` class (set in
+ * layout.tsx) introduces the hidden→visible transition; a shared observer
+ * adds `.in-view` once per element. No JS → no `.js` → content stays visible.
+ * Only opacity/transform animate. Reduced-motion → instant + always visible. */
+[data-reveal] {
+  opacity: 1;
+}
+.js [data-reveal] {
+  opacity: 0;
+  transform: translateY(var(--reveal-shift));
+  transition:
+    opacity var(--dur-reveal) var(--ease-entrance),
+    transform var(--dur-reveal) var(--ease-entrance);
+  transition-delay: calc(min(var(--i, 0), 5) * 60ms); /* stagger, capped at 6 steps */
+  will-change: opacity, transform;
+}
+.js [data-reveal].in-view {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .js [data-reveal] {
+    opacity: 1;
+    transform: none;
+    transition: none;
+    transition-delay: 0ms;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -649,6 +649,26 @@ body::before {
   }
 }
 
+/* Scroll-drawn progress line (degrade-safe): the parent is the static track;
+ * this fill scales from the left on first intersect (same shared observer as
+ * [data-reveal]). No JS → full width. Reduced-motion → instant full. */
+[data-progress] {
+  transform-origin: left;
+}
+.js [data-progress] {
+  transform: scaleX(0);
+  transition: transform var(--dur-hero) var(--ease-entrance);
+}
+.js [data-progress].in-view {
+  transform: scaleX(1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .js [data-progress] {
+    transform: none;
+    transition: none;
+  }
+}
+
 /* ─── Karibu identity (warm-light redesign) ─────────────────────────────
  * Scoped base + animation loops for the page-by-page overhaul. Applied via
  * the .karibu wrapper so it never leaks onto Terminal Noir pages. The global

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -221,14 +221,17 @@ export default async function RootLayout({
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
-        {/* Karibu theme init — runs before paint to avoid a light/dark flash.
-         * Only sets data-theme when the visitor has made an explicit choice
-         * via KaribuThemeToggle; absent that, the CSS prefers-color-scheme
-         * media query in globals.css handles the system default. */}
+        {/* Karibu theme + motion init — runs before paint.
+         * 1. Adds `.js` to <html> so the degrade-safe reveal CSS (globals.css)
+         *    activates its hidden→visible transition. No JS → no `.js` →
+         *    content stays fully visible (no legibility gated behind motion).
+         * 2. Sets data-theme only when the visitor made an explicit choice via
+         *    KaribuThemeToggle; absent that, the CSS prefers-color-scheme media
+         *    query in globals.css handles the system default. */}
         <script
           dangerouslySetInnerHTML={{
             __html:
-              "(function(){try{var t=localStorage.getItem('cck-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}})();",
+              "(function(){document.documentElement.classList.add('js');try{var t=localStorage.getItem('cck-theme');if(t==='dark'||t==='light'){document.documentElement.setAttribute('data-theme',t);}}catch(e){}})();",
           }}
         />
       </head>

--- a/src/components/karibu/KaribuAbout.tsx
+++ b/src/components/karibu/KaribuAbout.tsx
@@ -10,10 +10,10 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
 import type { CommunityStats } from "@/components/sections/HeroTerminal";
 import type { TeamMemberView } from "@/lib/data";
 import { SOCIAL_LINKS } from "@/lib/constants";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -23,21 +23,6 @@ interface TimelineEntry {
   title: string;
   description: string;
   hash: string;
-}
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
 }
 
 const VALUES = [

--- a/src/components/karibu/KaribuAbout.tsx
+++ b/src/components/karibu/KaribuAbout.tsx
@@ -8,8 +8,10 @@
  * redesigned, not removed. All content is DB-backed (team + past events + stats).
  */
 
+import { useRef } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { motion, useScroll, useTransform, useReducedMotion } from "framer-motion";
 import type { CommunityStats } from "@/components/sections/HeroTerminal";
 import type { TeamMemberView } from "@/lib/data";
 import { SOCIAL_LINKS } from "@/lib/constants";
@@ -159,24 +161,7 @@ export function KaribuAbout({
               How we got here
             </div>
           </Reveal>
-          <Reveal>
-            <ol className="relative border-l border-sand pl-6">
-              {timelineEntries.map((t) => (
-                <li key={t.hash} className="mb-7 last:mb-0">
-                  <span className="absolute -left-[7px] mt-1.5 h-3.5 w-3.5 rounded-full border-2 border-paper bg-clay" />
-                  <div className="font-inter text-[12.5px] font-semibold uppercase tracking-[0.06em] text-clay">
-                    {t.date}
-                  </div>
-                  <div className="font-newsreader text-[20px] text-ink">{t.title}</div>
-                  {t.description && (
-                    <p className="mt-1 max-w-2xl font-inter text-[14.5px] leading-[1.55] text-ink-soft">
-                      {t.description}
-                    </p>
-                  )}
-                </li>
-              ))}
-            </ol>
-          </Reveal>
+          <Timeline entries={timelineEntries} />
         </section>
       )}
 
@@ -211,6 +196,50 @@ function Stat({ big, label }: { big: string; label: string }) {
   );
 }
 
+/**
+ * Community timeline with a scroll-linked clay line-draw. The static sand
+ * border is the always-visible track (degrade-safe); the clay overlay draws
+ * as the list scrolls through the viewport and is omitted under reduced
+ * motion. Each milestone reveals once via the shared degrade-safe Reveal.
+ */
+function Timeline({ entries }: { entries: TimelineEntry[] }) {
+  const reduce = useReducedMotion();
+  const ref = useRef<HTMLOListElement>(null);
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start 85%", "end 55%"],
+  });
+  const scaleY = useTransform(scrollYProgress, [0, 1], [0, 1]);
+
+  return (
+    <ol ref={ref} className="relative border-l border-sand pl-6">
+      {!reduce && (
+        <motion.span
+          aria-hidden="true"
+          style={{ scaleY, transformOrigin: "top" }}
+          className="pointer-events-none absolute -left-px top-0 h-full w-px bg-clay"
+        />
+      )}
+      {entries.map((t, i) => (
+        <li key={t.hash} className="mb-7 last:mb-0">
+          <span className="absolute -left-[7px] mt-1.5 h-3.5 w-3.5 rounded-full border-2 border-paper bg-clay" />
+          <Reveal index={i}>
+            <div className="font-inter text-[12.5px] font-semibold uppercase tracking-[0.06em] text-clay">
+              {t.date}
+            </div>
+            <div className="font-newsreader text-[20px] text-ink">{t.title}</div>
+            {t.description && (
+              <p className="mt-1 max-w-2xl font-inter text-[14.5px] leading-[1.55] text-ink-soft">
+                {t.description}
+              </p>
+            )}
+          </Reveal>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
 function TeamCard({ member }: { member: TeamMemberView }) {
   const initials = member.name
     .split(" ")
@@ -219,7 +248,7 @@ function TeamCard({ member }: { member: TeamMemberView }) {
     .slice(0, 2)
     .toUpperCase();
   return (
-    <div>
+    <div className="group">
       <div className="mb-3 flex aspect-square items-center justify-center overflow-hidden rounded-xl bg-sand">
         {member.avatar ? (
           <Image
@@ -227,7 +256,7 @@ function TeamCard({ member }: { member: TeamMemberView }) {
             alt={member.name}
             width={220}
             height={220}
-            className="h-full w-full object-cover"
+            className="h-full w-full object-cover transition-transform duration-300 ease-[var(--ease-reversible)] group-hover:scale-105"
           />
         ) : (
           <span className="font-newsreader text-[34px] text-ink-muted">{initials}</span>

--- a/src/components/karibu/KaribuBlog.tsx
+++ b/src/components/karibu/KaribuBlog.tsx
@@ -9,28 +9,13 @@
  */
 
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
 import { Calendar, Clock, User } from "lucide-react";
 import type { BlogPostView } from "@/lib/data";
 import { formatDate } from "@/lib/utils";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 function PostMeta({ post }: { post: BlogPostView }) {
   return (

--- a/src/components/karibu/KaribuCommunity.tsx
+++ b/src/components/karibu/KaribuCommunity.tsx
@@ -10,9 +10,9 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { motion, useReducedMotion } from "framer-motion";
 import { ArrowUp, ExternalLink, Github, Plus } from "lucide-react";
 import type { CommunitySubmissionView } from "@/lib/data";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -36,21 +36,6 @@ const TYPE_LABEL: Record<CommunitySubmissionView["type"], string> = {
   WORKFLOW: "Workflow",
   TOOL: "Tool",
 };
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuCommunity({
   items,

--- a/src/components/karibu/KaribuCommunity.tsx
+++ b/src/components/karibu/KaribuCommunity.tsx
@@ -76,7 +76,7 @@ export function KaribuCommunity({
             </div>
             <Link
               href="/community/submit"
-              className="inline-flex items-center gap-2 rounded-full bg-clay px-5 py-3 font-inter text-sm font-semibold text-paper-card transition-colors hover:bg-clay-dark"
+              className="inline-flex items-center gap-2 rounded-full bg-clay px-5 py-3 font-inter text-sm font-semibold text-paper-card transition-[background-color,transform] duration-150 ease-[var(--ease-reversible)] hover:scale-[1.03] hover:bg-clay-dark"
             >
               <Plus className="h-4 w-4" /> Share something
             </Link>

--- a/src/components/karibu/KaribuCommunity.tsx
+++ b/src/components/karibu/KaribuCommunity.tsx
@@ -161,7 +161,7 @@ function ResourceCard({ submission }: { submission: CommunitySubmissionView }) {
   return (
     <Link
       href={`/community/${submission.slug}`}
-      className="group flex h-full flex-col rounded-2xl border border-sand bg-paper-card p-6 transition-colors hover:border-clay"
+      className="group flex h-full flex-col rounded-2xl border border-sand bg-paper-card p-6 transition-[transform,border-color] duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1 hover:border-clay"
       aria-label={`${submission.title} — ${TYPE_LABEL[submission.type]}`}
     >
       <div className="mb-3">

--- a/src/components/karibu/KaribuEventDetail.tsx
+++ b/src/components/karibu/KaribuEventDetail.tsx
@@ -12,7 +12,6 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
 import { Twitter, Linkedin, Link as LinkIcon } from "lucide-react";
 import type { Event } from "@/lib/types";
 import type { DemoRequestView, PhotoView } from "@/lib/data";
@@ -20,6 +19,7 @@ import { SOCIAL_LINKS } from "@/lib/constants";
 import { PhotoLightbox } from "@/components/gallery/PhotoLightbox";
 import { KaribuDemoRequestForm } from "@/components/karibu/KaribuDemoRequestForm";
 import { eventCover } from "@/components/karibu/photos";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 
@@ -52,21 +52,6 @@ function parseDate(d: string): Date | null {
   return Number.isNaN(dt.getTime()) ? null : dt;
 }
 const fmt = (dt: Date, opts: Intl.DateTimeFormatOptions) => dt.toLocaleString("en-US", opts);
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuEventDetail({
   event,

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -12,10 +12,10 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
 import type { Event } from "@/lib/types";
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { eventCover } from "@/components/karibu/photos";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 
@@ -40,30 +40,6 @@ function parseDate(d: string): Date | null {
 }
 const fmt = (dt: Date, opts: Intl.DateTimeFormatOptions) =>
   dt.toLocaleString("en-US", opts);
-
-/** Reveal-on-scroll wrapper; inert under prefers-reduced-motion. */
-function Reveal({
-  children,
-  className,
-  delay = 0,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  delay?: number;
-}) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1], delay }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 type Filter = { key: string; label: string };
 

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -12,12 +12,14 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import type { Event } from "@/lib/types";
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { eventCover } from "@/components/karibu/photos";
 import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+const FLIP_EASE = [0.16, 1, 0.3, 1] as const;
 
 const TYPE_LABEL: Record<Event["type"], string> = {
   meetup: "Meetup",
@@ -45,6 +47,18 @@ type Filter = { key: string; label: string };
 
 export function KaribuEvents({ events }: { events: Event[] }) {
   const [active, setActive] = useState("all");
+  const reduce = useReducedMotion();
+
+  // Filtering re-orders events in place (FLIP) rather than hard-cutting, so the
+  // relationship between the old and new list stays legible. Reduced-motion
+  // skips the enter/exit offset; Framer disables the layout tween globally.
+  const flip = {
+    layout: true,
+    initial: reduce ? false : { opacity: 0, y: 8 },
+    animate: { opacity: 1, y: 0 },
+    exit: reduce ? { opacity: 0 } : { opacity: 0, y: -8 },
+    transition: { duration: 0.28, ease: FLIP_EASE },
+  } as const;
 
   // Build chips from real data: All + present cities + present types.
   const filters = useMemo<Filter[]>(() => {
@@ -138,9 +152,13 @@ export function KaribuEvents({ events }: { events: Event[] }) {
             <div className="mb-2 border-b border-sand pb-3 font-inter text-xs font-bold uppercase tracking-[0.14em] text-[#8A7F6E]">
               {bandLabel}
             </div>
-            {rest.map((ev) => (
-              <ListRow key={ev.slug} event={ev} />
-            ))}
+            <AnimatePresence mode="popLayout" initial={false}>
+              {rest.map((ev) => (
+                <motion.div key={ev.slug} {...flip}>
+                  <ListRow event={ev} />
+                </motion.div>
+              ))}
+            </AnimatePresence>
           </Reveal>
         </section>
       )}
@@ -172,9 +190,13 @@ export function KaribuEvents({ events }: { events: Event[] }) {
               Past · picha
             </div>
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {past.map((ev, i) => (
-                <PastCard key={ev.slug} event={ev} index={i} />
-              ))}
+              <AnimatePresence mode="popLayout" initial={false}>
+                {past.map((ev, i) => (
+                  <motion.div key={ev.slug} {...flip}>
+                    <PastCard event={ev} index={i} />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
             </div>
           </Reveal>
         </section>

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -50,10 +50,12 @@ export function KaribuEvents({ events }: { events: Event[] }) {
   const reduce = useReducedMotion();
 
   // Filtering re-orders events in place (FLIP) rather than hard-cutting, so the
-  // relationship between the old and new list stays legible. Reduced-motion
-  // skips the enter/exit offset; Framer disables the layout tween globally.
+  // relationship between the old and new list stays legible. Under reduced
+  // motion we drop the layout tween AND the enter/exit offset entirely (Framer
+  // defaults to reducedMotion:"never", so it will NOT do this for us) — items
+  // just cross-fade, no movement.
   const flip = {
-    layout: true,
+    layout: !reduce,
     initial: reduce ? false : { opacity: 0, y: 8 },
     animate: { opacity: 1, y: 0 },
     exit: reduce ? { opacity: 0 } : { opacity: 0, y: -8 },

--- a/src/components/karibu/KaribuFaq.tsx
+++ b/src/components/karibu/KaribuFaq.tsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import { ChevronDown, MessageSquare, Search, X } from "lucide-react";
 import { SOCIAL_LINKS, CONTACT } from "@/lib/constants";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 import type { FAQ } from "@/data/faq";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
@@ -21,21 +22,6 @@ export interface FaqCategory {
   key: string;
   label: string;
   command: string;
-}
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
 }
 
 function FaqItem({ faq, isOpen, onToggle }: { faq: FAQ; isOpen: boolean; onToggle: () => void }) {

--- a/src/components/karibu/KaribuGallery.tsx
+++ b/src/components/karibu/KaribuGallery.tsx
@@ -9,12 +9,13 @@
 
 import { useState, useMemo } from "react";
 import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
+import { motion } from "framer-motion";
 import { Camera } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { PhotoView } from "@/lib/data";
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { PhotoLightbox } from "@/components/gallery/PhotoLightbox";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -32,21 +33,6 @@ interface KaribuGalleryProps {
   photos: PhotoView[];
   eventChips?: EventChip[];
   initialFilter?: string | null;
-}
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
 }
 
 export function KaribuGallery({ photos, eventChips = [], initialFilter = null }: KaribuGalleryProps) {

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -24,6 +24,7 @@ import { rank, type Recommendable } from "@/lib/recommendations";
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { Marquee } from "@/components/karibu/Marquee";
 import { Reveal } from "@/components/karibu/motion/Reveal";
+import { CountUp } from "@/components/ui/CountUp";
 import { KaribuTestimonials } from "@/components/karibu/KaribuTestimonials";
 import { KaribuProjects } from "@/components/karibu/KaribuProjects";
 import { HERO_PHOTO, GALLERY_PHOTOS, eventCover } from "@/components/karibu/photos";
@@ -208,9 +209,15 @@ function TrustBar({
   stats?: CommunityStats;
   cities: string[];
 }) {
-  const items = [
+  const items: { big: React.ReactNode; small: string }[] = [
     {
-      big: stats?.totalMembers ? `~${stats.totalMembers.toLocaleString()}` : "Growing",
+      // Count up only the members figure — it's the one number that rewards
+      // watching it climb. City count (1–2) would read as filler animated.
+      big: stats?.totalMembers ? (
+        <CountUp target={stats.totalMembers} prefix="~" />
+      ) : (
+        "Growing"
+      ),
       small: "members & growing",
     },
     {
@@ -319,67 +326,81 @@ function WhatWeDo() {
         </h2>
       </Reveal>
 
-      <Reveal className="grid gap-4 md:grid-cols-3 md:grid-rows-2">
+      {/* Each card reveals on its own staggered delay (--i, capped at 6 steps)
+       * and lifts 4px on hover. The grid-span classes live on the Reveal so it
+       * is the grid item; the article fills it with h-full. */}
+      <div className="grid gap-4 md:grid-cols-3 md:grid-rows-2">
         {/* 01 — tall */}
-        <article className="flex flex-col justify-between rounded-2xl border border-sand bg-paper-card p-7 md:row-span-2">
-          <div className="font-mono text-xs tracking-[0.06em] text-clay">01</div>
-          <div>
-            <h3 className="mb-2.5 font-newsreader text-[27px] text-ink">
-              Events &amp; meetups
-            </h3>
-            <p className="font-inter text-[15px] leading-[1.55] text-ink-soft">
-              Regular in-person gatherings across our cities — live demos,
-              project showcases, and the hallway conversations that start real
-              projects.
-            </p>
-          </div>
-        </article>
+        <Reveal index={0} className="md:row-span-2">
+          <article className="flex h-full flex-col justify-between rounded-2xl border border-sand bg-paper-card p-7 transition-transform duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1">
+            <div className="font-mono text-xs tracking-[0.06em] text-clay">01</div>
+            <div>
+              <h3 className="mb-2.5 font-newsreader text-[27px] text-ink">
+                Events &amp; meetups
+              </h3>
+              <p className="font-inter text-[15px] leading-[1.55] text-ink-soft">
+                Regular in-person gatherings across our cities — live demos,
+                project showcases, and the hallway conversations that start real
+                projects.
+              </p>
+            </div>
+          </article>
+        </Reveal>
 
         {/* 02 */}
-        <article className="rounded-2xl border border-sand bg-paper-card p-6">
-          <div className="mb-8 font-mono text-xs tracking-[0.06em] text-clay">02</div>
-          <h3 className="mb-2 font-newsreader text-[22px] text-ink">
-            Hands-on workshops
-          </h3>
-          <p className="font-inter text-sm leading-[1.5] text-ink-soft">
-            Deep dives on Claude Code, agentic patterns and shipping real apps.
-          </p>
-        </article>
-
-        {/* 03 — clay */}
-        <article className="rounded-2xl bg-clay p-6 text-paper-card">
-          <div className="mb-8 font-mono text-xs tracking-[0.06em] text-clay-light">
-            03
-          </div>
-          <h3 className="mb-2 font-newsreader text-[22px]">Online community</h3>
-          <p className="font-inter text-sm leading-[1.5] text-[#F5E4DB]">
-            WhatsApp &amp; Discord — questions answered daily, wins shared
-            nightly.
-          </p>
-        </article>
-
-        {/* 04 — wide */}
-        <article className="flex items-center gap-6 rounded-2xl border border-sand bg-paper-card p-6 md:col-span-2">
-          <div className="flex-1">
-            <div className="mb-2.5 font-mono text-xs tracking-[0.06em] text-clay">
-              04
-            </div>
+        <Reveal index={1}>
+          <article className="h-full rounded-2xl border border-sand bg-paper-card p-6 transition-transform duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1">
+            <div className="mb-8 font-mono text-xs tracking-[0.06em] text-clay">02</div>
             <h3 className="mb-2 font-newsreader text-[22px] text-ink">
-              Learn with Claude
+              Hands-on workshops
             </h3>
             <p className="font-inter text-sm leading-[1.5] text-ink-soft">
-              Shared guides, prompts and starter projects pitched for every
-              level — from your first prompt to production.
+              Deep dives on Claude Code, agentic patterns and shipping real apps.
             </p>
-          </div>
-          <Link
-            href="/resources"
-            className="shrink-0 whitespace-nowrap font-inter text-sm font-semibold text-clay hover:underline"
-          >
-            Explore resources →
-          </Link>
-        </article>
-      </Reveal>
+          </article>
+        </Reveal>
+
+        {/* 03 — clay */}
+        <Reveal index={2}>
+          <article className="h-full rounded-2xl bg-clay p-6 text-paper-card transition-transform duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1">
+            <div className="mb-8 font-mono text-xs tracking-[0.06em] text-clay-light">
+              03
+            </div>
+            <h3 className="mb-2 font-newsreader text-[22px]">Online community</h3>
+            <p className="font-inter text-sm leading-[1.5] text-[#F5E4DB]">
+              WhatsApp &amp; Discord — questions answered daily, wins shared
+              nightly.
+            </p>
+          </article>
+        </Reveal>
+
+        {/* 04 — wide */}
+        <Reveal index={3} className="md:col-span-2">
+          <article className="group flex h-full items-center gap-6 rounded-2xl border border-sand bg-paper-card p-6 transition-transform duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1">
+            <div className="flex-1">
+              <div className="mb-2.5 font-mono text-xs tracking-[0.06em] text-clay">
+                04
+              </div>
+              <h3 className="mb-2 font-newsreader text-[22px] text-ink">
+                Learn with Claude
+              </h3>
+              <p className="font-inter text-sm leading-[1.5] text-ink-soft">
+                Shared guides, prompts and starter projects pitched for every
+                level — from your first prompt to production.
+              </p>
+            </div>
+            <Link
+              href="/resources"
+              className="shrink-0 whitespace-nowrap font-inter text-sm font-semibold text-clay hover:underline"
+            >
+              Explore resources{" "}
+              <span className="inline-block transition-transform duration-150 ease-[var(--ease-reversible)] group-hover:translate-x-1">
+                →
+              </span>
+            </Link>
+          </article>
+        </Reveal>
+      </div>
     </section>
   );
 }

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -23,6 +23,7 @@ import type { ProjectView } from "@/lib/data";
 import { rank, type Recommendable } from "@/lib/recommendations";
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { Marquee } from "@/components/karibu/Marquee";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 import { KaribuTestimonials } from "@/components/karibu/KaribuTestimonials";
 import { KaribuProjects } from "@/components/karibu/KaribuProjects";
 import { HERO_PHOTO, GALLERY_PHOTOS, eventCover } from "@/components/karibu/photos";
@@ -46,30 +47,6 @@ const TYPE_LABEL: Record<Event["type"], string> = {
   "career-talk": "Career talk",
   hackathon: "Hackathon",
 };
-
-/** Reveal-on-scroll wrapper; no-op when the visitor prefers reduced motion. */
-function Reveal({
-  children,
-  className,
-  delay = 0,
-}: {
-  children: React.ReactNode;
-  className?: string;
-  delay?: number;
-}) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1], delay }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuHome({
   communityStats,

--- a/src/components/karibu/KaribuJoin.tsx
+++ b/src/components/karibu/KaribuJoin.tsx
@@ -9,8 +9,8 @@
  */
 
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
 import { SOCIAL_LINKS } from "@/lib/constants";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -26,21 +26,6 @@ const CITIES = [
   { name: "Mombasa", note: "Coast chapter", href: SOCIAL_LINKS.lumaMombasa, cta: "Luma →" },
   { name: "Kisumu", note: "Growing — say hi", href: SOCIAL_LINKS.whatsapp, cta: "WhatsApp →" },
 ];
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuJoin() {
   return (

--- a/src/components/karibu/KaribuLearn.tsx
+++ b/src/components/karibu/KaribuLearn.tsx
@@ -73,7 +73,7 @@ export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
               <Link
                 key={card.href}
                 href={card.href}
-                className="group flex flex-col rounded-2xl border border-sand bg-paper-card p-7 transition-colors hover:border-clay"
+                className="group flex flex-col rounded-2xl border border-sand bg-paper-card p-7 transition-[transform,border-color] duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1 hover:border-clay"
               >
                 <div className="mb-5 flex items-center justify-between">
                   <span className="font-mono text-xs text-clay">
@@ -88,7 +88,10 @@ export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
                   {card.description}
                 </p>
                 <span className="font-inter text-sm font-semibold text-clay group-hover:underline">
-                  Open →
+                  Open{" "}
+                  <span className="inline-block transition-transform duration-150 ease-[var(--ease-reversible)] group-hover:translate-x-1">
+                    →
+                  </span>
                 </span>
               </Link>
             );

--- a/src/components/karibu/KaribuLearn.tsx
+++ b/src/components/karibu/KaribuLearn.tsx
@@ -8,6 +8,7 @@
  * remove.
  */
 
+import { useEffect, useRef } from "react";
 import Link from "next/link";
 import {
   Rocket,
@@ -20,6 +21,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import { Reveal } from "@/components/karibu/motion/Reveal";
+import { register, unregister } from "@/components/karibu/motion/observer";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -46,6 +48,26 @@ const PATH = [
   { n: "2", title: "Build with Claude Code", body: "Ship a small app or tool end to end." },
   { n: "3", title: "Come to a workshop", body: "Go further with people who'll help in person." },
 ];
+
+/**
+ * A thin progress line under the suggested-path steps that draws left→right on
+ * first scroll into view, reusing the shared reveal observer. The dark track is
+ * always visible (degrade-safe); only the clay fill animates.
+ */
+function ProgressLine() {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    register(el);
+    return () => unregister(el);
+  }, []);
+  return (
+    <div className="mt-8 h-px w-full bg-[#3B352D]" aria-hidden="true">
+      <div ref={ref} data-progress className="h-px w-full bg-clay-light" />
+    </div>
+  );
+}
 
 export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
   return (
@@ -107,14 +129,15 @@ export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
               A suggested path
             </div>
             <div className="grid gap-6 sm:grid-cols-3">
-              {PATH.map((s) => (
-                <div key={s.n} className="border-t border-[#3B352D] pt-[18px]">
+              {PATH.map((s, i) => (
+                <Reveal key={s.n} index={i} className="border-t border-[#3B352D] pt-[18px]">
                   <div className="mb-2 font-newsreader text-[30px] text-clay-light">{s.n}</div>
                   <div className="mb-1.5 font-inter text-base font-semibold text-paper">{s.title}</div>
                   <div className="font-inter text-sm leading-[1.55] text-[#A79E90]">{s.body}</div>
-                </div>
+                </Reveal>
               ))}
             </div>
+            <ProgressLine />
             <div className="mt-8">
               <Link
                 href="/events"

--- a/src/components/karibu/KaribuLearn.tsx
+++ b/src/components/karibu/KaribuLearn.tsx
@@ -9,7 +9,6 @@
  */
 
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
 import {
   Rocket,
   Terminal,
@@ -20,6 +19,7 @@ import {
   Link2,
   type LucideIcon,
 } from "lucide-react";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -46,21 +46,6 @@ const PATH = [
   { n: "2", title: "Build with Claude Code", body: "Ship a small app or tool end to end." },
   { n: "3", title: "Come to a workshop", body: "Go further with people who'll help in person." },
 ];
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
   return (

--- a/src/components/karibu/KaribuNav.tsx
+++ b/src/components/karibu/KaribuNav.tsx
@@ -57,8 +57,11 @@ export function KaribuNav() {
             : "bg-paper/[0.86]"
         }`}
       >
+        {/* Height snaps between states (no height *animation* — only
+         * transform/opacity/paint may animate); the smooth firm-up comes from
+         * the nav's background + shadow transition above. */}
         <div
-          className={`mx-auto flex max-w-[1180px] items-center justify-between px-5 transition-[height] duration-200 md:px-10 ${
+          className={`mx-auto flex max-w-[1180px] items-center justify-between px-5 md:px-10 ${
             scrolled ? "h-14" : "h-16"
           }`}
         >

--- a/src/components/karibu/KaribuNav.tsx
+++ b/src/components/karibu/KaribuNav.tsx
@@ -33,16 +33,35 @@ export function KaribuNav() {
   const isAuthed = status === "authenticated";
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isMac, setIsMac] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsMac(navigator.platform.toUpperCase().includes("MAC"));
   }, []);
 
+  // Shrink + firm up the bar once the visitor scrolls past the hero band.
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
   return (
     <>
-      <nav className="sticky top-0 z-50 border-b border-sand bg-paper/[0.86] backdrop-blur-md">
-        <div className="mx-auto flex h-16 max-w-[1180px] items-center justify-between px-5 md:px-10">
+      <nav
+        className={`sticky top-0 z-50 border-b border-sand backdrop-blur-md transition-[background-color,box-shadow] duration-200 ${
+          scrolled
+            ? "bg-paper/[0.96] shadow-[0_2px_20px_-10px_rgba(35,32,27,0.35)]"
+            : "bg-paper/[0.86]"
+        }`}
+      >
+        <div
+          className={`mx-auto flex max-w-[1180px] items-center justify-between px-5 transition-[height] duration-200 md:px-10 ${
+            scrolled ? "h-14" : "h-16"
+          }`}
+        >
           {/* Brand */}
           <Link
             href="/"
@@ -109,7 +128,7 @@ export function KaribuNav() {
                 </Link>
                 <Link
                   href="/signup"
-                  className="rounded-full bg-clay px-4 py-2 font-inter text-sm font-semibold text-paper-card transition-colors hover:bg-clay-dark"
+                  className="rounded-full bg-clay px-4 py-2 font-inter text-sm font-semibold text-paper-card transition-[background-color,transform] duration-150 ease-[var(--ease-reversible)] hover:scale-[1.03] hover:bg-clay-dark"
                 >
                   Join
                 </Link>

--- a/src/components/karibu/KaribuNewsletter.tsx
+++ b/src/components/karibu/KaribuNewsletter.tsx
@@ -9,8 +9,9 @@
 
 import { useEffect, useState, useTransition, type FormEvent } from "react";
 import Link from "next/link";
-import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
+import { motion, AnimatePresence } from "framer-motion";
 import type { NewsletterIssueView } from "@/lib/data";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -23,21 +24,6 @@ function formatIssueMonth(iso: string): string {
 /** Pads an issue number to 2 digits: 3 → "03" */
 function padIssueNumber(n: number): string {
   return String(n).padStart(2, "0");
-}
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
 }
 
 /** Warm-light subscribe form — same /api/newsletter + CSRF flow as HeroEmailCapture. */

--- a/src/components/karibu/KaribuProjects.tsx
+++ b/src/components/karibu/KaribuProjects.tsx
@@ -10,27 +10,12 @@
  */
 
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
 import { Sparkles, ExternalLink, Github } from "lucide-react";
 import type { ProjectView } from "@/lib/data";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuProjects({
   projectOfTheWeek,

--- a/src/components/karibu/KaribuProjectsPage.tsx
+++ b/src/components/karibu/KaribuProjectsPage.tsx
@@ -8,27 +8,12 @@
  */
 
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
 import { ExternalLink, Github, Plus } from "lucide-react";
 import type { ProjectView } from "@/lib/data";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 function statusLabel(status: string): string {
   return status

--- a/src/components/karibu/KaribuSubmitIdea.tsx
+++ b/src/components/karibu/KaribuSubmitIdea.tsx
@@ -11,7 +11,7 @@
 import { useState, useEffect, useTransition } from "react";
 import { Send, CheckCircle, AlertTriangle, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[880px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -34,21 +34,6 @@ const inputCls = (hasError?: string) =>
   `w-full rounded-lg border ${
     hasError ? "border-red-500/60" : "border-sand-2"
   } bg-paper px-3 py-2.5 font-inter text-sm text-ink placeholder:text-ink-muted/70 transition-colors focus:border-clay focus:outline-none focus:ring-2 focus:ring-clay/20`;
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuSubmitIdea() {
   const [isPending, startTransition] = useTransition();

--- a/src/components/karibu/KaribuSubmitProject.tsx
+++ b/src/components/karibu/KaribuSubmitProject.tsx
@@ -11,7 +11,7 @@
 import { useState, useEffect, useTransition } from "react";
 import { Send, CheckCircle, AlertTriangle, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[880px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -26,21 +26,6 @@ const inputCls = (hasError?: string) =>
   `w-full rounded-lg border ${
     hasError ? "border-red-500/60" : "border-sand-2"
   } bg-paper px-3 py-2.5 font-inter text-sm text-ink placeholder:text-ink-muted/70 transition-colors focus:border-clay focus:outline-none focus:ring-2 focus:ring-clay/20`;
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuSubmitProject() {
   const [isPending, startTransition] = useTransition();

--- a/src/components/karibu/KaribuTeam.tsx
+++ b/src/components/karibu/KaribuTeam.tsx
@@ -34,12 +34,16 @@ export function KaribuTeam({ members }: { members: TeamMemberView[] }) {
 
       <section className={`${WRAP} pb-16`} aria-label="Team">
         {active.length > 0 ? (
-          <Reveal className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
-            {active.map((m) => (
-              <TeamCard key={m.name} member={m} />
+          <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
+            {active.map((m, i) => (
+              <Reveal key={m.name} index={i}>
+                <TeamCard member={m} />
+              </Reveal>
             ))}
-          </Reveal>
+          </div>
         ) : (
+          // "Coming soon" appears instantly — we never animate attention onto
+          // an empty state.
           <p className="text-center font-inter text-ink-muted">Team coming soon.</p>
         )}
       </section>
@@ -55,10 +59,10 @@ function TeamCard({ member }: { member: TeamMemberView }) {
     .slice(0, 2)
     .toUpperCase();
   return (
-    <div className="rounded-2xl border border-sand bg-paper-card p-5 text-center">
+    <div className="group h-full rounded-2xl border border-sand bg-paper-card p-5 text-center transition-transform duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1">
       <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center overflow-hidden rounded-full bg-sand">
         {member.avatar ? (
-          <Image src={member.avatar} alt={member.name} width={96} height={96} className="h-full w-full object-cover" />
+          <Image src={member.avatar} alt={member.name} width={96} height={96} className="h-full w-full object-cover transition-transform duration-300 ease-[var(--ease-reversible)] group-hover:scale-105" />
         ) : (
           <span className="font-newsreader text-[28px] text-ink-muted">{initials}</span>
         )}

--- a/src/components/karibu/KaribuTeam.tsx
+++ b/src/components/karibu/KaribuTeam.tsx
@@ -8,27 +8,12 @@
  */
 
 import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
 import { Github, Linkedin, Twitter, Globe } from "lucide-react";
 import type { TeamMemberView } from "@/lib/data";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 export function KaribuTeam({ members }: { members: TeamMemberView[] }) {
   const active = members.filter((m) => m.active !== false);

--- a/src/components/karibu/KaribuVolunteer.tsx
+++ b/src/components/karibu/KaribuVolunteer.tsx
@@ -11,8 +11,8 @@
 
 import { useState, useTransition } from "react";
 import Link from "next/link";
-import { motion, useReducedMotion } from "framer-motion";
 import { HandHeart, Send, Loader2, CheckCircle, AlertTriangle } from "lucide-react";
+import { Reveal } from "@/components/karibu/motion/Reveal";
 
 const WRAP = "mx-auto max-w-[880px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
@@ -36,21 +36,6 @@ const inputCls = (hasError?: string) =>
   `w-full rounded-lg border ${
     hasError ? "border-red-500/60" : "border-sand-2"
   } bg-paper px-3 py-2.5 font-inter text-sm text-ink placeholder:text-ink-muted/70 transition-colors focus:border-clay focus:outline-none focus:ring-2 focus:ring-clay/20`;
-
-function Reveal({ children, className }: { children: React.ReactNode; className?: string }) {
-  const reduce = useReducedMotion();
-  return (
-    <motion.div
-      className={className}
-      initial={reduce ? false : { opacity: 0, y: 18 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, margin: "0px 0px -6% 0px" }}
-      transition={{ duration: 0.6, ease: [0.2, 0.7, 0.2, 1] }}
-    >
-      {children}
-    </motion.div>
-  );
-}
 
 function Field({
   label,

--- a/src/components/karibu/motion/Reveal.tsx
+++ b/src/components/karibu/motion/Reveal.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useEffect, useRef, type CSSProperties, type ReactNode } from "react";
+import { register, unregister } from "./observer";
+
+interface RevealProps {
+  children: ReactNode;
+  className?: string;
+  /** Optional stagger index (0-based). CSS caps the delay at 6 steps. */
+  index?: number;
+}
+
+/**
+ * Degrade-safe reveal wrapper. Renders a visible `<div data-reveal>`; the
+ * before-paint `.js` class (layout.tsx) + globals.css turn that into an
+ * opacity/transform entrance, and the shared observer adds `.in-view` once on
+ * scroll. No JS → content stays fully visible. Reduced-motion → instant.
+ */
+export function Reveal({ children, className, index }: RevealProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    register(el);
+    return () => unregister(el);
+  }, []);
+
+  const style = index != null ? ({ "--i": index } as CSSProperties) : undefined;
+
+  return (
+    <div ref={ref} data-reveal="" className={className} style={style}>
+      {children}
+    </div>
+  );
+}

--- a/src/components/karibu/motion/observer.ts
+++ b/src/components/karibu/motion/observer.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared IntersectionObserver singleton for the Karibu degrade-safe reveal.
+ *
+ * One observer instance for the whole page (not one per element). On an
+ * element's first intersection it adds `.in-view` and unobserves it, so every
+ * reveal fires exactly once. Constructed lazily on first `register` — which is
+ * only ever called from a client `useEffect`, so `IntersectionObserver` is
+ * always defined by then.
+ */
+
+let observer: IntersectionObserver | null = null;
+
+function getObserver(): IntersectionObserver {
+  if (observer) return observer;
+  observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("in-view");
+          observer?.unobserve(entry.target); // one-time
+        }
+      }
+    },
+    { rootMargin: "0px 0px -6% 0px", threshold: 0 },
+  );
+  return observer;
+}
+
+export function register(el: Element): void {
+  getObserver().observe(el);
+}
+
+export function unregister(el: Element): void {
+  observer?.unobserve(el);
+}


### PR DESCRIPTION
## Karibu Motion Layer (CSS-first, degrade-safe)

Implements the approved motion spec (`docs/superpowers/specs/2026-07-09-karibu-motion-layer-design.md`) per the phased plan (`docs/superpowers/plans/2026-07-09-karibu-motion-layer.md`).

> **Stacked on #36** (`redesign/karibu-darkmode`). Base is `redesign/karibu-darkmode` so this PR shows **only** the motion diff. After #36 merges, rebase/retarget onto `main` (per spec §7).

### The central fix — reveal-degradation bug
Every Karibu page defined its own Framer `Reveal` with `initial={opacity:0}`, so a failed trigger left content invisible. Replaced all **17** local copies with **one shared, visible-by-default reveal**: `[data-reveal]` is `opacity:1` by default; a before-paint `.js` class on `<html>` introduces the hidden→visible transition; a single shared `IntersectionObserver` adds `.in-view` once then unobserves. **No JS → content stays visible.** Reduced-motion → instant.

### What's in it
- **P0** — motion tokens + degrade-safe reveal CSS (`globals.css`); `.js` bootstrap (`layout.tsx`); `motion/Reveal.tsx` + `motion/observer.ts`.
- **P1** — 17-file `Reveal` unification (fixes the bug site-wide; Framer kept only where it earns it).
- **P2** — Home count-up + staggered bento + hover-lift; Nav shrink-on-scroll + Join hover; **Events FLIP** filter; Learn/Community hover-lift + arrow nudge.
- **P3** — About timeline scroll-draw + milestone reveals + organiser-face hover; Learn suggested-path stagger + scroll-drawn progress line; Team stagger/hover once populated (empty state instant); Community "Share something" hover.

### Non-negotiables held
reduced-motion → instant (incl. Events FLIP + marquee); only `transform`/`opacity` animate (nav height **snaps**, no layout animation); scroll reveals are one-time; empty/error/"coming soon" states never animate; no hero parallax; marquee is the only loop.

### Verification
`tsc --noEmit` clean; ESLint on all 21 changed files clean (0 problems); `next build` compiles + passes TypeScript (page-data step needs live Supabase/DB — verify motion on this PR's **Vercel preview**). Whole-branch review pass → 2 findings, both fixed (reduced-motion in FLIP; nav height animation).

### 🔶 Sign-offs to confirm before merge (not blockers)
1. **Testimonial name spellings** in `KaribuTestimonials.tsx` — Billy Mwangi, Samuel, James Lloyd, Isaac Toili / Tuigoin.
2. **`/join`** — WhatsApp-first vs form-returns decision.
3. **Deferred (out of scope, spec §9):** upvote scale-pop + copy checkmark-morph — those controls live only on the un-converted dark `community/[slug]` page, so animating them was intentionally skipped to avoid leaking motion onto Terminal Noir.
