### PR TITLE
feat(loading): token-driven skeleton system replaces terminal loader

### DIFF
--- a/src/app/admin/loading.tsx
+++ b/src/app/admin/loading.tsx
@@ -1,110 +1,31 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /admin — dark noir palette, mirrors dashboard anatomy. */
 export default function AdminLoading() {
   return (
-    <div
-      style={{
-        minHeight: "100vh",
-        backgroundColor: "#0a0a0a",
-        padding: "2rem",
-        fontFamily: "monospace",
-      }}
-    >
-      <div
-        style={{
-          maxWidth: "1200px",
-          margin: "0 auto",
-        }}
-      >
-        {/* Header skeleton */}
-        <div
-          style={{
-            height: "2rem",
-            width: "240px",
-            backgroundColor: "#1a1a1a",
-            borderRadius: "4px",
-            marginBottom: "2rem",
-            animation: "pulse 1.5s ease-in-out infinite",
-          }}
-        />
+    <div className="k-skeleton-noir min-h-screen bg-[#0a0a0a] p-8">
+      <SkeletonPage label="Loading admin dashboard" className="mx-auto max-w-[1200px]">
+        {/* Header */}
+        <Skeleton className="mb-8 h-8 w-60 rounded" />
 
-        {/* Stats row skeleton */}
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-            gap: "1rem",
-            marginBottom: "2rem",
-          }}
-        >
-          {[1, 2, 3, 4].map((i) => (
-            <div
-              key={i}
-              style={{
-                height: "80px",
-                backgroundColor: "#1a1a1a",
-                borderRadius: "8px",
-                border: "1px solid #222",
-                animation: "pulse 1.5s ease-in-out infinite",
-                animationDelay: `${i * 0.15}s`,
-              }}
-            />
+        {/* Stats row */}
+        <div className="mb-8 grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-20 rounded-lg border border-[#222]" delay={i * 0.15} />
           ))}
         </div>
 
