### PR TITLE
fix(compliance): align public copy with ambassador program rules

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -110,7 +110,7 @@ async function main() {
       description:
         "Our first university event! A career talk at Technical University of Mombasa exploring AI opportunities, Claude Code, and how students can start building with AI today.",
       fullDescription:
-        "Claude Community Kenya headed to Mombasa for our very first university event! In partnership with the Technical University of Mombasa and Swahilipot Hub Foundation, we brought an inspiring career talk on AI and development opportunities.\n\nThis event was designed specifically for university students and early-career developers. We covered what AI means for the future of software development in Kenya, how to get started with Claude and Claude Code, and the career opportunities emerging in the AI space.",
+        "Claude Community Kenya headed to Mombasa for our very first university event! Hosted at the Technical University of Mombasa, with thanks to the Swahilipot Hub Foundation, we brought an inspiring career talk on AI and development opportunities.\n\nThis event was designed specifically for university students and early-career developers. We covered what AI means for the future of software development in Kenya, how to get started with Claude and Claude Code, and the career opportunities emerging in the AI space.",
       agenda: [
         "10:00 AM — Registration & Welcome",
         "10:30 AM — Keynote: AI & The Future of Software Development in Kenya",

--- a/src/app/about/AboutClient.tsx
+++ b/src/app/about/AboutClient.tsx
@@ -164,8 +164,9 @@ export function AboutClient({ stats, team, timelineEntries }: AboutClientProps) 
               Still growing.
             </p>
             <p>
-              Claude Community Kenya is led by Peter Kibet, Anthropic-recognized Claude
-              Community Ambassador for Kenya.
+              Claude Community Kenya is led by Peter Kibet, Claude Community
+              Ambassador for Kenya — a volunteer role in Anthropic&apos;s founding
+              global ambassador cohort.
             </p>
             <p>
               Whether you write code, write copy, run a business, or do research —

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -286,7 +286,10 @@ export default function EditEventPage() {
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Organizer & Links</h2>
             <div className="grid grid-cols-2 gap-4">
               <FieldInput label="Host" value={host} onChange={setHost} placeholder="Optional" />
-              <FieldInput label="Partner Org" value={partnerOrg} onChange={setPartnerOrg} placeholder="Optional" />
+              {/* Renders publicly under "With thanks to" — per ambassador program
+                  rules, never use "partner"/"co-host"/"sponsor" framing for orgs
+                  that are not listed Claude customers. */}
+              <FieldInput label="Venue / host orgs (thanks)" value={partnerOrg} onChange={setPartnerOrg} placeholder="Optional" />
             </div>
             <div className="grid grid-cols-2 gap-4">
               <FieldInput label="Registration URL" type="url" value={registrationUrl} onChange={setRegistrationUrl} placeholder="Optional" />

--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -209,7 +209,7 @@ export default async function EventDetailPage({ params }: { params: Promise<{ id
                 )}
                 {event.partnerOrg && (
                   <div className="flex justify-between">
-                    <span className="text-[#555]">Partner</span>
+                    <span className="text-[#555]">Venue & hosts</span>
                     <span className="text-[#888]">{event.partnerOrg}</span>
                   </div>
                 )}

--- a/src/app/admin/events/new/page.tsx
+++ b/src/app/admin/events/new/page.tsx
@@ -209,7 +209,10 @@ export default function NewEventPage() {
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Organizer & Links</h2>
             <div className="grid grid-cols-2 gap-4">
               <FieldInput label="Host" value={host} onChange={setHost} placeholder="Optional" />
-              <FieldInput label="Partner Org" value={partnerOrg} onChange={setPartnerOrg} placeholder="Optional" />
+              {/* Renders publicly under "With thanks to" — per ambassador program
+                  rules, never use "partner"/"co-host"/"sponsor" framing for orgs
+                  that are not listed Claude customers. */}
+              <FieldInput label="Venue / host orgs (thanks)" value={partnerOrg} onChange={setPartnerOrg} placeholder="Optional" />
             </div>
             <div className="grid grid-cols-2 gap-4">
               <FieldInput label="Registration URL" type="url" value={registrationUrl} onChange={setRegistrationUrl} placeholder="Optional" />

--- a/src/app/events/[slug]/EventDetailContent.tsx
+++ b/src/app/events/[slug]/EventDetailContent.tsx
@@ -302,7 +302,7 @@ export function EventDetailContent({
                       : "font-mono text-xs uppercase tracking-wider"
                   }
                 >
-                  Partner Organizations
+                  With Thanks To
                 </span>
               </div>
               <p

--- a/src/app/join/JoinSwitcher.tsx
+++ b/src/app/join/JoinSwitcher.tsx
@@ -143,11 +143,11 @@ export function JoinSwitcher() {
                   </p>
                 </Card>
               </Link>
-              <Link href={`mailto:${CONTACT.email}?subject=Partnership%20with%20CCK`} className="block">
-                <Card title="partner.sh" padding="md" className="cursor-pointer">
-                  <h3 className="mb-2 font-mono text-lg font-bold text-text-primary">Partner with Us</h3>
+              <Link href={`mailto:${CONTACT.email}?subject=Hosting%20a%20CCK%20event`} className="block">
+                <Card title="host.sh" padding="md" className="cursor-pointer">
+                  <h3 className="mb-2 font-mono text-lg font-bold text-text-primary">Host an Event with Us</h3>
                   <p className="font-sans text-text-secondary">
-                    University, company, or venue? Let&apos;s collaborate and grow the AI developer community together.
+                    University, company, or venue? Bring a CCK meetup or workshop to your space.
                   </p>
                 </Card>
               </Link>

--- a/src/app/join/ProJoinContent.tsx
+++ b/src/app/join/ProJoinContent.tsx
@@ -93,10 +93,10 @@ const contributeCards = [
   },
   {
     icon: Mail,
-    title: "Partner with us",
+    title: "Host an event with us",
     description:
-      "University, company, or venue? Let's collaborate and grow the AI developer community together.",
-    href: `mailto:${CONTACT.email}?subject=Partnership%20with%20CCK`,
+      "University, company, or venue? Bring a CCK meetup or workshop to your space.",
+    href: `mailto:${CONTACT.email}?subject=Hosting%20a%20CCK%20event`,
   },
 ];
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -113,7 +113,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Claude Community Kenya",
     description:
-      "Kenya's official Anthropic developer community — building, learning, and shipping with Claude.",
+      "Kenya's Claude developer community — independent, volunteer-run, and Anthropic-supported. Building, learning, and shipping with Claude.",
     url: "https://www.claudekenya.org",
     siteName: "Claude Community Kenya",
     locale: "en_KE",
@@ -123,7 +123,7 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Claude Community Kenya",
     description:
-      "Kenya's official Anthropic developer community — building, learning, and shipping with Claude.",
+      "Kenya's Claude developer community — independent, volunteer-run, and Anthropic-supported. Building, learning, and shipping with Claude.",
     images: ["/opengraph-image"],
   },
   robots: {

--- a/src/components/karibu/KaribuAbout.tsx
+++ b/src/components/karibu/KaribuAbout.tsx
@@ -130,12 +130,12 @@ export function KaribuAbout({
             </div>
             <div>
               <div className="mb-2.5 font-inter text-xs font-semibold uppercase tracking-[0.18em] text-clay-light">
-                Official Anthropic tie
+                The Anthropic connection
               </div>
               <p className="max-w-[660px] font-newsreader text-[21px] leading-[1.4] text-paper sm:text-[23px]">
-                CCK is backed by Kenya&apos;s{" "}
-                <span className="italic text-clay-light">Claude Community Ambassador</span> — a
-                real link to Anthropic through the Claude Community Ambassadors program,
+                CCK is an independent, volunteer-run community, led by Kenya&apos;s{" "}
+                <span className="italic text-clay-light">Claude Community Ambassador</span> and
+                supported through Anthropic&apos;s Claude Community Ambassadors program —
                 kept firmly in service of the community, never a sales channel.
               </p>
             </div>

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -40,7 +40,7 @@ export const faqs: FAQ[] = [
     category: "general",
     question: "How is this related to Anthropic?",
     answer:
-      "Claude Community Kenya is a community of developers building with Claude and Anthropic's tools. We are part of the broader global Claude developer community ecosystem.",
+      "Claude Community Kenya is an independent, volunteer-run community, part of Anthropic's global Claude Community Ambassador program. Anthropic supports our events through that program, but we are not an official division or representative of Anthropic PBC — the community, its content, and its opinions are our own.",
   },
   {
     id: "gen-6",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -117,11 +117,6 @@ export const CONTACT = {
   city: "Nairobi, Kenya",
 } as const;
 
-// ─── Partners ───
-export const partners = [
-  { name: "Anthropic", url: "https://anthropic.com" },
-] as const;
-
 // ─── Official Resource URLs ───
 export const RESOURCE_URLS = {
   claude: "https://claude.ai",


### PR DESCRIPTION
## Why

The Ambassador Handbook requires ambassadors to present as volunteers (never as Anthropic), and reserves partner/co-host/sponsor framing for listed Claude customers branded "Claude Community x [Partner]". The site's OG/Twitter metadata claimed to be "Kenya's official Anthropic developer community", contradicting its own footer disclaimer, and event pages carried "Partner Organizations" framing for non-customer orgs. Full audit: `reference/fluent-cck-entanglement-audit.md` in the CCK HQ folder.

## What

- OG/Twitter metadata: "official Anthropic developer community" → "independent, volunteer-run, and Anthropic-supported"
- "Official Anthropic tie" section → "The Anthropic connection", leading on independence
- About: "Anthropic-recognized" → volunteer role in the founding global ambassador cohort
- FAQ Anthropic-relationship answer now carries the independence disclaimer
- Partner sweep: "Partner Organizations" → "With Thanks To"; seed copy drops "In partnership with"; admin field relabeled with a rule note; join CTAs → "Host an event with us"
- Removes the unused `partners = [Anthropic]` constant

## Verified

- `npm run build` green (includes prisma generate + type check)
- Full-repo lint identical to main (all 37 errors pre-existing, none in this diff)

## ⚠ Note for reviewers

`redesign/karibu-motion` (48 commits ahead) still contains the "official Anthropic" copy and needs the same sweep or a rebase onto this fix before it merges — otherwise it reintroduces the violation.

@Spidey-Acer