### PR TITLE
content: finish first->only sweep + backfill 3 missing events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Community Kenya
 
-> Africa's first Claude developer community — official community website.
+> Africa's only Claude developer community — official community website.
 
 **Live site:** [claudekenya.org](https://www.claudekenya.org)
 

--- a/prisma/events-backfill.ts
+++ b/prisma/events-backfill.ts
@@ -1,0 +1,91 @@
+/**
+ * events-backfill — completed CCK events the live site is missing.
+ *
+ * The production DB stops at the 4 Apr record; these three events ran and are
+ * documented in the Anthropic reimbursement invoices (CLAUDE-NBO-002/003/004)
+ * and the CCK HQ events dossier (`C:\Projects\Claude-Community-Kenya\EVENTS.md`,
+ * assembled 2026-07-21), but were never added to the website.
+ *
+ * Only events with a paper trail and Completed status are here. Deliberately
+ * excluded, pending Peter's confirmation:
+ *   - 4 Apr "Claude Code Hackathon" — DB says UPCOMING/venue-TBA, no completion
+ *     record, a funding-constraint note in the logs. Unconfirmed whether it ran.
+ *   - 25-26 Jul "Impact Lab / AI Mashinani" — real and upcoming, but its Luma
+ *     page is not yet published, so there is no registration link to show.
+ *
+ * Fields left null (time-of-day, exact attendee counts for the workshops) are
+ * genuinely unrecorded in the sources — not fabricated. Update from /admin/events
+ * once the real figures are known.
+ *
+ * Consumed by scripts/karibu/sync-events.ts (dry-run by default).
+ */
+
+import { EventType, EventStatus } from "../src/generated/prisma/client"
+
+export const EVENTS_BACKFILL = [
+  {
+    slug: "claude-for-everyone-workshop-apr",
+    title: "Claude for Everyone — Non-Developer Workshop",
+    date: new Date("2026-04-28T00:00:00+03:00"),
+    time: "Afternoon (3 hours) EAT",
+    venue: "Blockchain Centre",
+    city: "Nairobi",
+    type: EventType.WORKSHOP,
+    status: EventStatus.COMPLETED,
+    host: "Sam Kyalo & Billy Mwangi",
+    description:
+      "A hands-on session for non-developers — professionals grouped by field, each building a real Claude automation for a task from their own week.",
+    fullDescription:
+      "A three-hour workshop co-hosted by Sam Kyalo and Billy Mwangi, built for people who don't write code. Attendees sat at profession-grouped tables and each group built a working Claude automation against a real task from their own working week — turning \"AI is interesting\" into \"AI did my Tuesday.\"",
+    highlights: [
+      "Built for non-developers",
+      "Profession-grouped, hands-on format",
+      "Every group shipped a real Claude automation",
+    ],
+    featured: false,
+  },
+  {
+    slug: "claude-code-workshop-developers",
+    title: "Claude Code Workshop for Developers",
+    date: new Date("2026-04-29T00:00:00+03:00"),
+    time: "Afternoon EAT",
+    venue: "Blockchain Centre",
+    city: "Nairobi",
+    type: EventType.WORKSHOP,
+    status: EventStatus.COMPLETED,
+    host: "Sam Kyalo & Billy Mwangi",
+    description:
+      "A hands-on developer workshop covering repo-level workflows, hooks, custom skills, and agent dispatch patterns.",
+    fullDescription:
+      "The developer counterpart to the non-dev session, co-hosted by Sam Kyalo and Billy Mwangi. A hands-on deep dive into production Claude Code: repo-level workflows, hooks, custom skills, and multi-agent dispatch patterns — the same techniques the CCK team ships with daily.",
+    highlights: [
+      "Repo-level Claude Code workflows",
+      "Hooks, custom skills, and agent dispatch",
+      "Hands-on, developer-focused",
+    ],
+    featured: false,
+  },
+  {
+    slug: "kisumu-claude-developers-hackathon",
+    title: "Kisumu — Claude for Developers Mini-Hackathon",
+    date: new Date("2026-05-23T00:00:00+03:00"),
+    time: "Full day EAT",
+    venue: "Zone01",
+    city: "Kisumu",
+    type: EventType.HACKATHON,
+    status: EventStatus.COMPLETED,
+    host: "Peter Kibet",
+    partnerOrg: "Zone01 Kisumu",
+    description:
+      "The community's first out-of-town event — around 50 developers in Kisumu took an idea from validation to a deployed multi-agent app in a one-hour buildathon.",
+    fullDescription:
+      "Claude Community Kenya's first event beyond Nairobi. Roughly 50 developers gathered at Zone01 in Kisumu for a live ideation-to-production demo followed by a one-hour buildathon — in which the room built and deployed a multi-agent Startup Idea Validator together, end to end.",
+    highlights: [
+      "~50 developers attended",
+      "First out-of-town CCK event",
+      "The room built and deployed a multi-agent Startup Idea Validator",
+    ],
+    attendeeCount: 50,
+    featured: false,
+  },
+] as const

--- a/scripts/karibu/sync-events.ts
+++ b/scripts/karibu/sync-events.ts
@@ -1,0 +1,70 @@
+/**
+ * sync-events — upsert the backfill events, and nothing else.
+ *
+ * The full seed touches users, team, projects and blog; this syncs only the
+ * events in prisma/events-backfill.ts, so it is safe to run against production.
+ *
+ * Matched by slug. On an existing row, content fields are refreshed; nothing is
+ * ever deleted or its status downgraded here. New rows are created as listed.
+ *
+ * Dry run by default — prints the plan and changes nothing.
+ * Apply with:  DATABASE_URL='postgresql://...' npx tsx scripts/karibu/sync-events.ts --apply
+ */
+
+import { requireDatabaseUrl } from "./db-target"
+import { EVENTS_BACKFILL } from "../../prisma/events-backfill"
+
+const APPLY = process.argv.includes("--apply")
+
+requireDatabaseUrl()
+
+async function main() {
+  // Imported inside main() so the guard reports a missing DATABASE_URL before
+  // prisma connects. Dynamic because tsx compiles this to CJS.
+  const { prisma } = await import("../../src/lib/prisma")
+
+  try {
+    const slugs = EVENTS_BACKFILL.map((e) => e.slug)
+    const existing = await prisma.event.findMany({
+      where: { slug: { in: slugs } },
+      select: { slug: true },
+    })
+    const known = new Set(existing.map((e) => e.slug))
+
+    for (const e of EVENTS_BACKFILL) {
+      const verb = known.has(e.slug) ? "update" : "CREATE"
+      console.log(`  ${verb.padEnd(6)} ${e.date.toISOString().slice(0, 10)}  ${e.title}`)
+    }
+
+    if (!APPLY) {
+      const creates = EVENTS_BACKFILL.filter((e) => !known.has(e.slug)).length
+      console.log(
+        `\nDRY RUN — ${creates} to create, ${EVENTS_BACKFILL.length - creates} to update. Re-run with --apply.`,
+      )
+      return
+    }
+
+    for (const e of EVENTS_BACKFILL) {
+      // Prisma needs Json fields spread explicitly; the const arrays are fine as-is.
+      const data = {
+        ...e,
+        highlights: e.highlights ? [...e.highlights] : undefined,
+      }
+      await prisma.event.upsert({
+        where: { slug: e.slug },
+        update: data,
+        create: data,
+      })
+    }
+
+    const total = await prisma.event.count()
+    console.log(`\nSynced ${EVENTS_BACKFILL.length} event(s). ${total} events now in the database.`)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -6,14 +6,14 @@ import { KaribuJoin } from "@/components/karibu/KaribuJoin";
 export const metadata: Metadata = {
   title: `Join | ${SITE_CONFIG.name}`,
   description:
-    "Join Africa's first Claude developer community. Attend meetups in Nairobi and Mombasa, learn Claude Code, and build with AI.",
+    "Join Africa's only Claude developer community. Attend meetups in Nairobi and Mombasa, learn Claude Code, and build with AI.",
   alternates: {
     canonical: `${SITE_CONFIG.url}/join`,
   },
   openGraph: {
     title: `Join | ${SITE_CONFIG.name}`,
     description:
-      "Join Africa's first Claude developer community. Attend meetups in Nairobi and Mombasa, learn Claude Code, and build with AI.",
+      "Join Africa's only Claude developer community. Attend meetups in Nairobi and Mombasa, learn Claude Code, and build with AI.",
     url: `${SITE_CONFIG.url}/join`,
     siteName: SITE_CONFIG.name,
     type: "website",

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -2,7 +2,7 @@ import { ImageResponse } from "next/og";
 
 export const runtime = "edge";
 
-export const alt = "Claude Community Kenya — Africa's First Claude Developer Community";
+export const alt = "Claude Community Kenya — Africa's Only Claude Developer Community";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -8,12 +8,12 @@ export const revalidate = 1800
 export const metadata: Metadata = {
   title: "The team behind CCK | Claude Community Kenya",
   description:
-    "Meet the organizers, ambassadors, and contributors who run Claude Community Kenya — Africa's first Claude developer community.",
+    "Meet the organizers, ambassadors, and contributors who run Claude Community Kenya — Africa's only Claude developer community.",
   alternates: { canonical: "https://www.claudekenya.org/team" },
   openGraph: {
     title: "The team behind CCK | Claude Community Kenya",
     description:
-      "Meet the organizers and ambassadors running Africa's first Claude developer community.",
+      "Meet the organizers and ambassadors running Africa's only Claude developer community.",
     url: "https://www.claudekenya.org/team",
     siteName: "Claude Community Kenya",
     type: "website",

--- a/src/components/terminal/application/boot.ts
+++ b/src/components/terminal/application/boot.ts
@@ -24,7 +24,7 @@ export const BOOT_LINES: TerminalLine[] = [
 ];
 
 export const BOOT_INTRO_TEXT = [
-  "Africa's first Claude developer community.",
+  "Africa's only Claude developer community.",
   "Want in? Let's go.",
 ];
 

--- a/src/data/faq.ts
+++ b/src/data/faq.ts
@@ -12,7 +12,7 @@ export const faqs: FAQ[] = [
     category: "general",
     question: "What is Claude Community Kenya?",
     answer:
-      "Africa's first Claude developer community. We organize meetups, workshops, and career talks focused on building with Claude AI across Kenya.",
+      "Africa's only Claude developer community. We organize meetups, workshops, and career talks focused on building with Claude AI across Kenya.",
   },
   {
     id: "gen-2",

--- a/src/lib/chat/community-context.ts
+++ b/src/lib/chat/community-context.ts
@@ -63,7 +63,7 @@ export async function buildCommunityContext(): Promise<string> {
   return `
 === KEY FACTS ===
 - Community name: Claude Community Kenya (CCK)
-- Africa's first Claude developer community
+- Africa's only Claude developer community
 - First meetup: January 24, 2026 at iHiT Events Space, Westlands, Nairobi
 - Events hosted (completed): ${completedCount}
 - Cities: Nairobi + Mombasa (expanding)

--- a/src/lib/karibu/system-prompt.ts
+++ b/src/lib/karibu/system-prompt.ts
@@ -66,7 +66,7 @@ export async function buildKaribuPrompt(): Promise<string> {
     .map((r) => `- "${r.title}" — for: ${r.audiences.join(", ") || "all"}`)
     .join("\n");
 
-  return `You are Claude, greeting a first-time visitor to Claude Community Kenya (CCK), Africa's first Anthropic-supported Claude developer community.
+  return `You are Claude, greeting a first-time visitor to Claude Community Kenya (CCK), Africa's only Anthropic-supported Claude developer community.
 
 # Your job
 Run a SHORT (4 turns max) onboarding conversation. By the end, call the record_visitor tool ONCE with everything you learned. The conversation must feel like a warm, fast greeting — not a form.


### PR DESCRIPTION
Two pieces that landed on `redesign/karibu-motion` **after** PR #40 was cut, so they never reached `main`. PR #41's compliance work is complementary — this doesn't touch the copy #41 already fixed.

## 1. Finish the "Africa's first" → "only" sweep
`main` is internally inconsistent: `persona-content.ts` and the homepage say **"only"** (the deliberate stance — *"Not the first — the only one"*), while 8 other surfaces still said **"first"** — including `/join`, `/team`, the OG image, the FAQ, and **both AI system prompts** (`community-context.ts`, `karibu/system-prompt.ts`), where the chatbot was fed "first" as a KEY FACT and would contradict the site.

Swept to "only" everywhere. Deliberately left `"Africa's first Claude hackathon"` in the seed untouched — that's a factual claim about the event, not the community superlative.

## 2. Backfill 3 completed events missing from the site
The live DB stops at the 4 Apr record. The 28 Apr non-dev workshop, 29 Apr developer workshop, and 23 May Kisumu mini-hackathon all ran (documented in the Anthropic reimbursement invoices CLAUDE-NBO-002/003/004 and the CCK events dossier) but were never added.

- `prisma/events-backfill.ts` — the three events; unrecorded fields (exact times, workshop headcounts) left null, not fabricated
- `scripts/karibu/sync-events.ts` — dry-run by default, upsert by slug, never deletes/downgrades. Run `--apply` against prod after the merge.

Deliberately **excluded** pending Peter's call: the 4 Apr hackathon (unconfirmed it ran) and the 25–26 Jul Impact Lab (real, but its Luma page isn't published, so no registration link).

## Verify
`npm run build` and `npx tsc --noEmit` both pass.

@Spidey-Acer