-        {/* Content skeleton bars */}
-        <div
-          style={{
-            backgroundColor: "#1a1a1a",
-            borderRadius: "8px",
-            border: "1px solid #222",
-            padding: "1.5rem",
-          }}
-        >
-          {[100, 85, 70, 90, 60].map((width, i) => (
-            <div
-              key={i}
-              style={{
-                height: "1rem",
-                width: `${width}%`,
-                backgroundColor: "#222",
-                borderRadius: "4px",
-                marginBottom: i < 4 ? "1rem" : 0,
-                animation: "pulse 1.5s ease-in-out infinite",
-                animationDelay: `${i * 0.1}s`,
-              }}
+        {/* Content panel */}
+        <div className="rounded-lg border border-[#222] p-6">
+          {["w-[100%]", "w-[85%]", "w-[70%]", "w-[90%]", "w-[60%]"].map((width, i) => (
+            <Skeleton
+              key={width}
+              className={`h-4 rounded ${width} ${i < 4 ? "mb-4" : ""}`}
+              delay={i * 0.1}
             />
           ))}
         </div>
-
-        {/* Terminal cursor blink */}
-        <div
-          style={{
-            marginTop: "2rem",
-            color: "#00ff41",
-            fontSize: "0.875rem",
-            fontFamily: "monospace",
-          }}
-        >
-          <span>Loading</span>
-          <span
-            style={{
-              animation: "blink 1s step-end infinite",
-            }}
-          >
-            _
-          </span>
-        </div>
-      </div>
-
-      <style>{`
-        @keyframes pulse {
-          0%, 100% { opacity: 0.4; }
-          50% { opacity: 0.8; }
-        }
-        @keyframes blink {
-          0%, 100% { opacity: 1; }
-          50% { opacity: 0; }
-        }
-      `}</style>
+      </SkeletonPage>
     </div>
   );
 }

--- a/src/app/blog/loading.tsx
+++ b/src/app/blog/loading.tsx
@@ -1,0 +1,41 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /blog — mirrors KaribuBlog anatomy. */
+export default function BlogLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading blog">
+      {/* Header */}
+      <section className={`${WRAP} pb-6 pt-16`}>
+        <Skeleton className="mb-4 h-3 w-24" />
+        <Skeleton className="mb-4 h-11 w-2/3 max-w-lg" delay={0.08} />
+        <Skeleton className="h-5 w-full max-w-[600px]" delay={0.16} />
+      </section>
+
+      {/* Featured post card */}
+      <section className={`${WRAP} py-5`}>
+        <div className="rounded-2xl border border-sand p-8 sm:p-10">
+          <Skeleton className="mb-4 h-3 w-20" delay={0.24} />
+          <Skeleton className="mb-4 h-9 w-full max-w-[720px]" delay={0.28} />
+          <Skeleton className="mb-5 h-5 w-full max-w-[640px]" delay={0.32} />
+          <Skeleton className="h-4 w-64" delay={0.36} />
+        </div>
+      </section>
+
+      {/* Post card grid */}
+      <section className={`${WRAP} py-5 pb-16`}>
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex flex-col rounded-2xl border border-sand p-7">
+              <Skeleton className="mb-2 h-6 w-3/4" delay={0.4 + i * 0.08} />
+              <Skeleton className="mb-1.5 h-4 w-full" delay={0.42 + i * 0.08} />
+              <Skeleton className="mb-4 h-4 w-2/3" delay={0.44 + i * 0.08} />
+              <Skeleton className="h-4 w-40" delay={0.46 + i * 0.08} />
+            </div>
+          ))}
+        </div>
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/app/community/loading.tsx
+++ b/src/app/community/loading.tsx
@@ -1,0 +1,55 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /community — mirrors KaribuCommunity anatomy. */
+export default function CommunityLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading community hub">
+      {/* Header */}
+      <section className={`${WRAP} pb-6 pt-16`}>
+        <div className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <Skeleton className="mb-4 h-3 w-28" />
+            <Skeleton className="mb-3 h-11 w-80 max-w-full" delay={0.08} />
+            <Skeleton className="h-5 w-full max-w-[600px]" delay={0.16} />
+          </div>
+          <Skeleton className="h-11 w-48 shrink-0 rounded-full" delay={0.2} />
+        </div>
+      </section>
+
+      {/* Filter chips */}
+      <section className={`${WRAP} pb-6`}>
+        <div className="flex flex-wrap items-center gap-4">
+          <div className="flex gap-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-20 rounded-full" delay={0.24 + i * 0.04} />
+            ))}
+          </div>
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-7 w-16 rounded-full" delay={0.44} />
+            <Skeleton className="h-7 w-16 rounded-full" delay={0.48} />
+          </div>
+        </div>
+      </section>
+
+      {/* Submission card grid */}
+      <section className={`${WRAP} pb-16`}>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex h-full flex-col rounded-2xl border border-sand p-6">
+              <Skeleton className="mb-3 h-5 w-20 rounded-full" delay={0.5 + i * 0.08} />
+              <Skeleton className="mb-2 h-6 w-3/4" delay={0.5 + i * 0.08} />
+              <Skeleton className="mb-4 h-4 w-full" delay={0.5 + i * 0.08} />
+              <div className="mb-4 flex gap-1.5">
+                <Skeleton className="h-5 w-12 rounded-full" delay={0.5 + i * 0.08} />
+                <Skeleton className="h-5 w-12 rounded-full" delay={0.5 + i * 0.08} />
+              </div>
+              <Skeleton className="h-4 w-full border-t border-sand pt-3" delay={0.5 + i * 0.08} />
+            </div>
+          ))}
+        </div>
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/app/events/loading.tsx
+++ b/src/app/events/loading.tsx
@@ -1,0 +1,54 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /events — mirrors KaribuEvents anatomy. */
+export default function EventsLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading events">
+      {/* Header */}
+      <section className={`${WRAP} pb-6 pt-16`}>
+        <Skeleton className="mb-4 h-3 w-32" />
+        <Skeleton className="mb-[18px] h-11 w-2/3 max-w-md" />
+        <Skeleton className="mb-7 h-5 w-full max-w-[560px]" delay={0.08} />
+        <div className="flex flex-wrap gap-2.5">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-20 rounded-full" delay={0.16 + i * 0.04} />
+          ))}
+        </div>
+      </section>
+
+      {/* Featured "Next up" card */}
+      <section className={`${WRAP} py-5`}>
+        <div className="grid overflow-hidden rounded-2xl border border-sand md:grid-cols-2">
+          <Skeleton className="aspect-[4/3] w-full md:aspect-auto md:min-h-[280px]" delay={0.24} />
+          <div className="p-8 md:p-[34px]">
+            <div className="mb-3.5 flex gap-2">
+              <Skeleton className="h-6 w-16 rounded-full" delay={0.28} />
+              <Skeleton className="h-6 w-20 rounded-full" delay={0.32} />
+            </div>
+            <Skeleton className="mb-2.5 h-3 w-3/4" delay={0.36} />
+            <Skeleton className="mb-3.5 h-8 w-full" delay={0.4} />
+            <Skeleton className="mb-5 h-5 w-full" delay={0.44} />
+            <Skeleton className="h-11 w-40 rounded-full" delay={0.48} />
+          </div>
+        </div>
+      </section>
+
+      {/* Upcoming list rows */}
+      <section className={`${WRAP} pb-16 pt-2`}>
+        <Skeleton className="mb-2 h-3 w-40" delay={0.5} />
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="grid grid-cols-[84px_1fr] items-center gap-5 border-b border-sand py-5 sm:grid-cols-[120px_1fr_auto] sm:gap-[26px]">
+            <Skeleton className="h-16 w-full" delay={0.5 + i * 0.04} />
+            <div>
+              <Skeleton className="mb-1.5 h-5 w-32" delay={0.5 + i * 0.04} />
+              <Skeleton className="h-6 w-2/3" delay={0.5 + i * 0.04} />
+            </div>
+            <Skeleton className="col-span-2 h-9 w-24 rounded-full sm:col-span-1" delay={0.5 + i * 0.04} />
+          </div>
+        ))}
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/app/gallery/loading.tsx
+++ b/src/app/gallery/loading.tsx
@@ -1,0 +1,40 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /gallery — mirrors KaribuGallery anatomy. */
+export default function GalleryLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading gallery">
+      {/* Header */}
+      <section className={`${WRAP} pb-6 pt-16`}>
+        <Skeleton className="mb-4 h-3 w-24" />
+        <Skeleton className="mb-4 h-11 w-full max-w-[760px]" delay={0.08} />
+        <Skeleton className="mb-6 h-5 w-full max-w-[600px]" delay={0.16} />
+        <Skeleton className="h-4 w-48" delay={0.24} />
+      </section>
+
+      {/* Filter chips */}
+      <section className={`${WRAP} pb-2`}>
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-24 rounded-full" delay={0.28 + i * 0.04} />
+          ))}
+        </div>
+      </section>
+
+      {/* Photo grid */}
+      <section className={`${WRAP} py-5 pb-16`}>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              className="aspect-[4/3] w-full rounded-xl"
+              delay={Math.min(0.4 + i * 0.04, 0.5)}
+            />
+          ))}
+        </div>
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -700,6 +700,41 @@ body::before {
   animation-play-state: paused;
 }
 
