### PR TITLE
HOTFIX #2: admin loop — expose role to the edge proxy (log-confirmed root cause)

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -8,6 +8,19 @@ export const authConfig = {
   },
   providers: [], // Providers defined in auth.ts (non-Edge only)
   callbacks: {
+    // Expose `role` on the session in the EDGE runtime. The proxy/middleware
+    // (proxy.ts) gates /admin on session.user.role; without this callback the
+    // edge session has no role, so every admin request 307-redirects to
+    // /admin/login while the Node-rendered login page (which DOES see the role)
+    // sends the user back to /admin — an infinite loop that locked admins out.
+    // auth.ts defines a richer session callback for Node; this is the edge-safe
+    // minimum that must exist in the shared config the middleware runs.
+    session({ session, token }) {
+      if (session.user && typeof token.role === "string") {
+        ;(session.user as { role?: string }).role = token.role
+      }
+      return session
+    },
     authorized({ auth, request: { nextUrl } }) {
       const isLoggedIn = !!auth?.user
       const role = (auth?.user as { role?: string } | undefined)?.role


### PR DESCRIPTION
## The actual root cause (from production logs)

`vercel logs` on the looping traffic showed:
- `/admin` → **307** from `serverless-middleware` (the proxy redirects it)
- `/admin/login` → **200** (renders, then sends the user back to /admin)

The middleware redirects every `/admin` request to `/admin/login`. `proxy.ts` gates `/admin` on `session.user.role`, but **`auth.config.ts` (the config the edge middleware runs) had no `session` callback**, so `role` is `undefined` in the edge. The Node runtime (`auth.ts`, which has its own session callback) sees the role fine — so the two layers disagree: edge sends admin → login, Node sends login → admin. Infinite loop, all admins locked out.

This is **not** the session-revalidation reverted in #43 — that was a separate, unrelated change. #43's revert was correct to keep (per-request cookie rotation is still bad) but it was not this bug.

## Fix

Add the edge-safe `session` callback to `auth.config.ts` so the middleware can read `role`. One callback, no behavior change for the Node side.

## Verification

Build + typecheck + lint clean. **After merge+deploy I will confirm from `vercel logs` that `/admin` returns 200 (not 307)** before calling this fixed — not repeating the "claim it works" mistake.

**Merge to restore admin access.**

@Spidey-Acer