+/* ─── Karibu skeleton loading ─────────────────────────────────────────────
+ * Token-driven shimmer for route-level loading states. The sweep is a
+ * translucent ink gradient, so it reads darker-on-light in light mode and
+ * lighter-on-dark in dark mode with zero extra rules. Stagger per element
+ * via the --sk-delay custom property. The global reduced-motion reset
+ * freezes the sweep automatically. */
+.k-skeleton {
+  position: relative;
+  overflow: hidden;
+  background: var(--paper-alt);
+  border-radius: 8px;
+}
+.k-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in oklab, var(--ink) 6%, transparent) 50%,
+    transparent
+  );
+  animation: karibu-shimmer 1.6s ease-in-out var(--sk-delay, 0s) infinite;
+}
+@keyframes karibu-shimmer {
+  100% { transform: translateX(100%); }
+}
+/* Terminal Noir scope (admin): remap the skeleton's tokens onto the dark
+ * admin palette so the same primitive reads correctly on #0a0a0a. */
+.k-skeleton-noir {
+  --paper-alt: #1a1a1a;
+  --ink: #e5e5e5;
+}
+
 /* ─── Karibu adaptive dark mode ───────────────────────────────────────────
  * Warm-dark overrides for the Karibu paper/ink/sand/clay tokens ONLY.
  * Precedence: system preference (prefers-color-scheme) applies by default;

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,13 +1,18 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Fallback route skeleton for pages without their own loading.tsx — neutral Karibu shell. */
 export default function GlobalLoading() {
   return (
-    <div className="min-h-[60vh] flex items-center justify-center">
-      <div className="font-mono text-sm text-green-primary">
-        <span className="inline-flex items-center gap-2">
-          <span className="h-2 w-2 rounded-full bg-green-primary animate-pulse" />
-          loading
-          <span className="cursor-blink">▊</span>
-        </span>
+    <SkeletonPage label="Loading page">
+      <div className="mx-auto max-w-[1180px] px-6 pb-24 pt-28 md:px-10">
+        <Skeleton className="mb-4 h-10 w-2/3 max-w-md" />
+        <Skeleton className="mb-10 h-5 w-full max-w-lg" delay={0.08} />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 w-full rounded-2xl" delay={0.16 + i * 0.08} />
+          ))}
+        </div>
       </div>
-    </div>
+    </SkeletonPage>
   );
 }

--- a/src/app/newsletter/loading.tsx
+++ b/src/app/newsletter/loading.tsx
@@ -1,0 +1,32 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /newsletter — mirrors KaribuNewsletter anatomy. */
+export default function NewsletterLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading newsletter">
+      {/* Header + subscribe */}
+      <section className={`${WRAP} pb-10 pt-16 text-center`}>
+        <Skeleton className="mx-auto mb-4 h-3 w-32" />
+        <Skeleton className="mx-auto mb-4 h-11 w-full max-w-[500px]" delay={0.08} />
+        <Skeleton className="mx-auto mb-8 h-5 w-full max-w-[560px]" delay={0.16} />
+        <Skeleton className="mx-auto h-14 w-full max-w-md rounded-full" delay={0.24} />
+      </section>
+
+      {/* Past issue rows */}
+      <section className={`${WRAP} py-10`}>
+        <Skeleton className="mb-6 h-3 w-24" delay={0.32} />
+        <div className="grid gap-4">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="rounded-2xl border border-sand p-7">
+              <Skeleton className="mb-3 h-3 w-32" delay={0.4 + i * 0.08} />
+              <Skeleton className="mb-2 h-7 w-2/3" delay={0.42 + i * 0.08} />
+              <Skeleton className="h-4 w-full" delay={0.44 + i * 0.08} />
+            </div>
+          ))}
+        </div>
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/app/projects/loading.tsx
+++ b/src/app/projects/loading.tsx
@@ -1,0 +1,50 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /projects — mirrors KaribuProjectsPage anatomy. */
+export default function ProjectsLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading projects">
+      {/* Header */}
+      <section className={`${WRAP} pb-6 pt-16`}>
+        <Skeleton className="mb-4 h-3 w-28" />
+        <Skeleton className="mb-4 h-11 w-2/3 max-w-lg" delay={0.08} />
+        <Skeleton className="h-5 w-full max-w-[600px]" delay={0.16} />
+      </section>
+
+      {/* Submit CTA band */}
+      <section className={`${WRAP} py-4`}>
+        <div className="flex flex-col items-center justify-between gap-4 rounded-2xl border border-sand p-7 sm:flex-row">
+          <div className="w-full sm:w-auto">
+            <Skeleton className="mb-2 h-6 w-56" delay={0.24} />
+            <Skeleton className="h-4 w-72" delay={0.28} />
+          </div>
+          <Skeleton className="h-11 w-44 shrink-0 rounded-full" delay={0.32} />
+        </div>
+      </section>
+
+      {/* Project card grid */}
+      <section className={`${WRAP} pb-16 pt-4`}>
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="flex h-full flex-col rounded-2xl border border-sand p-6">
+              <div className="mb-3 flex items-center justify-between">
+                <Skeleton className="h-4 w-16" delay={0.4 + i * 0.08} />
+                <Skeleton className="h-5 w-20 rounded-full" delay={0.42 + i * 0.08} />
+              </div>
+              <Skeleton className="mb-1 h-6 w-2/3" delay={0.44 + i * 0.08} />
+              <Skeleton className="mb-3 h-3 w-24" delay={0.46 + i * 0.08} />
+              <Skeleton className="mb-4 h-4 w-full" delay={0.48 + i * 0.08} />
+              <div className="mb-4 flex gap-1.5">
+                <Skeleton className="h-5 w-14 rounded-full" delay={0.5 + i * 0.08} />
+                <Skeleton className="h-5 w-14 rounded-full" delay={0.5 + i * 0.08} />
+              </div>
+              <Skeleton className="h-4 w-32 border-t border-sand pt-3" delay={0.5 + i * 0.08} />
+            </div>
+          ))}
+        </div>
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/app/team/loading.tsx
+++ b/src/app/team/loading.tsx
@@ -1,0 +1,39 @@
+import { Skeleton, SkeletonPage } from "@/components/ui/Skeleton";
+
+/** Route skeleton for /team — mirrors KaribuTeam anatomy. */
+export default function TeamLoading() {
+  const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
+
+  return (
+    <SkeletonPage label="Loading team">
+      {/* Header */}
+      <section className={`${WRAP} pb-8 pt-16 text-center`}>
+        <Skeleton className="mx-auto mb-4 h-3 w-24" />
+        <Skeleton className="mx-auto mb-4 h-11 w-full max-w-[600px]" delay={0.08} />
+        <Skeleton className="mx-auto h-5 w-full max-w-[560px]" delay={0.16} />
+      </section>
+
+      {/* Member grid */}
+      <section className={`${WRAP} pb-16`}>
+        <div className="grid grid-cols-2 gap-5 sm:grid-cols-3 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="rounded-2xl border border-sand p-5 text-center">
+              <Skeleton
+                className="mx-auto mb-4 h-24 w-24 rounded-full"
+                delay={Math.min(0.24 + i * 0.04, 0.5)}
+              />
+              <Skeleton
+                className="mx-auto mb-1.5 h-4 w-24"
+                delay={Math.min(0.26 + i * 0.04, 0.5)}
+              />
+              <Skeleton
+                className="mx-auto h-3 w-16"
+                delay={Math.min(0.28 + i * 0.04, 0.5)}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+    </SkeletonPage>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * Skeleton — token-driven shimmer placeholder for route-level loading states.
+ *
+ * Renders a `.k-skeleton` block (see globals.css) that inherits the Karibu
+ * paper/ink tokens, so it is automatically correct in light and dark mode.
+ * Size and shape come from the caller via `className` (e.g. `h-4 w-40`,
+ * `rounded-full` for avatars). Stagger sibling shimmers with `delay`.
+ *
+ * Pages composing skeletons should wrap them in <SkeletonPage> so screen
+ * readers announce a single "Loading" status instead of decorative noise.
+ */
+
+import { cn } from "@/lib/utils";
+
+/** One shimmering placeholder block. Purely decorative (aria-hidden). */
+export function Skeleton({
+  className,
+  delay = 0,
+}: {
+  className?: string;
+  /** Shimmer stagger in seconds. */
+  delay?: number;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("k-skeleton", className)}
+      style={delay ? ({ "--sk-delay": `${delay}s` } as React.CSSProperties) : undefined}
+    />
+  );
+}
+
+/** Accessible wrapper for a page-level skeleton composition. */
+export function SkeletonPage({
+  label = "Loading page",
+  className,
+  children,
+}: {
+  label?: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div role="status" aria-label={label} className={className}>
+      <span className="sr-only">{label}</span>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Replaces the legacy green terminal `loading ▊` blinker with a premium, token-driven skeleton loading system across the Karibu redesign.

- **`Skeleton` / `SkeletonPage` primitive** (`src/components/ui/Skeleton.tsx`) — shimmer sweep built from a translucent `--ink` color-mix over `--paper-alt`, so it auto-adapts to light/dark mode with zero extra rules. Reduced-motion safe (global reset freezes it), staggered via `--sk-delay`, single `role=status` announcement for screen readers.
- **7 content-shaped route skeletons** — `/events`, `/blog`, `/projects`, `/community`, `/gallery`, `/team`, `/newsletter` — each mirrors its real page's container, grid, and radii so content swaps in without layout shift.
- **Root fallback** — neutral Karibu page shell for routes without their own skeleton.
- **Admin** — rebuilt on the same primitive via a `k-skeleton-noir` token remap; inline styles eliminated.

Submit-button spinners intentionally untouched (correct UX for in-flight form actions).

## Verification

- `npx tsc --noEmit` — clean (verified on top of the karibu-motion head)
- `npm run build` — clean (verified pre-cherry-pick; zero file overlap with motion commits, `globals.css` auto-merged)

## Notes

Single commit cherry-picked onto `origin/redesign/karibu-motion` to stay clear of the concurrent `fix/team-and-copy` split.

@Spidey-Acer