### PR TITLE
feat: Impact Lab team matching (deterministic engine + Claude explanation layer)

### DIFF
--- a/docs/impact-lab-matching-spec.md
+++ b/docs/impact-lab-matching-spec.md
@@ -1,0 +1,148 @@
+# Impact Lab Team Matching — Implementation Spec / Prompt
+
+**Status:** Ready to execute. Paste the "Implementation Prompt" section below into Claude Code
+(or run it via the Claude API) to build the feature in this repo.
+
+**Deadline context:** Impact Lab / AI Mashinani runs **25–26 July 2026** (see
+`prisma/events-backfill.ts`). Teams have already applied; matching must be usable before the event.
+
+**Provenance:** Design informed by an audit of
+[best-ed/HackMatch-AI](https://github.com/best-ed/HackMatch-AI) (2026-07-21).
+That repo has **no LICENSE file** and `"private": true` in package.json — all rights reserved by
+default. **Do NOT copy code from it.** This spec describes the concepts (which are not
+copyrightable) for a clean reimplementation in our own stack, or obtain written permission from
+the repo owner first.
+
+---
+
+## What HackMatch-AI does (audit summary)
+
+- **Deterministic matcher, AI explains only.** Teams are assigned by a pure algorithm; an
+  optional LLM call explains the already-final assignments and can never change them.
+- Algorithm pipeline: validate → normalize roles/skills → exclude non-consenting →
+  honor blocked-teammate + locked-team constraints → seed teams with scarce/high-impact roles →
+  distribute advanced participants → greedy fill by marginal contribution score →
+  deterministic pairwise swap optimization → per-team 0–100 score breakdown.
+- Score dimensions (weighted): role coverage, skill balance, experience balance, interest
+  alignment, availability overlap, participant preference satisfaction, minus constraint
+  penalties.
+- Organizer features: cohorts, settings presets, locked teams, saved runs (frozen snapshots),
+  mark-final, CSV import/export, health checks.
+- Weaknesses we will NOT inherit: localStorage persistence (data trapped in one browser),
+  env-gated admin auth that is **open by default**, OpenAI-only explanation layer.
+
+## Feasibility verdict
+
+**Yes — port is feasible.** The matching engine is ~1,450 lines of dependency-free TypeScript
+concepts that map cleanly onto our stack. Our repo already has the hard parts HackMatch lacks:
+real Postgres/Prisma persistence, NextAuth-protected admin, RBAC, rate limiting, audit logging.
+Lean scope below is 1–2 focused days.
+
+## Open decision (confirm with Peter before running)
+
+**Where does participant data come from?**
+- **Default (lean):** CSV import into admin from wherever applications live today
+  (Luma export / Google Form sheet). Ship this first.
+- **Stretch:** public registration form at `/impact-lab/register` in the Karibu design.
+  Only if time remains before the 25th.
+
+---
+
+## Implementation Prompt
+
+> Copy everything below into Claude Code, running in the Claude-Community-Kenya repo.
+
+You are implementing **Impact Lab team matching** for claudekenya.org (this repo: Next.js 16
+App Router, TypeScript strict, Prisma 7 + PostgreSQL, NextAuth v5, Tailwind v4, Upstash rate
+limiting). Follow the repo's CLAUDE.md conventions. Do not copy code from any external repo —
+implement from this spec. Plan first, then execute.
+
+### 1. Data model (Prisma — use `npm run db:migrate`, never reset)
+
+Add two models (+ enums), following existing schema conventions:
+
+- `ImpactLabParticipant`: id, cohort (String, default "impact-lab-2026-07"), fullName, email
+  (unique per cohort), phone?, institution?, experienceLevel (enum BEGINNER/INTERMEDIATE/ADVANCED
+  — reuse existing `Experience` enum if compatible), primaryRole (String), secondaryRoles
+  String[], technicalSkills String[], interests String[], availability String[],
+  projectIdeas? (Text), preferredTeammates String[] (emails), blockedTeammates String[]
+  (emails, never shown publicly), consentToMatch Boolean @default(false), consentToShareContact
+  Boolean @default(false), createdAt/updatedAt. Index on (cohort).
+- `ImpactLabMatchRun`: id, cohort, name, notes?, isFinal Boolean @default(false),
+  settings Json, result Json (teams + score breakdowns + warnings + unassigned),
+  participantsSnapshot Json, createdBy (relation to User), createdAt. Only one run per cohort
+  may be `isFinal` — enforce in the API layer.
+
+### 2. Matching engine — `src/lib/matching/` (pure, deterministic, zero deps)
+
+Modules: `types.ts`, `normalization.ts`, `constraints.ts`, `scoring.ts`, `algorithm.ts`,
+`optimization.ts`, `explanations.ts` (deterministic fallback). Rules:
+
+- **Determinism is a hard requirement:** no `Math.random`, no `Date.now` inside the engine;
+  all iteration orders sorted (by id as final tiebreaker). Same input → identical output.
+- Settings type: desiredTeamSize (default 4), minTeamSize 3, maxTeamSize 5, numberOfTeams?,
+  allowUnassignedParticipants, requireBuilder, requirePresenter, preventBeginnerOnlyTeams,
+  distributeAdvancedParticipants, lockedTeams?, and weights for: roleCoverage (2),
+  skillBalance (1.5), experienceBalance (1.4), interestAlignment (1), availabilityOverlap (1),
+  participantPreferences (0.8).
+- Normalization: lowercase/trim roles, skills, interests; map synonyms to canonical role slugs
+  (builder/developer, designer, presenter/pitcher, data, product).
+- Hard constraints: consentToMatch required to be matched; blockedTeammates never share a team;
+  locked teams pass through untouched; team size within [min, max].
+- Algorithm: (a) compute target team count = ceil(eligible / desiredTeamSize) unless
+  numberOfTeams set; (b) seed one scarce/high-impact-role participant per team (scarcity =
+  1/roleCount, prioritize presenter > designer > data > product > builder, weight experience);
+  (c) if distributeAdvancedParticipants, place advanced participants round-robin by best
+  marginal contribution; (d) fill everyone else greedily into the team where their **marginal
+  score contribution** (score-with minus score-without, minus a size penalty, plus a bonus for
+  preferred teammates already present) is highest; (e) run deterministic pairwise swap passes:
+  try swapping members between team pairs, keep a swap only if total score strictly improves,
+  repeat until no improvement or max 3 passes.
+- Scoring (0–100 per team): weighted sum of the six dimensions, minus penalties (beginner-only
+  team, missing builder/presenter when required, size violations). Return a full breakdown
+  object per team — the UI must show WHY a team scored what it did.
+- `explanations.ts`: deterministic text summaries (strengths, gaps, suggested internal roles)
+  built from the score breakdown — used as fallback when the AI layer is off or fails.
+
+### 3. Claude API explanation layer (env-gated, never assigns)
+
+- `src/lib/matching/ai-explanations.ts` + route `POST /api/admin/impact-lab/explain`.
+- Server-side only. Use `ANTHROPIC_API_KEY` env var; model `claude-sonnet-5` via the Messages
+  API with **tool use / structured output** enforcing a strict schema: per team — summary,
+  strengths[], weaknesses[], suggestedProjectDirection, suggestedInternalRoles (participantId →
+  role), warnings[].
+- System instruction: "Teams were already assigned by a deterministic algorithm. Explain the
+  assignments; never propose changing membership; only reference supplied participants."
+- Validate the response: drop explanations for unknown teamIds; role suggestions must map to
+  participants actually on that team; any invalid/missing team falls back to the deterministic
+  explanation. On any API error, return fallback explanations with a warning — never fail the
+  page.
+- Send the model only matching-relevant fields (names, roles, skills, levels, availability) —
+  no phone numbers, no blockedTeammates.
+- Protect the route with existing admin auth + `src/lib/rate-limit` + write an
+  `src/lib/audit-log` entry per run.
+
+### 4. Admin UI — `/admin/impact-lab` (follow existing admin panel patterns)
+
+- **Participants tab:** table (name, role, level, skills, consent), CSV import with column
+  mapping + preview + row-level validation errors, inline edit, delete. CSV export.
+- **Matching tab:** settings form (sizes, toggles, weights), Generate button, results as team
+  cards with score breakdown bars, per-team lock toggle, Regenerate (respects locks), warnings
+  list, unassigned list.
+- **Runs tab:** save current result as named run, list runs, view snapshot, mark one as Final
+  (confirm dialog; unmarks any previous final), export final teams CSV (team, member names,
+  emails only if consentToShareContact).
+- All mutations behind existing CSRF + admin session checks; use existing UI components
+  (`src/components/admin/`, `src/components/ui/`).
+
+### 5. Non-negotiables
+
+- `npm run build && npx tsc --noEmit` must pass clean before every commit.
+- Conventional commits, one concern per commit, on a feature branch (e.g.
+  `feat/impact-lab-matching`).
+- No `any`, no console.log, no magic numbers (weights/defaults as named constants).
+- Unit-test the engine's pure functions if test infra exists; otherwise add a
+  `scripts/verify-matching.ts` script that runs the engine on fixture data and asserts
+  determinism (two runs → deep-equal results) and constraint compliance.
+- YAGNI: no cohort archive/handoff/backup features from HackMatch — CSV import, match,
+  explain, save runs, export. That's the MVP for the 25th.

--- a/docs/impact-lab/01-data-model.md
+++ b/docs/impact-lab/01-data-model.md
@@ -1,0 +1,78 @@
+# 01 — Data Model
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+> Each doc in this folder explains one logical chunk so the feature doubles as a
+> learning reference.
+
+## What we added
+
+Two Prisma models and one enum in `prisma/schema.prisma`, plus a hand-authored
+migration at `prisma/migrations/20260721160000_impact_lab_matching/`.
+
+- `ImpactLabParticipant` — one hackathon applicant.
+- `ImpactLabMatchRun` — a frozen snapshot of one matching run.
+- `ImpactLabExperience` — `BEGINNER | INTERMEDIATE | ADVANCED`.
+
+## Decisions worth understanding
+
+### 1. Why a new experience enum instead of reusing `Experience`
+
+The repo already has an `Experience` enum, but it tracks *Claude familiarity*
+(`never_used → claude_ai → claude_code → api_builder`). The matcher needs a
+generic *skill ladder* to balance strong and new builders across teams. Those are
+different axes — forcing one to serve both would couple the matcher to a
+Claude-specific vocabulary it has no reason to care about. New enum, clean model.
+
+**Lesson:** reuse a type only when the *meaning* matches, not just the shape.
+
+### 2. Native `String[]` over `Json` arrays
+
+Older models in this repo store arrays as `Json` (e.g. `BlogPost.tags`). Newer
+ones use Postgres native arrays (`Event.audiences Audience[]`). We use `String[]`
+for `technicalSkills`, `interests`, etc. because:
+
+- The matcher iterates and set-intersects these constantly — native arrays are
+  typed as `string[]` by Prisma with no `JSON.parse`/casting at every read.
+- They're queryable (`has`, `hasSome`) if we ever need to filter server-side.
+
+### 3. `@@unique([cohort, email])` — scoped uniqueness
+
+Email is unique *within a cohort*, not globally. The same person can attend a
+future Impact Lab under a new cohort string without a collision, and CSV re-import
+into the same cohort can safely upsert on `(cohort, email)`.
+
+### 4. Snapshotting: `settings` + `participantsSnapshot` + `result` as `Json`
+
+A match run captures everything it needs to be re-read identically later, even
+after participants are edited or deleted. This is the antidote to the audited
+project's localStorage approach — runs are durable rows, not browser state. We
+store them as `Json` because their shape is owned by the matching engine
+(`src/lib/matching/types.ts`), not the database; the DB is just a safe.
+
+### 5. `isFinal` enforced in the API layer, not the DB
+
+Postgres can express "at most one final per cohort" with a partial unique index,
+but that would make swapping the final run a two-statement dance that can
+transiently violate the constraint. Enforcing it in the API (unset the old final,
+set the new one, in a transaction) keeps the swap atomic and the rule readable
+where it's actually applied. Documented as a deliberate trade-off.
+
+### 6. `createdBy` uses `onDelete: SetNull`
+
+Every user-linked model in this repo detaches rather than cascades
+(`onDelete: SetNull`). Deleting an admin should never delete the match-run
+history they happened to generate. We follow the house pattern.
+
+## Applying the migration
+
+This environment has no `DATABASE_URL`, so the migration SQL was hand-authored to
+match Prisma's own output format (compare against
+`prisma/migrations/20260324091654_community_hub/`). Against a real database:
+
+```bash
+npm run db:migrate      # prisma migrate dev — applies the pending migration
+```
+
+Because the SQL already reflects the exact schema diff, `migrate dev` applies it
+as-is without generating a second migration. **Never** `prisma migrate reset` on
+a database with real applications in it.

--- a/docs/impact-lab/02-engine-design.md
+++ b/docs/impact-lab/02-engine-design.md
@@ -1,0 +1,67 @@
+# 02 — Engine Design: Types & Constants
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+## The one rule that shapes everything: the engine is pure
+
+`src/lib/matching/` is a **pure, dependency-free** module. It imports nothing
+from Prisma, Next, or the network. It takes plain objects in and returns plain
+objects out.
+
+Why this matters:
+
+- **Testability** — we can run it on fixtures in a plain `tsx` script with no
+  database (see [09-verification.md](./09-verification.md)).
+- **Determinism** — with no I/O, no clock, and no randomness, the same input
+  *always* produces the same output. That's a hard requirement (organisers must
+  be able to re-run and defend a result), and purity is how we get it for free.
+- **Portability** — the audited project trapped its logic behind a UI and
+  localStorage. Ours is a library; the API layer and the verify script are just
+  two different callers.
+
+The boundary is enforced by types: the API layer maps a Prisma
+`ImpactLabParticipant` row into a plain `MatchParticipant` (`types.ts`), and
+persists the returned `MatchResult` as JSON. The engine never sees a database row.
+
+## Two participant shapes, on purpose
+
+- `MatchParticipant` — **raw input.** Role strings as the human typed them,
+  skills un-normalized. It carries only matching-relevant fields; no phone, no
+  institution. `blockedTeammates` rides along *only* so the constraint layer can
+  honour it — it is never passed to scoring, explanations, or the AI.
+- `NormalizedParticipant` — **the engine's working shape.** Roles canonicalized,
+  skills/interests/availability lowercased and deduped. Everything after
+  normalization operates exclusively on this.
+
+Splitting them means normalization happens exactly once, at a known boundary, and
+the type system stops us from accidentally scoring un-normalized data.
+
+## Why score breakdowns are structured, not just a number
+
+`ScoreBreakdown` keeps every dimension's `raw` (0–1), its `weight`, and its
+`weighted` contribution, plus a list of named `PenaltyEntry`. The UI renders this
+object directly. A team doesn't just score 72 — it scores 72 *because* role
+coverage was perfect but experience balance was weak and it took a −20 for being
+beginner-only. Transparency is a feature, not debug output.
+
+## Everything tunable lives in `constants.ts`
+
+No magic numbers anywhere in the engine. Weights, size bounds, the role synonym
+map, experience weights, penalty magnitudes, and the greedy-fill bonuses are all
+named constants. Two consequences:
+
+1. Reading `constants.ts` tells you exactly how the matcher is tuned.
+2. `DEFAULT_SETTINGS` seeds the admin form, and any field can be overridden per
+   run through `MatchSettings` without touching engine code.
+
+## Role vocabulary
+
+Five canonical roles: `builder`, `designer`, `presenter`, `data`, `product`.
+`ROLE_SYNONYMS` maps free-text ("dev", "UI/UX", "pitcher", "ML engineer") onto
+them. The map is deliberately conservative — an unmapped role contributes no
+canonical role rather than being force-fit, because a silent wrong mapping is
+harder to catch than a visibly missing one.
+
+`ROLE_PRIORITY` (`presenter > designer > data > product > builder`) drives
+seeding: scarce, high-impact roles are placed first so no team ends up with
+nobody to present. Builders are last because they're usually the most abundant.

--- a/docs/impact-lab/03-normalization.md
+++ b/docs/impact-lab/03-normalization.md
@@ -1,0 +1,50 @@
+# 03 — Normalization
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+`src/lib/matching/normalization.ts` is the boundary where messy human input
+becomes clean, canonical data. Every stage after this can assume the data is
+tidy — which is exactly why we do it once, here.
+
+## What it cleans
+
+| Field | Raw | Normalized |
+|-------|-----|------------|
+| roles | `"Dev"`, `"UI/UX"`, `"Pitcher"` | `builder`, `designer`, `presenter` |
+| skills / interests / availability | `" React "`, `"react"` | `react` (deduped) |
+| emails | `" Ann@X.io "` | `ann@x.io` |
+
+## The determinism backbone: sort by id, once
+
+`normalizeParticipants` sorts the input by `id` before mapping. This is small but
+load-bearing. Every later stage (seeding, greedy fill, swap passes) iterates over
+participants; if that iteration order depended on how rows arrived from the
+database or a CSV, two runs on the same data could diverge. Fixing the order at
+the entry point means the whole pipeline inherits a stable order.
+
+Combined with "no `Math.random`, no `Date.now`" inside the engine, this is what
+makes **same input → identical output** true.
+
+## Dedupe preserves first-seen order
+
+`normalizeTokenList` and `normalizeEmailList` dedupe with a `Set` but keep the
+first occurrence's position rather than sorting alphabetically. Two reasons:
+
+- The order a participant listed their skills carries mild signal (they tend to
+  list their strongest first); we don't destroy it.
+- It's still deterministic, because the input order is already fixed upstream.
+
+## Unmapped roles are dropped, not guessed
+
+`canonicalizeRole` returns `CanonicalRole | null`. If someone writes "vibes
+coordinator", it maps to nothing and contributes no canonical role. We could
+fuzzy-match, but a *wrong* mapping is invisible and corrupts scoring silently,
+whereas a *missing* one shows up as a gap the organiser can eyeball and fix in
+the participant record. Conservative on purpose.
+
+## `roles` vs `primaryRole`
+
+- `roles` — the full canonical set (primary + secondaries), deduped, **primary
+  first**. Used by role-coverage scoring: a person covers all the roles they can.
+- `primaryRole` — just the canonical primary, or null. Used by seeding, where we
+  care specifically what someone leads with.

--- a/docs/impact-lab/04-constraints.md
+++ b/docs/impact-lab/04-constraints.md
@@ -1,0 +1,62 @@
+# 04 — Hard Constraints
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+## Hard vs soft
+
+The engine has two kinds of rules:
+
+- **Hard constraints** (this file) — inviolable. No score, however high, may
+  break them. Checked *before* a placement is scored.
+- **Soft preferences** (scoring, [05](./05-scoring.md)) — things we optimise
+  *for*, expressed as points. A better arrangement can outweigh them.
+
+Keeping these separate is the core discipline of the whole matcher. The scorer
+never has to worry about legality, because it only ever ranks arrangements that
+are already legal.
+
+## The four hard constraints
+
+### 1. Consent — filtered on raw input
+
+`partitionByConsent` runs on raw `MatchParticipant`s, before normalization. A
+participant without `consentToMatch` never enters the engine's working set. The
+payoff: every `NormalizedParticipant` downstream has, *by construction*, already
+consented — no stage has to re-check. Excluded ids come back so we can warn the
+organiser "3 people weren't matched: they haven't consented."
+
+### 2. Blocks — symmetric
+
+`participantsConflict(a, b)` is true if *either* blocked the other. If A doesn't
+want to work with B, we keep them apart whether or not B reciprocated. Blocks are
+the one place `blockedTeammates` is read — and it's read only here, never passed
+to scoring, explanations, or the AI layer. Privacy by data-flow, not by promise.
+
+### 3. Locked teams — pass through untouched
+
+`resolveLockedTeams` maps organiser-pinned teams (given by email, the identifier
+humans use) to participant ids. It defends against two real mistakes:
+
+- an email that matches nobody eligible → skip + warn,
+- the same person pinned to two teams → keep the first, skip + warn.
+
+Resolved locked members are removed from the pool the algorithm distributes, and
+their teams are emitted as-is. This replaces the audited project's behaviour
+cleanly: the organiser's manual decisions are respected absolutely.
+
+### 4. Size — one gate for every placement
+
+`canPlace(candidate, members, settings)` is the single function every placement
+passes through: it returns true only when the candidate adds no block conflict
+**and** the team is under `maxTeamSize`. `isValidTeamSize` separately validates a
+*finished* team against `[min, max]` so the scorer can penalise undersized teams
+that couldn't be avoided (e.g. leftover participants when unassigned isn't
+allowed).
+
+## Why check legality before scoring, not after
+
+The naive approach — build teams by score, then throw out illegal ones — wastes
+work and can paint you into a corner (the best-scoring arrangement might be
+illegal, and the legal fallback arbitrary). Gating at placement time means the
+search space *is* the legal space. Every intermediate state the algorithm holds
+is already valid.

--- a/docs/impact-lab/05-scoring.md
+++ b/docs/impact-lab/05-scoring.md
@@ -1,0 +1,63 @@
+# 05 — Scoring
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+`scoreTeam(members, context)` returns a `ScoreBreakdown`: six weighted
+dimensions, a normalized 0–100 total, and a list of named penalties. It never
+checks hard constraints — by the time a team is scored it's already legal.
+
+## The six dimensions
+
+Each is a **pure function** returning a raw score in `[0, 1]`. Keeping them
+separate and exported means the verify script and the UI can call them
+individually, and each is independently explainable.
+
+| Dimension | What it rewards | How |
+|-----------|-----------------|-----|
+| `roleCoverage` | Having the different roles a project needs | distinct canonical roles / 5 |
+| `skillBalance` | A complementary, non-redundant skill set | distinct skills / total skill mentions |
+| `experienceBalance` | A mix of levels *with* a mentor present | ½ level-spread + ½ has-non-beginner |
+| `interestAlignment` | Shared ground to pick a project | average pairwise interest Jaccard |
+| `availabilityOverlap` | Times everyone can actually meet | slots shared by all who stated any / union |
+| `participantPreferences` | Friends who asked to be together | avg fraction of resolvable wishes satisfied |
+
+## How raw scores become a 0–100 total
+
+```
+sumWeighted = Σ (raw_d × weight_d)
+maxWeighted = Σ weight_d              // every raw maxes at 1
+base        = sumWeighted / maxWeighted × 100
+total       = clamp(base − Σ penalties, 0, 100)
+```
+
+Normalizing by `maxWeighted` means the total is always on a 0–100 scale
+regardless of how the weights are set — an organiser can double a weight without
+blowing the scale. Default weights (role coverage 2, skill 1.5, experience 1.4,
+interest 1, availability 1, preferences 0.8) come straight from the spec and live
+in `constants.ts`.
+
+## Penalties are separate from dimensions — deliberately
+
+Penalties (`beginner-only −20`, `no builder −15`, `no presenter −15`, `size
+violation −12`) are subtracted *after* normalization and returned as their own
+list. Why not fold them into a dimension?
+
+- **They're categorical, not gradual.** A team either has a presenter or it
+  doesn't. That's a discrete cliff, not a smooth 0–1 signal.
+- **Explainability.** "Scored 58 (−20 beginner-only)" reads far better than a
+  mysteriously deflated experience-balance number.
+
+Note the interplay with soft settings: `requireBuilder`/`requirePresenter` here
+produce a *penalty*, not a hard block. Truly requiring a role is impossible when
+there simply aren't enough presenters to go around — so we make missing one
+expensive rather than forbidden, and surface it. Hard blocking lives only in
+[constraints](./04-constraints.md) (consent, blocks, size cap at placement time).
+
+## Edge cases, and why they're chosen
+
+- **Empty availability** is ignored, not counted as "never available", so one
+  person leaving it blank doesn't zero out an overlapping team.
+- **Unresolvable preferences** (a preferred email that never registered) are
+  dropped before scoring — a team isn't punished for a wish it *couldn't* grant.
+- **No preferences at all** → `participantPreferences = 1`. Nothing was left
+  unsatisfied, so the dimension is vacuously full rather than zero.

--- a/docs/impact-lab/06-algorithm.md
+++ b/docs/impact-lab/06-algorithm.md
@@ -1,0 +1,76 @@
+# 06 — The Algorithm
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+`algorithm.ts` orchestrates everything into a `MatchResult`. It's a **greedy
+constructive** algorithm: build teams up one placement at a time, always taking
+the locally best legal move, then (next commit) polish with swaps.
+
+## The pipeline
+
+```
+consent filter → normalize → resolve locked teams → size the run
+   → seed → distribute advanced → greedy fill → optimize → assemble
+```
+
+### Step 4 — sizing the run
+
+`targetTeamCount` = `numberOfTeams` if the organiser set it, else
+`ceil(pool / desiredTeamSize)`. It's then clamped so (a) there are always enough
+teams that nobody is forced above `maxTeamSize`, and (b) we never make more teams
+than we have people. Locked teams are *additional* — the count sizes only the
+unlocked pool.
+
+### Step 5 — seeding (the clever bit)
+
+We sort the pool by, in order: **role priority** (presenter → builder),
+**scarcity** (rarer primary role first), **experience** (advanced first), then
+id. Then we drop the first *N* onto the *N* teams, one each.
+
+Why this spreads scarce roles correctly: if presenters are both high-priority and
+scarce, they sort to the front, so the first few teams each get one presenter —
+never two on one team, never a team left presenter-less while another hoards them.
+When presenters run out, designers seed the rest, and so on. One elegant sort does
+what would otherwise be a pile of special cases.
+
+### Step 6 — distribute advanced participants
+
+Before the general fill, advanced participants are spread out: each goes to a
+legal team with the **fewest advanced members**, ties broken by marginal
+contribution. This stops the seniors clustering into one super-team that
+steamrolls the event — the whole point is teams that can each stand on their own.
+
+### Step 7 — greedy fill by marginal contribution
+
+Everyone left is placed, in id order, onto the team where their **marginal
+contribution** is highest:
+
+```
+marginal = score(team + candidate) − score(team)     // how much they help
+           − sizePenalty × currentMembers            // prefer smaller teams
+           + preferredTeammateBonus (if applicable)  // honour friendships
+```
+
+The size penalty is what keeps teams balanced instead of everyone landing on the
+one strong team. The preferred-teammate bonus is soft — it steers ties, it never
+overrides score or a hard constraint.
+
+If nobody's a legal home: unassigned (when allowed), else the least-bad
+block-legal team even if it goes over max — the size penalty then shows up
+honestly in that team's score.
+
+## Where determinism comes from
+
+- Participants arrive **id-sorted** from normalization.
+- Every sort has **id as the final tiebreaker**.
+- Member id lists and the unassigned list are **sorted before returning**.
+- No `Math.random`, no `Date.now`, no I/O anywhere in the module.
+
+The result: two runs on the same participants and settings are byte-for-byte
+identical. [09-verification.md](./09-verification.md) asserts exactly this.
+
+## The optimization seam
+
+`assign()` takes an optional `optimize` hook and applies it between fill and
+assembly. This keeps `algorithm.ts` independent of `optimization.ts`; `index.ts`
+wires the real optimizer into `runMatching`. See [07](./07-optimization.md).

--- a/docs/impact-lab/07-optimization.md
+++ b/docs/impact-lab/07-optimization.md
@@ -1,0 +1,54 @@
+# 07 — Pairwise Swap Optimization
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+## Why greedy isn't enough
+
+The greedy fill ([06](./06-algorithm.md)) places each participant onto the best
+team *at the moment they're placed*. But it can't see the future: someone placed
+early might have been a better fit for a team that didn't exist yet, or a later
+arrival might strand an earlier one on the wrong team. Greedy gets a good answer,
+rarely the best one.
+
+## Local search: swap and keep what helps
+
+`optimizeAssignment` does a classic **local search**. For every pair of teams and
+every pair of members across them, it tries the swap and keeps it only if the two
+teams' **combined score strictly improves**:
+
+```
+delta = score(teamI after) + score(teamJ after)
+      − score(teamI before) − score(teamJ before)
+keep the swap ⟺ delta > ε
+```
+
+Two properties make this safe:
+
+- **Size-preserving.** A swap is one-out-one-in per team, so team sizes never
+  change. The optimizer can't undo the balance the fill worked to achieve.
+- **Monotonic.** Every accepted swap strictly raises the total score, and the
+  total is bounded (≤ 100 × teams), so it converges. `MAX_SWAP_PASSES` (3) caps
+  it regardless, which also bounds the O(passes × teams² × size²) cost.
+
+## Two things that are easy to get wrong
+
+1. **A swap can create a block conflict.** The pre-swap teams were conflict-free,
+   but moving people around can put two people who blocked each other together.
+   So every candidate swap re-checks `teamHasConflict` on *both* resulting teams
+   and skips illegal ones. Hard constraints still win, always.
+2. **Locked teams must not move.** They're filtered out before optimization and
+   spliced back untouched in their original positions.
+
+## Determinism, again
+
+Teams are visited in fixed order, members in id-sorted order, and we take
+**first-improvement** (apply the first improving swap, keep scanning) rather than
+searching for the single best swap. Same input → same swaps → same output. The
+`ε` (`SWAP_IMPROVEMENT_EPSILON`, `1e-9`) exists purely so floating-point noise
+can't register as an "improvement" and churn between equivalent arrangements.
+
+## Wiring
+
+`algorithm.ts` stays independent of this module via its `optimize` hook.
+`index.ts` injects `optimizeAssignment` into `runMatching`, so every caller gets
+an optimized result by default while the two modules never import each other.

--- a/docs/impact-lab/08-explanations.md
+++ b/docs/impact-lab/08-explanations.md
@@ -1,0 +1,44 @@
+# 08 — Deterministic Explanations
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+A score of `72/100` isn't actionable on its own. `explanations.ts` turns each
+team's `ScoreBreakdown` into words an organiser can act on: what's strong, what's
+weak, who should lead what, and a possible project direction.
+
+## Why this exists *before* the AI layer
+
+This is the **fallback**. The Claude explanation layer ([10](./10-ai-layer.md))
+is env-gated and can fail (no API key, rate limit, network). When it's off or
+errors, these deterministic explanations are what the UI shows. So they're
+written to be genuinely useful on their own — never "AI unavailable" filler.
+
+Building the fallback first also forces a healthy discipline: the AI layer is an
+*enhancement*, not a dependency. The feature works fully without it.
+
+## What it produces per team
+
+- **Summary** — score, size, and experience spread ("2 advanced, 2 beginner").
+- **Strengths** — dimensions scoring ≥ 66%, named in plain language.
+- **Weaknesses** — dimensions scoring ≤ 40%, plus every penalty reason.
+- **Suggested internal roles** — `participantId → role`. The most experienced
+  member becomes "Team lead & coordinator"; everyone else is labelled by their
+  primary role. Purely a starting suggestion for the team to adopt or ignore.
+- **Suggested project direction** — the interest shared by the most members
+  (≥ 2), if any.
+- **Warnings** — the penalty reasons, surfaced explicitly.
+
+## Determinism carries through
+
+Every choice here is deterministic: the team lead is decided by experience then
+id; the shared interest breaks ties alphabetically; thresholds are named
+constants (`EXPLANATION_STRENGTH_THRESHOLD` etc.). The same team always produces
+the same explanation — which matters because [09](./09-verification.md) deep-
+equals two full runs, explanations included.
+
+## The `source` field
+
+Every `TeamExplanation` carries `source: "deterministic" | "ai"`. The UI can badge
+which produced a given explanation, and the AI layer reuses the exact same
+`TeamExplanation` shape — so swapping one for the other is a field change, not a
+data-model change.

--- a/docs/impact-lab/09-verification.md
+++ b/docs/impact-lab/09-verification.md
@@ -1,0 +1,55 @@
+# 09 — Verification
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+The repo has no unit-test framework, so `scripts/verify-matching.ts` is the
+engine's test suite. It's a plain `tsx` script — no Jest, no config — that runs
+the matcher on a realistic 15-person fixture and asserts the properties that
+matter. Run it:
+
+```bash
+npm run verify:matching     # or: npx tsx scripts/verify-matching.ts
+```
+
+Exit 0 = all checks passed; exit 1 = something regressed.
+
+## What it asserts
+
+**Determinism** — the whole reason the engine is pure:
+- two runs on identical input are deep-equal (`JSON.stringify` equality),
+- the result is **invariant to input ordering** (a reversed input produces the
+  same teams). This is the real test of the "sort by id up front" decision from
+  [03](./03-normalization.md).
+
+**Constraint safety** — the hard rules from [04](./04-constraints.md):
+- non-consenting participants are excluded from teams *and* unassigned,
+- every placed participant consented,
+- nobody is assigned to two teams,
+- every consenting participant is either assigned or explicitly unassigned,
+- no team contains a blocked pair,
+- no team exceeds `maxTeamSize` (when unassigned is allowed),
+- any out-of-range team carries a size-violation penalty (nothing fails silently),
+- the locked team keeps exactly its pinned members,
+- every score lands in `[0, 100]`.
+
+## The fixture is chosen to exercise the hard paths
+
+It isn't random data. It deliberately includes:
+- a **block** (Felix blocks Amina) — the run proves they never share a team,
+- a **preference** (Cynthia wants Amina) — visibly satisfied in the output,
+- three **advanced** participants — to show they get distributed, not clustered,
+- a **locked pair** — pinned, undersized, and correctly penalised rather than
+  quietly "fixed",
+- a **non-consenting** participant — excluded entirely.
+
+The script also prints the full result — teams, scores, strengths/weaknesses,
+project directions, warnings — so a human can eyeball that the numbers are
+sensible, not just that the asserts pass.
+
+## Why this over "add Jest"
+
+The spec is explicit: unit-test the pure functions *if test infra exists*,
+otherwise ship a verify script. Adding a test runner is a dependency and a config
+surface this project hasn't opted into. One dependency-free script that asserts
+determinism and constraint compliance covers the real risks for a deadline build,
+and it's trivial to fold into CI later (`npm run verify:matching`).

--- a/docs/impact-lab/10-ai-layer.md
+++ b/docs/impact-lab/10-ai-layer.md
@@ -1,0 +1,62 @@
+# 10 — The Claude Explanation Layer
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+## The rule that makes this safe: AI explains, never assigns
+
+This is the single most important design decision in the whole feature, inherited
+from the audited project and kept deliberately: **the LLM has no say in who is on
+a team.** The deterministic engine produces the final assignment. Claude is handed
+the finished result and asked only to *explain* it in richer prose than the
+[deterministic explanations](./08-explanations.md) can.
+
+Why this matters:
+
+- **Determinism survives.** The thing organisers can re-run and defend is the
+  algorithm's output, which never depends on a model.
+- **No hallucinated teams.** The model can't invent a member, move someone, or
+  drop a person — it only ever receives teams that already exist.
+- **Graceful degradation.** If the model is off or fails, the deterministic
+  explanations stand in. The feature never depends on the API being up.
+
+## What the model receives — and what it never does
+
+`buildPayload` sends a **slim, privacy-safe view** per team: participant id, name,
+canonical roles, experience level, skills, availability. That's it.
+
+Never sent: phone numbers, emails, or `blockedTeammates`. Blocked teammates are a
+sensitive organiser-only signal; keeping them out of the payload is enforced by
+the *shape of the data flow*, not by a promise — `AiParticipantView` simply has no
+field for them.
+
+## Structured output, then validate anyway
+
+The call uses the AI SDK's `generateObject` with a Zod schema, so the model is
+constrained to return exactly the shape we expect. But structured output
+guarantees *shape*, not *truth* — so every response is still validated:
+
+- explanations for **unknown team ids** are dropped (that team falls back),
+- **role suggestions** are filtered to participants actually on that team
+  (`memberIds.has(participantId)`),
+- a team the model **omitted entirely** falls back to its deterministic
+  explanation.
+
+The model is a drafting assistant whose output is checked against ground truth,
+not a source of record.
+
+## Fail-open to deterministic, always
+
+Every failure path — no `ANTHROPIC_API_KEY`, rate limit, network error, invalid
+output — returns the deterministic explanations with a warning. `explainWithAi`
+never throws to the caller. The admin route wraps it, so the matching UI renders
+whether or not the AI layer is available.
+
+## Model and stack
+
+`claude-sonnet-5`, via the repo's existing `@ai-sdk/anthropic` + AI SDK v6 — the
+same stack the Karibu onboarding chat already uses, so no new dependency. The
+model id comes straight from the spec; the API key is read from the environment by
+`createAnthropic()`. This module is the one non-pure part of the matcher, so it's
+kept out of the engine's `index.ts` barrel — the admin route imports it directly,
+and it's protected there by admin auth, rate limiting, and an audit-log entry
+(see [11-api.md](./11-api.md)).

--- a/docs/impact-lab/11-api.md
+++ b/docs/impact-lab/11-api.md
@@ -1,0 +1,70 @@
+# 11 — API Layer
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+The API is where the pure engine meets the real world: authentication, the
+database, CSRF, rate limiting, audit logging. Every route follows the repo's
+established admin pattern — nothing bespoke.
+
+## Shared helpers (`src/lib/impact-lab/`)
+
+Small modules that keep the routes thin and the engine boundary clean:
+
+- **`mappers.ts`** — `toMatchParticipant(row)` turns a Prisma row into the
+  engine's plain `MatchParticipant`. This is *the* boundary that lets the engine
+  stay Prisma-free: the DB layer imports the engine's types, never the reverse.
+- **`settings.ts`** — validates the organiser's (partial) settings with Zod and
+  merges them over `DEFAULT_SETTINGS`. Weights merge field-by-field, so tweaking
+  one weight doesn't reset the others.
+- **`participant-schema.ts`** — one Zod schema (`participantDraftSchema`) shared
+  by create, edit, and import, with the repo's sanitizers applied to every text
+  field. Arrays are validated and trimmed.
+- **`csv.ts`** — dependency-free RFC-4180 CSV serialization for exports.
+
+## Participant routes
+
+| Route | Method | Permission | Notes |
+|-------|--------|-----------|-------|
+| `/participants` | GET | `view` | List a cohort |
+| `/participants` | POST | `create` | Create one; 409 on duplicate email |
+| `/participants/[id]` | PATCH | `edit` | Edit; guards email uniqueness |
+| `/participants/[id]` | DELETE | `delete` | Delete |
+| `/participants/import` | POST | `create` | Bulk upsert on (cohort, email) |
+| `/participants/export` | GET | `view` | CSV download |
+
+Every mutating route: `withCsrfProtection` → `checkApiPermission` → Zod validate
+→ act → `logAudit`. That ordering is deliberate — reject a forged or
+unauthorized request before touching the body or the database.
+
+## CSV import is resilient, not all-or-nothing
+
+The client parses the CSV, maps columns, and splits multi-value cells, then posts
+an array of drafts. The server validates **each row independently**: a bad row is
+collected into an `errors[]` list with its row number, and the rest still import.
+The response reports `{ created, updated, failed, errors }`. For a deadline
+import from a Google Form export, "18 imported, 2 need fixing (rows 5, 11)" is far
+more useful than a single rejection of the whole file.
+
+Import upserts on `(cohort, email)` — re-importing a corrected sheet updates
+existing people instead of duplicating them, which the scoped unique index makes
+safe.
+
+## Why `blockedTeammates` is in export but not the AI payload
+
+The participant CSV export includes `blockedTeammates` because it's the
+organiser's own working data — they're the audience. The *AI layer* never sees it
+([10-ai-layer.md](./10-ai-layer.md)), and the **final-teams** export
+([13, runs](./06-algorithm.md)) only includes contact details for participants who
+set `consentToShareContact`. Different audiences, different disclosure — decided
+per route, not globally.
+
+## Match, explain, and run routes
+
+Built on the same pattern (next commit):
+
+- `POST /match` — map cohort participants → engine → `runMatching` → return the
+  result. Pure computation; nothing saved.
+- `POST /explain` — hand a result to the Claude layer; rate-limited and audited.
+- `/runs` — save a result as a frozen named run, list runs, view a snapshot,
+  mark one final (atomic swap — unset the previous final in a transaction), and
+  export the final teams.

--- a/docs/impact-lab/12-admin-ui.md
+++ b/docs/impact-lab/12-admin-ui.md
@@ -1,0 +1,52 @@
+# 12 — Admin UI
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+
+`/admin/impact-lab` is where organisers actually run the matcher. It follows the
+repo's admin conventions: a server page (`page.tsx`) renders `AdminHeader` and a
+client dashboard; all data flows through the API routes over `fetch`, gated by
+the same session + CSRF the rest of the admin panel uses.
+
+## Server page, client dashboard
+
+`page.tsx` is a thin server component (`force-dynamic`) that passes the cohort to
+`ImpactLabDashboard`, a client component holding the tab state. This is the same
+split every admin page in the repo uses — server for the shell, client for
+interactivity — so the new pages sit naturally alongside the existing ones.
+
+## Three tabs, three jobs
+
+- **Participants** — the roster. Table, add form, resilient CSV import (parsed
+  and column-mapped in the browser, then posted as drafts), and CSV export.
+- **Matching** — the workbench. A settings form (sizes + toggles), a Generate
+  button, results as team cards, an Explain-with-Claude button, and a Save-run
+  field.
+- **Runs** — the archive. Saved runs with mark-final, export-teams, and delete.
+
+## The team card renders the score breakdown directly
+
+Each team card shows the total, the members (with the AI's suggested internal role
+when available), and a **bar per scoring dimension** — the `raw` value straight
+from the engine's `ScoreBreakdown`. Penalties render in red with their reason.
+This is the payoff of making the score breakdown a structured object back in
+[05-scoring](./05-scoring.md): the UI doesn't recompute or guess anything, it just
+draws what the engine already explained.
+
+## AI explanations layer onto the same cards
+
+"Explain with Claude" calls `/explain` and merges the returned `TeamExplanation`s
+into the cards by `teamId` — the summary, project direction, and per-member role
+suggestions appear in place. When a team falls back to the deterministic
+explanation, the card labels it "(deterministic summary)" so the organiser knows
+which they're looking at. The page works fully before the button is ever pressed;
+the AI is strictly additive, exactly as [10-ai-layer](./10-ai-layer.md) designed.
+
+## Small deliberate touches
+
+- Saving a run jumps to the Runs tab and bumps a `refreshKey` so the list
+  reloads — no manual refresh.
+- Type-only imports from `@/lib/matching` give the client components the engine's
+  `MatchResult` / `TeamExplanation` types with zero runtime cost (the engine code
+  is never bundled into the client).
+- Every mutating call fetches a fresh CSRF token first, matching the existing
+  `CommunityActions` pattern rather than inventing a new one.

--- a/docs/impact-lab/13-hardening.md
+++ b/docs/impact-lab/13-hardening.md
@@ -1,0 +1,87 @@
+# 13 — Audit Hardening
+
+> Part of the [Impact Lab team-matching](../impact-lab-matching-spec.md) build.
+> This documents the response to the multi-reviewer audit on PR #46.
+
+The feature shipped functionally complete, then got a serious security/
+testing/performance review before merge. This doc captures the fixes and the
+reasoning — the review itself was a second design pass, and the lessons are worth
+keeping.
+
+## The theme: an admin tool still has adversaries
+
+Everything here is admin-gated, so it's tempting to treat it as trusted. But the
+*data* flows to less-trusted places (a CSV opened in Excel, a shared export file,
+a venue full of organisers behind one NAT), and admins make mistakes (edit a
+participant mid-run). The fixes fall into a few buckets.
+
+### Don't let data escape its audience
+
+- **Blocked teammates never leave the app.** They were being written into the
+  participant CSV export. `blockedTeammates` is the one field the schema contract
+  says is never exposed — one shared file leaks who blocked whom. Dropped from the
+  export; and the run-detail endpoint no longer returns `participantsSnapshot`
+  (which holds every email + block, including non-consenting people).
+- **CSV formula injection.** RFC-4180 quoting protects the *file*; it does nothing
+  for the *reader*. A participant named `=HYPERLINK(...)` executes when the
+  organiser opens the export in Excel/Sheets. Fixed by prefixing a `'` to any cell
+  starting with `= + - @` or a control char.
+
+### Design for the room, not the request
+
+- **Rate limit by user, not IP.** On event day every organiser shares the venue's
+  NAT IP, so an IP-keyed limit throttles the *whole team* to one person's quota.
+  The explain and import limits are now keyed by user id.
+- **Batch the import.** 500 sequential `findUnique + write` round-trips over
+  PgBouncer can blow the function timeout and leave a silent partial import. Now
+  one `findMany` + one `$transaction`, with `maxDuration` and in-file dedupe.
+
+### Trust the database, handle the race
+
+- **P2002 → 409, not 500.** Find-then-create has a TOCTOU window; under a race the
+  unique index throws and the naive handler 500s. Every create/update now leans on
+  the index and maps the violation to a clean 409.
+- **One final per cohort, enforced in SQL.** The mark-final transaction can
+  write-skew into *two* finals under read-committed. A partial unique index
+  (`(cohort) WHERE isFinal`) makes that impossible. Prisma can't model partial
+  indexes, so it's raw SQL — documented in the schema so a future `migrate dev`
+  doesn't "helpfully" drop it.
+
+### The subtle one: what you saved isn't what you saw
+
+The engine recomputes server-side for integrity, but that opened a gap: if a
+participant is edited between **Generate** and **Save**, the frozen "final" run
+silently differs from what the organiser reviewed. The fix keeps server-side
+recomputation *and* guarantees fidelity: `/match` returns a content
+**signature** of the result; the UI echoes it back on save/explain; the server
+recomputes, and if the signature no longer matches, returns **409 — regenerate**.
+Integrity (server is authoritative) and fidelity (== what was reviewed) at once.
+
+### Least privilege
+
+`/match` and `/explain` were gated on `view`, so a read-only moderator could
+generate matches and trigger paid Claude calls. Both now require `create`.
+
+## Correctness nits worth the fix
+
+- `resolveSettings` rejects `minTeamSize > maxTeamSize` (zod can't express the
+  cross-field check when a bound is omitted; the inverted range silently produced
+  garbage teams).
+- Locked teams are passed through untouched, so a block *inside* one can't be
+  auto-resolved — but blocks are unconditional, so it's now surfaced as a warning
+  instead of passing silently.
+- The AI layer logs the failure cause before falling back, and merges the
+  engine's penalty warnings with the model's instead of letting the model's
+  replace them.
+- `cohort` is coerced to a slug everywhere (it fed a `Content-Disposition`
+  header), and the runs list stopped loading full snapshots to compute three
+  numbers.
+
+## Deployment / governance (not code)
+
+Two items are for the deploy, flagged in the PR reply, not fixed here:
+
+- Confirm `UPSTASH_REDIS_REST_*` is set in production — without it, all the rate
+  limits above are per-instance in-memory and don't hold across the fleet.
+- Decide a retention policy for non-consenting participants' data captured in run
+  snapshots.

--- a/docs/impact-lab/README.md
+++ b/docs/impact-lab/README.md
@@ -35,6 +35,7 @@ output.
 | 10 | [AI layer](./10-ai-layer.md) | Claude explains-only; privacy by data-flow; fail-open |
 | 11 | [API layer](./11-api.md) | Routes, shared helpers, resilient CSV import |
 | 12 | [Admin UI](./12-admin-ui.md) | The three tabs; rendering the score breakdown |
+| 13 | [Audit hardening](./13-hardening.md) | Security/perf fixes from the PR review, and why |
 
 ## Try it
 

--- a/docs/impact-lab/README.md
+++ b/docs/impact-lab/README.md
@@ -1,0 +1,55 @@
+# Impact Lab Team Matching
+
+A deterministic hackathon team-matcher for Claude Community Kenya, with an
+optional Claude explanation layer. Built for the Impact Lab / AI Mashinani event
+from the [implementation spec](../impact-lab-matching-spec.md).
+
+These docs are written to be read **in order** — each explains one logical chunk
+of the build and the decision behind it, so the feature doubles as a learning
+reference for how to design a small, testable, deterministic engine behind a
+Next.js admin panel.
+
+## The one idea to take away
+
+**A pure, deterministic core with a thin, effectful shell around it.** The
+matching engine (`src/lib/matching/`) is pure TypeScript — no database, no clock,
+no randomness, no network. That single constraint is what buys determinism (same
+input → identical output), trivial testing (a plain script, no framework), and a
+clean seam for the AI layer (which explains, never decides). Everything else —
+Prisma, auth, CSRF, the UI — is the shell that feeds the core and renders its
+output.
+
+## Reading order
+
+| # | Doc | What it covers |
+|---|-----|----------------|
+| 01 | [Data model](./01-data-model.md) | Prisma models, the migration, scoped uniqueness, snapshotting |
+| 02 | [Engine design](./02-engine-design.md) | Why the engine is pure; types and constants |
+| 03 | [Normalization](./03-normalization.md) | Canonicalizing messy input; the determinism backbone |
+| 04 | [Constraints](./04-constraints.md) | The four hard rules; hard vs soft |
+| 05 | [Scoring](./05-scoring.md) | Six weighted dimensions; penalties; the transparent breakdown |
+| 06 | [Algorithm](./06-algorithm.md) | Seed → distribute → greedy fill; the seeding sort trick |
+| 07 | [Optimization](./07-optimization.md) | Pairwise-swap local search; keeping constraints safe |
+| 08 | [Explanations](./08-explanations.md) | The deterministic fallback, built first |
+| 09 | [Verification](./09-verification.md) | Asserting determinism + constraint compliance without a test runner |
+| 10 | [AI layer](./10-ai-layer.md) | Claude explains-only; privacy by data-flow; fail-open |
+| 11 | [API layer](./11-api.md) | Routes, shared helpers, resilient CSV import |
+| 12 | [Admin UI](./12-admin-ui.md) | The three tabs; rendering the score breakdown |
+
+## Try it
+
+```bash
+npm run verify:matching   # run the engine on a fixture; assert determinism + constraints
+npm run db:migrate        # apply the schema (needs a real DATABASE_URL)
+npm run dev               # /admin/impact-lab
+```
+
+The Claude explanation layer is optional and env-gated: without `ANTHROPIC_API_KEY`
+the deterministic explanations stand in, and nothing else changes.
+
+## Provenance & licensing
+
+The *concepts* were informed by an audit of `best-ed/HackMatch-AI` (the author's
+own earlier private project). No code was copied — this is a clean reimplementation
+in the community repo's stack, built to serve the community for the hackathon. See
+the [spec](../impact-lab-matching-spec.md) for the full audit and rationale.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "db:migrate": "prisma migrate dev",
     "db:push": "prisma db push",
     "db:seed": "prisma db seed",
-    "db:studio": "prisma studio"
+    "db:studio": "prisma studio",
+    "verify:matching": "tsx scripts/verify-matching.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/prisma/migrations/20260721160000_impact_lab_matching/migration.sql
+++ b/prisma/migrations/20260721160000_impact_lab_matching/migration.sql
@@ -1,0 +1,58 @@
+-- CreateEnum
+CREATE TYPE "ImpactLabExperience" AS ENUM ('BEGINNER', 'INTERMEDIATE', 'ADVANCED');
+
+-- CreateTable
+CREATE TABLE "impact_lab_participants" (
+    "id" TEXT NOT NULL,
+    "cohort" TEXT NOT NULL DEFAULT 'impact-lab-2026-07',
+    "fullName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "phone" TEXT,
+    "institution" TEXT,
+    "experienceLevel" "ImpactLabExperience" NOT NULL DEFAULT 'BEGINNER',
+    "primaryRole" TEXT NOT NULL,
+    "secondaryRoles" TEXT[],
+    "technicalSkills" TEXT[],
+    "interests" TEXT[],
+    "availability" TEXT[],
+    "projectIdeas" TEXT,
+    "preferredTeammates" TEXT[],
+    "blockedTeammates" TEXT[],
+    "consentToMatch" BOOLEAN NOT NULL DEFAULT false,
+    "consentToShareContact" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "impact_lab_participants_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "impact_lab_match_runs" (
+    "id" TEXT NOT NULL,
+    "cohort" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "notes" TEXT,
+    "isFinal" BOOLEAN NOT NULL DEFAULT false,
+    "settings" JSONB NOT NULL,
+    "result" JSONB NOT NULL,
+    "participantsSnapshot" JSONB NOT NULL,
+    "createdById" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "impact_lab_match_runs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "impact_lab_participants_cohort_idx" ON "impact_lab_participants"("cohort");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "impact_lab_participants_cohort_email_key" ON "impact_lab_participants"("cohort", "email");
+
+-- CreateIndex
+CREATE INDEX "impact_lab_match_runs_cohort_idx" ON "impact_lab_match_runs"("cohort");
+
+-- CreateIndex
+CREATE INDEX "impact_lab_match_runs_cohort_isFinal_idx" ON "impact_lab_match_runs"("cohort", "isFinal");
+
+-- AddForeignKey
+ALTER TABLE "impact_lab_match_runs" ADD CONSTRAINT "impact_lab_match_runs_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260722120000_impact_lab_hardening/migration.sql
+++ b/prisma/migrations/20260722120000_impact_lab_hardening/migration.sql
@@ -1,0 +1,16 @@
+-- Drop redundant single-column cohort indexes: the (cohort, email) unique index
+-- and the (cohort, isFinal) index already cover cohort-prefix lookups.
+DROP INDEX IF EXISTS "impact_lab_participants_cohort_idx";
+DROP INDEX IF EXISTS "impact_lab_match_runs_cohort_idx";
+
+-- Index the foreign key (repo convention for user-linked models).
+CREATE INDEX "impact_lab_match_runs_createdById_idx" ON "impact_lab_match_runs"("createdById");
+
+-- Enforce "at most one final run per cohort" at the database level. The API
+-- swaps the final flag in a transaction, but under read-committed isolation two
+-- concurrent mark-final calls on different runs can write-skew into two finals;
+-- this partial unique index makes that impossible. Prisma can't model partial
+-- indexes, so it is defined here in raw SQL only.
+CREATE UNIQUE INDEX "impact_lab_match_runs_one_final_per_cohort"
+  ON "impact_lab_match_runs"("cohort")
+  WHERE "isFinal";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,15 @@ enum Experience {
   api_builder
 }
 
+// Skill ladder for Impact Lab team matching. Deliberately NOT the `Experience`
+// enum above — that one tracks Claude familiarity (never_used → api_builder),
+// whereas the matcher needs a generic beginner→advanced axis to balance teams.
+enum ImpactLabExperience {
+  BEGINNER
+  INTERMEDIATE
+  ADVANCED
+}
+
 // ─── Users & Auth ────────────────────────────────────────────────────────────
 
 model User {
@@ -135,6 +144,7 @@ model User {
   volunteerApplications VolunteerApplication[]
   demoRequests         DemoRequest[]
   onboardingSessions   OnboardingSession[]
+  impactLabMatchRuns   ImpactLabMatchRun[]
 
   @@map("users")
 }
@@ -629,4 +639,59 @@ model NewsletterIssue {
   @@index([publishedAt])
   @@index([status])
   @@map("newsletter_issues")
+}
+
+// ─── Impact Lab Team Matching ────────────────────────────────────────────────
+
+// A hackathon participant eligible for team matching. Scoped by `cohort` so the
+// same table serves future events without collisions. Matching only ever reads
+// rows where consentToMatch = true; blockedTeammates is organiser-only and is
+// never sent to the AI layer or exposed in public/CSV export.
+model ImpactLabParticipant {
+  id                    String              @id @default(cuid())
+  cohort                String              @default("impact-lab-2026-07")
+  fullName              String
+  email                 String
+  phone                 String?
+  institution           String?
+  experienceLevel       ImpactLabExperience @default(BEGINNER)
+  primaryRole           String
+  secondaryRoles        String[]
+  technicalSkills       String[]
+  interests             String[]
+  availability          String[]
+  projectIdeas          String?             @db.Text
+  preferredTeammates    String[]            // emails — soft preference, honoured when possible
+  blockedTeammates      String[]            // emails — hard constraint, never shown publicly
+  consentToMatch        Boolean             @default(false)
+  consentToShareContact Boolean             @default(false)
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
+
+  @@unique([cohort, email])
+  @@index([cohort])
+  @@map("impact_lab_participants")
+}
+
+// A frozen snapshot of one matching run: the settings used, the participants as
+// they were at run time, and the computed result (teams + score breakdowns +
+// warnings + unassigned). Snapshotting means a saved run stays reproducible even
+// after participants are edited. At most one run per cohort may have isFinal =
+// true — enforced in the API layer, not the DB, so we can atomically swap it.
+model ImpactLabMatchRun {
+  id                   String   @id @default(cuid())
+  cohort               String
+  name                 String
+  notes                String?  @db.Text
+  isFinal              Boolean  @default(false)
+  settings             Json
+  result               Json
+  participantsSnapshot Json
+  createdById          String?
+  createdBy            User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
+  createdAt            DateTime @default(now())
+
+  @@index([cohort])
+  @@index([cohort, isFinal])
+  @@map("impact_lab_match_runs")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -668,8 +668,9 @@ model ImpactLabParticipant {
   createdAt             DateTime            @default(now())
   updatedAt             DateTime            @updatedAt
 
+  // @@unique([cohort, email]) already indexes the cohort prefix, so a standalone
+  // @@index([cohort]) would be redundant.
   @@unique([cohort, email])
-  @@index([cohort])
   @@map("impact_lab_participants")
 }
 
@@ -691,7 +692,13 @@ model ImpactLabMatchRun {
   createdBy            User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdAt            DateTime @default(now())
 
-  @@index([cohort])
+  // @@index([cohort, isFinal]) also covers plain cohort lookups (prefix).
+  // "At most one final run per cohort" is additionally enforced at the DB level
+  // by a PARTIAL UNIQUE index (`... ON (cohort) WHERE "isFinal"`) added in the
+  // 20260722120000_impact_lab_hardening migration. Prisma can't express partial
+  // indexes, so it lives only in SQL — if `prisma migrate dev` ever proposes
+  // dropping it as "drift", keep it.
   @@index([cohort, isFinal])
+  @@index([createdById])
   @@map("impact_lab_match_runs")
 }

--- a/scripts/verify-matching.ts
+++ b/scripts/verify-matching.ts
@@ -235,6 +235,35 @@ assert(
   "every team score is within [0, 100]"
 )
 
+console.log("\nEdge cases")
+// Empty cohort must not crash.
+const emptyRun = runMatching([], SETTINGS)
+assert(
+  emptyRun.teams.length === 0 && emptyRun.unassignedIds.length === 0,
+  "empty participant list yields no teams and does not crash"
+)
+
+// Oversized locked team: pin 6 people (> maxTeamSize 5). It must pass through
+// intact, carry a size-violation penalty, and — since Felix blocks Amina and
+// both are pinned — surface the blocked-pair warning.
+const oversizedSettings: MatchSettings = {
+  ...SETTINGS,
+  lockedTeams: [
+    { name: "Oversized", memberEmails: PARTICIPANTS.slice(0, 6).map((x) => x.email) },
+  ],
+}
+const oversizedRun = runMatching(PARTICIPANTS, oversizedSettings)
+const bigTeam = oversizedRun.teams.find((t) => t.locked && t.memberIds.length === 6)
+assert(bigTeam != null, "oversized locked team (6 > max 5) is preserved intact")
+assert(
+  !!bigTeam && bigTeam.score.penalties.some((p) => p.reason.startsWith("Team size")),
+  "oversized locked team carries a size-violation penalty"
+)
+assert(
+  oversizedRun.warnings.some((w) => w.includes("blocked each other but are pinned together")),
+  "a blocked pair pinned into a locked team is flagged with a warning"
+)
+
 // ─── Human-readable dump ─────────────────────────────────────────────────────
 
 const normalized = normalizeParticipants(PARTICIPANTS.filter((x) => x.consentToMatch))

--- a/scripts/verify-matching.ts
+++ b/scripts/verify-matching.ts
@@ -1,0 +1,270 @@
+/**
+ * Impact Lab matching engine — verification harness.
+ *
+ * No unit-test framework is set up in this repo, so this script is the engine's
+ * test suite. It runs the matcher on a realistic fixture and asserts the two
+ * properties that actually matter:
+ *
+ *   1. Determinism      — two runs on identical input are deep-equal.
+ *   2. Constraint safety — consent, blocks, sizes and locked teams all hold.
+ *
+ * Run with:  npx tsx scripts/verify-matching.ts   (or: npm run verify:matching)
+ * Exits 0 on success, 1 on any failed assertion.
+ */
+
+import {
+  DEFAULT_SETTINGS,
+  normalizeParticipants,
+  runMatching,
+  explainResult,
+  type MatchParticipant,
+  type MatchSettings,
+} from "../src/lib/matching"
+
+// ─── Fixture ─────────────────────────────────────────────────────────────────
+
+function p(
+  id: string,
+  fullName: string,
+  email: string,
+  experienceLevel: MatchParticipant["experienceLevel"],
+  primaryRole: string,
+  opts: Partial<MatchParticipant> = {}
+): MatchParticipant {
+  return {
+    id,
+    fullName,
+    email,
+    experienceLevel,
+    primaryRole,
+    secondaryRoles: [],
+    technicalSkills: [],
+    interests: [],
+    availability: ["day 1", "day 2"],
+    preferredTeammates: [],
+    blockedTeammates: [],
+    consentToMatch: true,
+    ...opts,
+  }
+}
+
+const PARTICIPANTS: MatchParticipant[] = [
+  p("u01", "Amina", "amina@x.io", "ADVANCED", "Developer", {
+    technicalSkills: ["typescript", "react", "node"],
+    interests: ["fintech", "education"],
+  }),
+  p("u02", "Brian", "brian@x.io", "BEGINNER", "Designer", {
+    technicalSkills: ["figma", "ui"],
+    interests: ["health", "education"],
+  }),
+  p("u03", "Cynthia", "cynthia@x.io", "INTERMEDIATE", "Presenter", {
+    technicalSkills: ["public speaking", "product"],
+    interests: ["agritech"],
+    preferredTeammates: ["amina@x.io"],
+  }),
+  p("u04", "David", "david@x.io", "BEGINNER", "Developer", {
+    technicalSkills: ["python"],
+    interests: ["agritech", "climate"],
+  }),
+  p("u05", "Esther", "esther@x.io", "ADVANCED", "Data scientist", {
+    technicalSkills: ["python", "ml", "pandas"],
+    interests: ["health"],
+  }),
+  p("u06", "Felix", "felix@x.io", "INTERMEDIATE", "Product manager", {
+    technicalSkills: ["roadmapping"],
+    interests: ["fintech"],
+    blockedTeammates: ["amina@x.io"], // Felix should never be with Amina
+  }),
+  p("u07", "Grace", "grace@x.io", "BEGINNER", "Designer", {
+    technicalSkills: ["design"],
+    interests: ["climate"],
+  }),
+  p("u08", "Hassan", "hassan@x.io", "INTERMEDIATE", "Developer", {
+    technicalSkills: ["go", "backend"],
+    interests: ["fintech"],
+  }),
+  p("u09", "Irene", "irene@x.io", "ADVANCED", "Presenter", {
+    technicalSkills: ["pitching", "strategy"],
+    interests: ["education"],
+  }),
+  p("u10", "James", "james@x.io", "BEGINNER", "Developer", {
+    technicalSkills: ["html", "css"],
+    interests: ["health"],
+  }),
+  p("u11", "Khadija", "khadija@x.io", "INTERMEDIATE", "Data analyst", {
+    technicalSkills: ["sql", "viz"],
+    interests: ["agritech"],
+  }),
+  p("u12", "Leon", "leon@x.io", "BEGINNER", "Product", {
+    technicalSkills: ["research"],
+    interests: ["climate"],
+  }),
+  // Locked pair — must stay together, and both are pinned.
+  p("u13", "Maria", "maria@x.io", "INTERMEDIATE", "Developer", {
+    technicalSkills: ["rust"],
+    interests: ["fintech"],
+  }),
+  p("u14", "Noah", "noah@x.io", "BEGINNER", "Designer", {
+    technicalSkills: ["branding"],
+    interests: ["fintech"],
+  }),
+  // Non-consenting — must be excluded entirely.
+  p("u15", "Omar", "omar@x.io", "ADVANCED", "Developer", {
+    consentToMatch: false,
+  }),
+]
+
+const SETTINGS: MatchSettings = {
+  ...DEFAULT_SETTINGS,
+  lockedTeams: [{ name: "Alpha (pinned)", memberEmails: ["maria@x.io", "noah@x.io"] }],
+}
+
+// ─── Assertions ──────────────────────────────────────────────────────────────
+
+let failures = 0
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`  ✓ ${message}`)
+  } else {
+    failures++
+    console.error(`  ✗ ${message}`)
+  }
+}
+
+// Raw lookups for constraint checks (independent of the engine's internals).
+const byId = new Map(PARTICIPANTS.map((x) => [x.id, x]))
+const emailToId = new Map(PARTICIPANTS.map((x) => [x.email.toLowerCase(), x.id]))
+const consentingIds = new Set(
+  PARTICIPANTS.filter((x) => x.consentToMatch).map((x) => x.id)
+)
+
+function blockedPair(a: string, b: string): boolean {
+  const pa = byId.get(a)!
+  const pb = byId.get(b)!
+  return (
+    pa.blockedTeammates.map((e) => e.toLowerCase()).includes(pb.email.toLowerCase()) ||
+    pb.blockedTeammates.map((e) => e.toLowerCase()).includes(pa.email.toLowerCase())
+  )
+}
+
+// ─── Run ─────────────────────────────────────────────────────────────────────
+
+console.log("Impact Lab matching — verification\n")
+
+const runA = runMatching(PARTICIPANTS, SETTINGS)
+const runB = runMatching(PARTICIPANTS, SETTINGS)
+
+console.log("Determinism")
+assert(
+  JSON.stringify(runA) === JSON.stringify(runB),
+  "two runs on identical input are deep-equal"
+)
+
+// Shuffle input order — determinism must not depend on arrival order.
+const shuffled = [...PARTICIPANTS].reverse()
+const runC = runMatching(shuffled, SETTINGS)
+assert(
+  JSON.stringify(runA) === JSON.stringify(runC),
+  "result is invariant to input ordering"
+)
+
+console.log("\nConsent")
+const assignedIds = runA.teams.flatMap((t) => t.memberIds)
+const allPlaced = new Set([...assignedIds, ...runA.unassignedIds])
+assert(
+  !allPlaced.has("u15"),
+  "non-consenting participant is excluded from teams and unassigned"
+)
+assert(
+  [...allPlaced].every((id) => consentingIds.has(id)),
+  "every placed participant consented"
+)
+
+console.log("\nCompleteness")
+assert(
+  assignedIds.length === new Set(assignedIds).size,
+  "no participant is assigned to two teams"
+)
+assert(
+  [...consentingIds].every((id) => allPlaced.has(id)),
+  "every consenting participant is either assigned or unassigned"
+)
+
+console.log("\nBlocks")
+let blockViolations = 0
+for (const team of runA.teams) {
+  for (let i = 0; i < team.memberIds.length; i++) {
+    for (let j = i + 1; j < team.memberIds.length; j++) {
+      if (blockedPair(team.memberIds[i], team.memberIds[j])) blockViolations++
+    }
+  }
+}
+assert(blockViolations === 0, "no team contains a blocked pair (Felix never with Amina)")
+
+console.log("\nSizes")
+const oversized = runA.teams.filter(
+  (t) => t.memberIds.length > SETTINGS.maxTeamSize
+).length
+assert(
+  oversized === 0,
+  `no team exceeds maxTeamSize (${SETTINGS.maxTeamSize}) when unassigned is allowed`
+)
+const badSizeUnflagged = runA.teams.filter(
+  (t) =>
+    (t.memberIds.length < SETTINGS.minTeamSize ||
+      t.memberIds.length > SETTINGS.maxTeamSize) &&
+    !t.score.penalties.some((pen) => pen.reason.startsWith("Team size"))
+).length
+assert(
+  badSizeUnflagged === 0,
+  "any out-of-range team carries a size-violation penalty"
+)
+
+console.log("\nLocked teams")
+const alpha = runA.teams.find((t) => t.locked)
+const alphaIds = alpha ? [...alpha.memberIds].sort() : []
+assert(alpha != null, "the pinned locked team is present in the result")
+assert(
+  JSON.stringify(alphaIds) === JSON.stringify([emailToId.get("maria@x.io"), emailToId.get("noah@x.io")].sort()),
+  "locked team contains exactly its pinned members, unchanged"
+)
+
+console.log("\nScores in range")
+assert(
+  runA.teams.every((t) => t.score.total >= 0 && t.score.total <= 100),
+  "every team score is within [0, 100]"
+)
+
+// ─── Human-readable dump ─────────────────────────────────────────────────────
+
+const normalized = normalizeParticipants(PARTICIPANTS.filter((x) => x.consentToMatch))
+const normById = new Map(normalized.map((n) => [n.id, n]))
+const explanations = explainResult(runA, normById)
+
+console.log("\n─── Result ───")
+console.log(`Average team score: ${runA.averageScore}/100`)
+for (const team of runA.teams) {
+  const names = team.memberIds.map((id) => byId.get(id)?.fullName ?? id)
+  console.log(
+    `\n${team.name}${team.locked ? " [locked]" : ""} — ${team.score.total}/100`
+  )
+  console.log(`  Members: ${names.join(", ")}`)
+  const ex = explanations.find((e) => e.teamId === team.id)
+  if (ex) {
+    if (ex.strengths.length) console.log(`  Strengths: ${ex.strengths.join(" ")}`)
+    if (ex.weaknesses.length) console.log(`  Weaknesses: ${ex.weaknesses.join(" ")}`)
+    if (ex.suggestedProjectDirection) console.log(`  Direction: ${ex.suggestedProjectDirection}`)
+  }
+}
+if (runA.unassignedIds.length) {
+  console.log(
+    `\nUnassigned: ${runA.unassignedIds.map((id) => byId.get(id)?.fullName ?? id).join(", ")}`
+  )
+}
+if (runA.warnings.length) {
+  console.log("\nWarnings:")
+  for (const w of runA.warnings) console.log(`  - ${w}`)
+}
+
+console.log(`\n${failures === 0 ? "ALL CHECKS PASSED" : `${failures} CHECK(S) FAILED`}`)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/app/admin/impact-lab/page.tsx
+++ b/src/app/admin/impact-lab/page.tsx
@@ -1,0 +1,20 @@
+import { AdminHeader } from "@/components/admin/AdminHeader"
+import { ImpactLabDashboard } from "@/components/admin/impact-lab/ImpactLabDashboard"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+
+export const dynamic = "force-dynamic"
+
+export default function ImpactLabAdminPage() {
+  return (
+    <div>
+      <AdminHeader title="Impact Lab" />
+      <div className="p-6">
+        <p className="text-xs font-mono text-[#555] mb-4">
+          Team matching for cohort <span className="text-[#00ff41]">{DEFAULT_COHORT}</span> — import
+          participants, generate teams, explain with Claude, and freeze a final run.
+        </p>
+        <ImpactLabDashboard cohort={DEFAULT_COHORT} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { runMatching, normalizeParticipants } from "@/lib/matching"
+import { explainWithAi } from "@/lib/matching/ai-explanations"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { toMatchParticipant } from "@/lib/impact-lab/mappers"
+import { resolveSettings } from "@/lib/impact-lab/settings"
+
+/**
+ * Explain a match with Claude. The result is recomputed server-side from the
+ * cohort + settings (deterministic, so it matches what the UI showed) rather than
+ * trusting a client-sent result. Rate-limited (AI cost) and audited.
+ */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const limit = await rateLimit(request, RateLimits.STRICT)
+  if (!limit.success) {
+    return NextResponse.json(
+      { success: false, error: "AI explanation rate limit reached. Try again later." },
+      { status: 429, headers: limit.headers }
+    )
+  }
+
+  let body: { cohort?: string; settings?: unknown } = {}
+  try {
+    body = (await request.json()) ?? {}
+  } catch {
+    // Defaults are fine.
+  }
+
+  const cohort = body.cohort ?? DEFAULT_COHORT
+
+  let settings
+  try {
+    settings = resolveSettings(body.settings)
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid settings" }, { status: 400 })
+  }
+
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { cohort },
+  })
+  const mapped = participants.map(toMatchParticipant)
+  const result = runMatching(mapped, settings)
+  const normalized = normalizeParticipants(mapped.filter((p) => p.consentToMatch))
+
+  const explained = await explainWithAi(result, normalized)
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "CREATE",
+    entity: "ImpactLabExplanation",
+    entityId: cohort,
+    changes: { teams: result.teams.length, usedFallback: explained.usedFallback },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, data: explained })
+}

--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -23,7 +23,9 @@ export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 
-  const check = await checkApiPermission("impact-lab", "view")
+  // Requires create, not view — this spends on a paid Claude call, so a
+  // read-only moderator must not be able to trigger it.
+  const check = await checkApiPermission("impact-lab", "create")
   if (!check.authorized) return check.response
 
   // Key by user id, not IP: on event day every organiser shares the venue NAT,

--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -9,6 +9,7 @@ import { explainWithAi } from "@/lib/matching/ai-explanations"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
+import { resultSignature } from "@/lib/impact-lab/signature"
 
 // The Claude call can take several seconds — give it room past the default.
 export const maxDuration = 30
@@ -39,7 +40,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  let body: { cohort?: string; settings?: unknown } = {}
+  let body: { cohort?: string; settings?: unknown; expectedSignature?: string } = {}
   try {
     body = (await request.json()) ?? {}
   } catch {
@@ -60,6 +61,17 @@ export async function POST(request: NextRequest) {
   })
   const mapped = participants.map(toMatchParticipant)
   const result = runMatching(mapped, settings)
+
+  if (body.expectedSignature && resultSignature(result) !== body.expectedSignature) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Participants changed since these teams were generated. Regenerate first.",
+      },
+      { status: 409 }
+    )
+  }
+
   const normalized = normalizeParticipants(mapped.filter((p) => p.consentToMatch))
 
   const explained = await explainWithAi(result, normalized)

--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -6,7 +6,7 @@ import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { runMatching, normalizeParticipants } from "@/lib/matching"
 import { explainWithAi } from "@/lib/matching/ai-explanations"
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { safeCohort } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
     // Defaults are fine.
   }
 
-  const cohort = body.cohort ?? DEFAULT_COHORT
+  const cohort = safeCohort(body.cohort)
 
   let settings
   try {

--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -2,13 +2,16 @@ import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
-import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { runMatching, normalizeParticipants } from "@/lib/matching"
 import { explainWithAi } from "@/lib/matching/ai-explanations"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
+
+// The Claude call can take several seconds — give it room past the default.
+export const maxDuration = 30
 
 /**
  * Explain a match with Claude. The result is recomputed server-side from the
@@ -22,7 +25,13 @@ export async function POST(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "view")
   if (!check.authorized) return check.response
 
-  const limit = await rateLimit(request, RateLimits.STRICT)
+  // Key by user id, not IP: on event day every organiser shares the venue NAT,
+  // so an IP-keyed limit would throttle the whole team to a handful of calls.
+  const limit = await rateLimit(request, {
+    maxRequests: 20,
+    windowInSeconds: 3600,
+    identifier: () => `impact-lab-explain:${check.user.id}`,
+  })
   if (!limit.success) {
     return NextResponse.json(
       { success: false, error: "AI explanation rate limit reached. Try again later." },

--- a/src/app/api/admin/impact-lab/match/route.ts
+++ b/src/app/api/admin/impact-lab/match/route.ts
@@ -18,7 +18,9 @@ export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 
-  const check = await checkApiPermission("impact-lab", "view")
+  // Generating teams is an organiser action, not a read — a view-only moderator
+  // must not be able to run it (explain additionally spends on the AI call).
+  const check = await checkApiPermission("impact-lab", "create")
   if (!check.authorized) return check.response
 
   const limit = await rateLimit(request, RateLimits.ADMIN)

--- a/src/app/api/admin/impact-lab/match/route.ts
+++ b/src/app/api/admin/impact-lab/match/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { runMatching } from "@/lib/matching"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { toMatchParticipant } from "@/lib/impact-lab/mappers"
+import { resolveSettings } from "@/lib/impact-lab/settings"
+
+/**
+ * Generate a match for a cohort. Pure computation — nothing is persisted here;
+ * saving happens via /runs. Returns the result plus a slim participant directory
+ * so the UI can render member names without a second fetch.
+ */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const limit = await rateLimit(request, RateLimits.ADMIN)
+  if (!limit.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Please slow down." },
+      { status: 429, headers: limit.headers }
+    )
+  }
+
+  let body: { cohort?: string; settings?: unknown } = {}
+  try {
+    body = (await request.json()) ?? {}
+  } catch {
+    // Empty body is fine — run with defaults.
+  }
+
+  const cohort = body.cohort ?? DEFAULT_COHORT
+
+  let settings
+  try {
+    settings = resolveSettings(body.settings)
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid settings" },
+      { status: 400 }
+    )
+  }
+
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { cohort },
+  })
+
+  const result = runMatching(participants.map(toMatchParticipant), settings)
+
+  const directory = participants.map((p) => ({
+    id: p.id,
+    fullName: p.fullName,
+    email: p.email,
+    primaryRole: p.primaryRole,
+    experienceLevel: p.experienceLevel,
+    consentToShareContact: p.consentToShareContact,
+  }))
+
+  return NextResponse.json({ success: true, data: { result, participants: directory } })
+}

--- a/src/app/api/admin/impact-lab/match/route.ts
+++ b/src/app/api/admin/impact-lab/match/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { runMatching } from "@/lib/matching"
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { safeCohort } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
     // Empty body is fine — run with defaults.
   }
 
-  const cohort = body.cohort ?? DEFAULT_COHORT
+  const cohort = safeCohort(body.cohort)
 
   let settings
   try {

--- a/src/app/api/admin/impact-lab/match/route.ts
+++ b/src/app/api/admin/impact-lab/match/route.ts
@@ -7,6 +7,7 @@ import { runMatching } from "@/lib/matching"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
+import { resultSignature } from "@/lib/impact-lab/signature"
 
 /**
  * Generate a match for a cohort. Pure computation — nothing is persisted here;
@@ -62,5 +63,8 @@ export async function POST(request: NextRequest) {
     consentToShareContact: p.consentToShareContact,
   }))
 
-  return NextResponse.json({ success: true, data: { result, participants: directory } })
+  return NextResponse.json({
+    success: true,
+    data: { result, participants: directory, signature: resultSignature(result) },
+  })
 }

--- a/src/app/api/admin/impact-lab/participants/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/participants/[id]/route.ts
@@ -53,10 +53,22 @@ export async function PATCH(
     }
   }
 
-  const updated = await prisma.impactLabParticipant.update({
-    where: { id },
-    data: validation.data,
-  })
+  let updated
+  try {
+    updated = await prisma.impactLabParticipant.update({
+      where: { id },
+      data: validation.data,
+    })
+  } catch (error) {
+    // Race on the (cohort, email) unique index when the email is changed.
+    if ((error as { code?: string }).code === "P2002") {
+      return NextResponse.json(
+        { success: false, error: "Another participant in this cohort already uses that email." },
+        { status: 409 }
+      )
+    }
+    throw error
+  }
 
   await logAudit({
     userId: check.user.id,

--- a/src/app/api/admin/impact-lab/participants/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/participants/[id]/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { withCsrfProtection } from "@/lib/csrf"
+import { participantUpdateSchema } from "@/lib/impact-lab/participant-schema"
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "edit")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid request body" },
+      { status: 400 }
+    )
+  }
+
+  const validation = participantUpdateSchema.safeParse(body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { success: false, error: "Validation failed", details: validation.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const existing = await prisma.impactLabParticipant.findUnique({ where: { id } })
+  if (!existing) {
+    return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+  }
+
+  // Guard the (cohort, email) uniqueness when the email is being changed.
+  if (validation.data.email && validation.data.email !== existing.email) {
+    const clash = await prisma.impactLabParticipant.findUnique({
+      where: { cohort_email: { cohort: existing.cohort, email: validation.data.email } },
+    })
+    if (clash) {
+      return NextResponse.json(
+        { success: false, error: "Another participant in this cohort already uses that email." },
+        { status: 409 }
+      )
+    }
+  }
+
+  const updated = await prisma.impactLabParticipant.update({
+    where: { id },
+    data: validation.data,
+  })
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "UPDATE",
+    entity: "ImpactLabParticipant",
+    entityId: id,
+    changes: { fields: Object.keys(validation.data) },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, data: updated })
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "delete")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+  const existing = await prisma.impactLabParticipant.findUnique({ where: { id } })
+  if (!existing) {
+    return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+  }
+
+  await prisma.impactLabParticipant.delete({ where: { id } })
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "DELETE",
+    entity: "ImpactLabParticipant",
+    entityId: id,
+    changes: { fullName: existing.fullName, email: existing.email },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, message: "Participant deleted" })
+}

--- a/src/app/api/admin/impact-lab/participants/export/route.ts
+++ b/src/app/api/admin/impact-lab/participants/export/route.ts
@@ -16,7 +16,9 @@ const HEADERS = [
   "interests",
   "availability",
   "preferredTeammates",
-  "blockedTeammates",
+  // blockedTeammates is deliberately NOT exported — the schema contract says it
+  // is never exposed in a CSV. One shared export file would reveal who blocked
+  // whom. Organisers edit blocks in the admin UI, not via round-tripped CSV.
   "consentToMatch",
   "consentToShareContact",
 ]
@@ -46,7 +48,6 @@ export async function GET(request: NextRequest) {
     p.interests.join("; "),
     p.availability.join("; "),
     p.preferredTeammates.join("; "),
-    p.blockedTeammates.join("; "),
     p.consentToMatch,
     p.consentToShareContact,
   ])

--- a/src/app/api/admin/impact-lab/participants/export/route.ts
+++ b/src/app/api/admin/impact-lab/participants/export/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { toCsv } from "@/lib/impact-lab/csv"
+
+const HEADERS = [
+  "fullName",
+  "email",
+  "phone",
+  "institution",
+  "experienceLevel",
+  "primaryRole",
+  "secondaryRoles",
+  "technicalSkills",
+  "interests",
+  "availability",
+  "preferredTeammates",
+  "blockedTeammates",
+  "consentToMatch",
+  "consentToShareContact",
+]
+
+/** Export all participants in a cohort as CSV. Multi-value fields joined with ";". */
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const { searchParams } = new URL(request.url)
+  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { cohort },
+    orderBy: { fullName: "asc" },
+  })
+
+  const rows = participants.map((p) => [
+    p.fullName,
+    p.email,
+    p.phone,
+    p.institution,
+    p.experienceLevel,
+    p.primaryRole,
+    p.secondaryRoles.join("; "),
+    p.technicalSkills.join("; "),
+    p.interests.join("; "),
+    p.availability.join("; "),
+    p.preferredTeammates.join("; "),
+    p.blockedTeammates.join("; "),
+    p.consentToMatch,
+    p.consentToShareContact,
+  ])
+
+  const csv = toCsv(HEADERS, rows)
+
+  return new NextResponse(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="impact-lab-participants-${cohort}.csv"`,
+    },
+  })
+}

--- a/src/app/api/admin/impact-lab/participants/export/route.ts
+++ b/src/app/api/admin/impact-lab/participants/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { safeCohort } from "@/lib/impact-lab/constants"
 import { toCsv } from "@/lib/impact-lab/csv"
 
 const HEADERS = [
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+  const cohort = safeCohort(searchParams.get("cohort"))
 
   const participants = await prisma.impactLabParticipant.findMany({
     where: { cohort },

--- a/src/app/api/admin/impact-lab/participants/import/route.ts
+++ b/src/app/api/admin/impact-lab/participants/import/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { withCsrfProtection } from "@/lib/csrf"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
+
+const importSchema = z.object({
+  cohort: z.string().max(60).optional(),
+  // Raw rows — validated individually so one bad row doesn't fail the batch.
+  participants: z.array(z.unknown()).max(500),
+})
+
+/**
+ * Bulk import participants. The client maps CSV columns to fields and splits
+ * multi-value cells, then posts an array of drafts. Each row is validated and
+ * upserted on (cohort, email); per-row failures are reported, not fatal.
+ */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "create")
+  if (!check.authorized) return check.response
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid request body" },
+      { status: 400 }
+    )
+  }
+
+  const parsed = importSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Validation failed", details: parsed.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const cohort = parsed.data.cohort ?? DEFAULT_COHORT
+  const errors: { row: number; error: string }[] = []
+  let created = 0
+  let updated = 0
+
+  for (let i = 0; i < parsed.data.participants.length; i++) {
+    const validation = participantDraftSchema.safeParse(parsed.data.participants[i])
+    if (!validation.success) {
+      errors.push({ row: i + 1, error: validation.error.issues[0]?.message ?? "Invalid row" })
+      continue
+    }
+
+    const existing = await prisma.impactLabParticipant.findUnique({
+      where: { cohort_email: { cohort, email: validation.data.email } },
+    })
+
+    if (existing) {
+      await prisma.impactLabParticipant.update({
+        where: { id: existing.id },
+        data: validation.data,
+      })
+      updated++
+    } else {
+      await prisma.impactLabParticipant.create({
+        data: { ...validation.data, cohort },
+      })
+      created++
+    }
+  }
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "CREATE",
+    entity: "ImpactLabParticipant",
+    entityId: cohort,
+    changes: { imported: created, updated, failed: errors.length },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({
+    success: true,
+    data: { created, updated, failed: errors.length, errors },
+  })
+}

--- a/src/app/api/admin/impact-lab/participants/import/route.ts
+++ b/src/app/api/admin/impact-lab/participants/import/route.ts
@@ -4,8 +4,13 @@ import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { withCsrfProtection } from "@/lib/csrf"
+import { rateLimit } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
+
+// A large import must finish in one function invocation — give it headroom
+// beyond the default so a ~500-row upload doesn't time out mid-write.
+export const maxDuration = 60
 
 const importSchema = z.object({
   cohort: z.string().max(60).optional(),
@@ -15,8 +20,10 @@ const importSchema = z.object({
 
 /**
  * Bulk import participants. The client maps CSV columns to fields and splits
- * multi-value cells, then posts an array of drafts. Each row is validated and
- * upserted on (cohort, email); per-row failures are reported, not fatal.
+ * multi-value cells, then posts an array of drafts. Rows are validated
+ * individually (per-row failures are reported, not fatal), deduped by email, and
+ * written in a single findMany + $transaction so the whole import is one
+ * round-trip pair regardless of size.
  */
 export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
@@ -25,14 +32,24 @@ export async function POST(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "create")
   if (!check.authorized) return check.response
 
+  // Key by user id, not IP — organisers share a venue NAT on event day.
+  const limit = await rateLimit(request, {
+    maxRequests: 6,
+    windowInSeconds: 60,
+    identifier: () => `impact-lab-import:${check.user.id}`,
+  })
+  if (!limit.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many imports. Please wait a minute." },
+      { status: 429, headers: limit.headers }
+    )
+  }
+
   let body: unknown
   try {
     body = await request.json()
   } catch {
-    return NextResponse.json(
-      { success: false, error: "Invalid request body" },
-      { status: 400 }
-    )
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 })
   }
 
   const parsed = importSchema.safeParse(body)
@@ -45,33 +62,39 @@ export async function POST(request: NextRequest) {
 
   const cohort = parsed.data.cohort ?? DEFAULT_COHORT
   const errors: { row: number; error: string }[] = []
-  let created = 0
-  let updated = 0
 
-  for (let i = 0; i < parsed.data.participants.length; i++) {
-    const validation = participantDraftSchema.safeParse(parsed.data.participants[i])
+  // Validate every row; dedupe by email (last occurrence wins) so a repeated
+  // email in one file can't self-collide inside the transaction.
+  const draftsByEmail = new Map<string, z.infer<typeof participantDraftSchema>>()
+  parsed.data.participants.forEach((raw, i) => {
+    const validation = participantDraftSchema.safeParse(raw)
     if (!validation.success) {
       errors.push({ row: i + 1, error: validation.error.issues[0]?.message ?? "Invalid row" })
-      continue
+      return
     }
+    draftsByEmail.set(validation.data.email, validation.data)
+  })
 
-    const existing = await prisma.impactLabParticipant.findUnique({
-      where: { cohort_email: { cohort, email: validation.data.email } },
-    })
+  const drafts = [...draftsByEmail.values()]
+  const existing = await prisma.impactLabParticipant.findMany({
+    where: { cohort, email: { in: drafts.map((d) => d.email) } },
+    select: { id: true, email: true },
+  })
+  const idByEmail = new Map(existing.map((e) => [e.email, e.id]))
 
-    if (existing) {
-      await prisma.impactLabParticipant.update({
-        where: { id: existing.id },
-        data: validation.data,
-      })
+  let created = 0
+  let updated = 0
+  const ops = drafts.map((draft) => {
+    const id = idByEmail.get(draft.email)
+    if (id) {
       updated++
-    } else {
-      await prisma.impactLabParticipant.create({
-        data: { ...validation.data, cohort },
-      })
-      created++
+      return prisma.impactLabParticipant.update({ where: { id }, data: draft })
     }
-  }
+    created++
+    return prisma.impactLabParticipant.create({ data: { ...draft, cohort } })
+  })
+
+  await prisma.$transaction(ops)
 
   await logAudit({
     userId: check.user.id,

--- a/src/app/api/admin/impact-lab/participants/import/route.ts
+++ b/src/app/api/admin/impact-lab/participants/import/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit } from "@/lib/rate-limit"
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { safeCohort } from "@/lib/impact-lab/constants"
 import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
 
 // A large import must finish in one function invocation — give it headroom
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = parsed.data.cohort ?? DEFAULT_COHORT
+  const cohort = safeCohort(parsed.data.cohort)
   const errors: { row: number; error: string }[] = []
 
   // Validate every row; dedupe by email (last occurrence wins) so a repeated

--- a/src/app/api/admin/impact-lab/participants/route.ts
+++ b/src/app/api/admin/impact-lab/participants/route.ts
@@ -3,7 +3,7 @@ import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { withCsrfProtection } from "@/lib/csrf"
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { safeCohort } from "@/lib/impact-lab/constants"
 import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
 
 export async function GET(request: NextRequest) {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+  const cohort = safeCohort(searchParams.get("cohort"))
 
   const participants = await prisma.impactLabParticipant.findMany({
     where: { cohort },
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
-  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+  const cohort = safeCohort(searchParams.get("cohort"))
 
   const validation = participantDraftSchema.safeParse(body)
   if (!validation.success) {

--- a/src/app/api/admin/impact-lab/participants/route.ts
+++ b/src/app/api/admin/impact-lab/participants/route.ts
@@ -49,19 +49,22 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const existing = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort, email: validation.data.email } },
-  })
-  if (existing) {
-    return NextResponse.json(
-      { success: false, error: "A participant with this email already exists in this cohort." },
-      { status: 409 }
-    )
+  // Rely on the (cohort, email) unique index rather than a find-then-create,
+  // which has a race window under concurrent submits. P2002 → clean 409.
+  let created
+  try {
+    created = await prisma.impactLabParticipant.create({
+      data: { ...validation.data, cohort },
+    })
+  } catch (error) {
+    if ((error as { code?: string }).code === "P2002") {
+      return NextResponse.json(
+        { success: false, error: "A participant with this email already exists in this cohort." },
+        { status: 409 }
+      )
+    }
+    throw error
   }
-
-  const created = await prisma.impactLabParticipant.create({
-    data: { ...validation.data, cohort },
-  })
 
   await logAudit({
     userId: check.user.id,

--- a/src/app/api/admin/impact-lab/participants/route.ts
+++ b/src/app/api/admin/impact-lab/participants/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { withCsrfProtection } from "@/lib/csrf"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
+
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const { searchParams } = new URL(request.url)
+  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { cohort },
+    orderBy: { createdAt: "asc" },
+  })
+
+  return NextResponse.json({ success: true, data: participants })
+}
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "create")
+  if (!check.authorized) return check.response
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json(
+      { success: false, error: "Invalid request body" },
+      { status: 400 }
+    )
+  }
+
+  const { searchParams } = new URL(request.url)
+  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+
+  const validation = participantDraftSchema.safeParse(body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { success: false, error: "Validation failed", details: validation.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const existing = await prisma.impactLabParticipant.findUnique({
+    where: { cohort_email: { cohort, email: validation.data.email } },
+  })
+  if (existing) {
+    return NextResponse.json(
+      { success: false, error: "A participant with this email already exists in this cohort." },
+      { status: 409 }
+    )
+  }
+
+  const created = await prisma.impactLabParticipant.create({
+    data: { ...validation.data, cohort },
+  })
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "CREATE",
+    entity: "ImpactLabParticipant",
+    entityId: created.id,
+    changes: { fullName: created.fullName, email: created.email, cohort },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, data: created }, { status: 201 })
+}

--- a/src/app/api/admin/impact-lab/runs/[id]/export/route.ts
+++ b/src/app/api/admin/impact-lab/runs/[id]/export/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { toCsv } from "@/lib/impact-lab/csv"
+import type { MatchParticipant, MatchResult } from "@/lib/matching"
+
+/**
+ * Export a run's teams as CSV: team, member name, and email. Email is included
+ * ONLY for participants who set consentToShareContact — read from the live
+ * participant record so the latest consent wins, falling back to the run's
+ * snapshot for the name when a participant has since been deleted.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+  const run = await prisma.impactLabMatchRun.findUnique({ where: { id } })
+  if (!run) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+
+  const result = run.result as unknown as MatchResult
+  const snapshot = run.participantsSnapshot as unknown as MatchParticipant[]
+  const snapshotById = new Map(snapshot.map((p) => [p.id, p]))
+
+  // Live records give us the current consent + email.
+  const live = await prisma.impactLabParticipant.findMany({ where: { cohort: run.cohort } })
+  const liveById = new Map(live.map((p) => [p.id, p]))
+
+  const rows: (string | number)[][] = []
+  for (const team of result.teams) {
+    for (const memberId of team.memberIds) {
+      const liveP = liveById.get(memberId)
+      const snap = snapshotById.get(memberId)
+      const name = liveP?.fullName ?? snap?.fullName ?? memberId
+      const email = liveP?.consentToShareContact ? liveP.email : ""
+      rows.push([team.name, team.score.total, name, email])
+    }
+  }
+
+  const csv = toCsv(["team", "teamScore", "member", "email"], rows)
+
+  return new NextResponse(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="impact-lab-teams-${run.id}.csv"`,
+    },
+  })
+}

--- a/src/app/api/admin/impact-lab/runs/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/runs/[id]/route.ts
@@ -13,7 +13,23 @@ export async function GET(
   if (!check.authorized) return check.response
 
   const { id } = await params
-  const run = await prisma.impactLabMatchRun.findUnique({ where: { id } })
+  // participantsSnapshot is deliberately omitted — it holds every participant's
+  // email + blockedTeammates (including non-consenting people) and is only
+  // needed server-side for the final-teams export, never by the client.
+  const run = await prisma.impactLabMatchRun.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      cohort: true,
+      name: true,
+      notes: true,
+      isFinal: true,
+      settings: true,
+      result: true,
+      createdById: true,
+      createdAt: true,
+    },
+  })
   if (!run) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
 
   return NextResponse.json({ success: true, data: run })

--- a/src/app/api/admin/impact-lab/runs/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/runs/[id]/route.ts
@@ -83,20 +83,32 @@ export async function PATCH(
     const approveCheck = await checkApiPermission("impact-lab", "approve")
     if (!approveCheck.authorized) return approveCheck.response
 
-    await prisma.$transaction([
-      prisma.impactLabMatchRun.updateMany({
-        where: { cohort: existing.cohort, isFinal: true, NOT: { id } },
-        data: { isFinal: false },
-      }),
-      prisma.impactLabMatchRun.update({
-        where: { id },
-        data: {
-          isFinal: true,
-          ...(name !== undefined ? { name } : {}),
-          ...(notes !== undefined ? { notes } : {}),
-        },
-      }),
-    ])
+    try {
+      await prisma.$transaction([
+        prisma.impactLabMatchRun.updateMany({
+          where: { cohort: existing.cohort, isFinal: true, NOT: { id } },
+          data: { isFinal: false },
+        }),
+        prisma.impactLabMatchRun.update({
+          where: { id },
+          data: {
+            isFinal: true,
+            ...(name !== undefined ? { name } : {}),
+            ...(notes !== undefined ? { notes } : {}),
+          },
+        }),
+      ])
+    } catch (error) {
+      // The partial unique index (one final per cohort) rejects a concurrent
+      // mark-final race that the transaction alone can't stop under read-committed.
+      if ((error as { code?: string }).code === "P2002") {
+        return NextResponse.json(
+          { success: false, error: "Another run was just marked final. Refresh and try again." },
+          { status: 409 }
+        )
+      }
+      throw error
+    }
   } else {
     await prisma.impactLabMatchRun.update({
       where: { id },

--- a/src/app/api/admin/impact-lab/runs/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/runs/[id]/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+  const run = await prisma.impactLabMatchRun.findUnique({ where: { id } })
+  if (!run) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+
+  return NextResponse.json({ success: true, data: run })
+}
+
+const updateSchema = z.object({
+  name: z.string().min(1).max(120).optional(),
+  notes: z.string().max(1000).nullable().optional(),
+  isFinal: z.boolean().optional(),
+})
+
+/**
+ * Update a run: rename/re-note, or mark it final. Marking final is an atomic
+ * swap — the previous final in the cohort is unset in the same transaction, so
+ * the "at most one final per cohort" rule can never be transiently violated.
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "edit")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 })
+  }
+
+  const validation = updateSchema.safeParse(body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { success: false, error: "Validation failed", details: validation.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const existing = await prisma.impactLabMatchRun.findUnique({ where: { id } })
+  if (!existing) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+
+  const { name, notes, isFinal } = validation.data
+
+  if (isFinal === true) {
+    // Approving a final run requires the `approve` permission, not just `edit`.
+    const approveCheck = await checkApiPermission("impact-lab", "approve")
+    if (!approveCheck.authorized) return approveCheck.response
+
+    await prisma.$transaction([
+      prisma.impactLabMatchRun.updateMany({
+        where: { cohort: existing.cohort, isFinal: true, NOT: { id } },
+        data: { isFinal: false },
+      }),
+      prisma.impactLabMatchRun.update({
+        where: { id },
+        data: {
+          isFinal: true,
+          ...(name !== undefined ? { name } : {}),
+          ...(notes !== undefined ? { notes } : {}),
+        },
+      }),
+    ])
+  } else {
+    await prisma.impactLabMatchRun.update({
+      where: { id },
+      data: {
+        ...(name !== undefined ? { name } : {}),
+        ...(notes !== undefined ? { notes } : {}),
+        ...(isFinal === false ? { isFinal: false } : {}),
+      },
+    })
+  }
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: isFinal === true ? "APPROVE" : "UPDATE",
+    entity: "ImpactLabMatchRun",
+    entityId: id,
+    changes: { ...(name ? { name } : {}), ...(isFinal !== undefined ? { isFinal } : {}) },
+    ...getRequestMetadata(request),
+  })
+
+  const updated = await prisma.impactLabMatchRun.findUnique({ where: { id } })
+  return NextResponse.json({ success: true, data: updated })
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "delete")
+  if (!check.authorized) return check.response
+
+  const { id } = await params
+  const existing = await prisma.impactLabMatchRun.findUnique({ where: { id } })
+  if (!existing) return NextResponse.json({ success: false, error: "Not found" }, { status: 404 })
+
+  await prisma.impactLabMatchRun.delete({ where: { id } })
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "DELETE",
+    entity: "ImpactLabMatchRun",
+    entityId: id,
+    changes: { name: existing.name },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, message: "Run deleted" })
+}

--- a/src/app/api/admin/impact-lab/runs/route.ts
+++ b/src/app/api/admin/impact-lab/runs/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { runMatching, type MatchResult } from "@/lib/matching"
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { safeCohort } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
@@ -25,11 +25,21 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+  const cohort = safeCohort(searchParams.get("cohort"))
 
+  // Only the fields the summary needs — skip the heavy participantsSnapshot and
+  // settings JSONB (the list computes three numbers from `result`).
   const runs = await prisma.impactLabMatchRun.findMany({
     where: { cohort },
     orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      name: true,
+      notes: true,
+      isFinal: true,
+      createdAt: true,
+      result: true,
+    },
   })
 
   // Surface a lightweight summary; the full result lives on the detail route.
@@ -77,7 +87,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = validation.data.cohort ?? DEFAULT_COHORT
+  const cohort = safeCohort(validation.data.cohort)
 
   let settings
   try {

--- a/src/app/api/admin/impact-lab/runs/route.ts
+++ b/src/app/api/admin/impact-lab/runs/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { runMatching, type MatchResult } from "@/lib/matching"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { toMatchParticipant } from "@/lib/impact-lab/mappers"
+import { resolveSettings } from "@/lib/impact-lab/settings"
+
+const saveSchema = z.object({
+  cohort: z.string().max(60).optional(),
+  name: z.string().min(1).max(120),
+  notes: z.string().max(1000).optional(),
+  settings: z.unknown().optional(),
+})
+
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const { searchParams } = new URL(request.url)
+  const cohort = searchParams.get("cohort") ?? DEFAULT_COHORT
+
+  const runs = await prisma.impactLabMatchRun.findMany({
+    where: { cohort },
+    orderBy: { createdAt: "desc" },
+  })
+
+  // Surface a lightweight summary; the full result lives on the detail route.
+  const data = runs.map((run) => {
+    const result = run.result as unknown as MatchResult
+    return {
+      id: run.id,
+      name: run.name,
+      notes: run.notes,
+      isFinal: run.isFinal,
+      createdAt: run.createdAt,
+      teamCount: result.teams?.length ?? 0,
+      averageScore: result.averageScore ?? 0,
+      unassignedCount: result.unassignedIds?.length ?? 0,
+    }
+  })
+
+  return NextResponse.json({ success: true, data })
+}
+
+/**
+ * Save the current match as a frozen run. The result is recomputed server-side
+ * from the cohort + settings so a saved run is always a legitimate output of the
+ * engine, and the participants are snapshotted for reproducibility.
+ */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "create")
+  if (!check.authorized) return check.response
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 })
+  }
+
+  const validation = saveSchema.safeParse(body)
+  if (!validation.success) {
+    return NextResponse.json(
+      { success: false, error: "Validation failed", details: validation.error.issues },
+      { status: 400 }
+    )
+  }
+
+  const cohort = validation.data.cohort ?? DEFAULT_COHORT
+
+  let settings
+  try {
+    settings = resolveSettings(validation.data.settings)
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid settings" }, { status: 400 })
+  }
+
+  const participants = await prisma.impactLabParticipant.findMany({ where: { cohort } })
+  const mapped = participants.map(toMatchParticipant)
+  const result = runMatching(mapped, settings)
+
+  // JSON.parse(JSON.stringify(...)) yields plain JSON values for Prisma's Json columns.
+  const run = await prisma.impactLabMatchRun.create({
+    data: {
+      cohort,
+      name: validation.data.name,
+      notes: validation.data.notes ?? null,
+      settings: JSON.parse(JSON.stringify(settings)),
+      result: JSON.parse(JSON.stringify(result)),
+      participantsSnapshot: JSON.parse(JSON.stringify(mapped)),
+      createdById: check.user.id || null,
+    },
+  })
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "CREATE",
+    entity: "ImpactLabMatchRun",
+    entityId: run.id,
+    changes: { name: run.name, cohort },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, data: run }, { status: 201 })
+}

--- a/src/app/api/admin/impact-lab/runs/route.ts
+++ b/src/app/api/admin/impact-lab/runs/route.ts
@@ -8,12 +8,16 @@ import { runMatching, type MatchResult } from "@/lib/matching"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
+import { resultSignature } from "@/lib/impact-lab/signature"
 
 const saveSchema = z.object({
   cohort: z.string().max(60).optional(),
   name: z.string().min(1).max(120),
   notes: z.string().max(1000).optional(),
   settings: z.unknown().optional(),
+  // Signature of the result the organiser reviewed. If the recomputed result
+  // differs (a participant was edited since Generate), we refuse to save.
+  expectedSignature: z.string().max(64).optional(),
 })
 
 export async function GET(request: NextRequest) {
@@ -85,6 +89,20 @@ export async function POST(request: NextRequest) {
   const participants = await prisma.impactLabParticipant.findMany({ where: { cohort } })
   const mapped = participants.map(toMatchParticipant)
   const result = runMatching(mapped, settings)
+
+  // Refuse to freeze a run that differs from what the organiser reviewed.
+  if (
+    validation.data.expectedSignature &&
+    resultSignature(result) !== validation.data.expectedSignature
+  ) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Participants changed since these teams were generated. Regenerate before saving.",
+      },
+      { status: 409 }
+    )
+  }
 
   // JSON.parse(JSON.stringify(...)) yields plain JSON values for Prisma's Json columns.
   const run = await prisma.impactLabMatchRun.create({

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -21,6 +21,7 @@ import {
   UsersRound,
   Sparkles,
   Camera,
+  Network,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -36,6 +37,7 @@ const navItems = [
   { href: "/admin/photos", label: "Photos", icon: Camera },
   { href: "/admin/blog", label: "Blog Posts", icon: FileText },
   { href: "/admin/community", label: "Community Hub", icon: Library },
+  { href: "/admin/impact-lab", label: "Impact Lab", icon: Network },
   { href: "/admin/contact", label: "Contact Messages", icon: MessageSquare },
   { href: "/admin/team", label: "Team", icon: UsersRound },
   { href: "/admin/settings", label: "Settings", icon: Settings },

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { useState } from "react"
+import { Users, Network, Save } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { ParticipantsTab } from "./ParticipantsTab"
+import { MatchingTab } from "./MatchingTab"
+import { RunsTab } from "./RunsTab"
+
+type Tab = "participants" | "matching" | "runs"
+
+const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
+  { key: "participants", label: "Participants", icon: Users },
+  { key: "matching", label: "Matching", icon: Network },
+  { key: "runs", label: "Runs", icon: Save },
+]
+
+export function ImpactLabDashboard({ cohort }: { cohort: string }) {
+  const [tab, setTab] = useState<Tab>("participants")
+  // Bumped when a run is saved so the Runs tab reloads.
+  const [runsKey, setRunsKey] = useState(0)
+
+  return (
+    <div className="space-y-5">
+      <div className="flex items-center gap-1 border-b border-[#1e1e1e]">
+        {TABS.map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={cn(
+              "flex items-center gap-2 px-4 py-2.5 text-xs font-mono transition-all border-b-2 -mb-px",
+              tab === key
+                ? "border-[#00ff41] text-[#00ff41]"
+                : "border-transparent text-[#666] hover:text-[#999]"
+            )}
+          >
+            <Icon className="w-3.5 h-3.5" /> {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "participants" && <ParticipantsTab cohort={cohort} />}
+      {tab === "matching" && (
+        <MatchingTab
+          cohort={cohort}
+          onSaved={() => {
+            setRunsKey((k) => k + 1)
+            setTab("runs")
+          }}
+        />
+      )}
+      {tab === "runs" && <RunsTab cohort={cohort} refreshKey={runsKey} />}
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -4,21 +4,25 @@ import { useMemo, useState } from "react"
 import { Loader2, Play, Sparkles, Save } from "lucide-react"
 import { apiSend } from "./api"
 import type { DirectoryParticipant, MatchResponse, TeamExplanation } from "./types"
+// Import path is the constants module directly (not the "@/lib/matching" barrel)
+// so the client bundle gets only the constant objects, not the engine code.
+import { DEFAULT_SETTINGS as ENGINE_DEFAULTS } from "@/lib/matching/constants"
 
 interface MatchingTabProps {
   cohort: string
   onSaved: () => void
 }
 
+// Seed the form from the engine's defaults rather than re-hardcoding them here.
 const DEFAULT_SETTINGS = {
-  desiredTeamSize: 4,
-  minTeamSize: 3,
-  maxTeamSize: 5,
-  requireBuilder: true,
-  requirePresenter: true,
-  preventBeginnerOnlyTeams: true,
-  distributeAdvancedParticipants: true,
-  allowUnassignedParticipants: true,
+  desiredTeamSize: ENGINE_DEFAULTS.desiredTeamSize,
+  minTeamSize: ENGINE_DEFAULTS.minTeamSize,
+  maxTeamSize: ENGINE_DEFAULTS.maxTeamSize,
+  requireBuilder: ENGINE_DEFAULTS.requireBuilder,
+  requirePresenter: ENGINE_DEFAULTS.requirePresenter,
+  preventBeginnerOnlyTeams: ENGINE_DEFAULTS.preventBeginnerOnlyTeams,
+  distributeAdvancedParticipants: ENGINE_DEFAULTS.distributeAdvancedParticipants,
+  allowUnassignedParticipants: ENGINE_DEFAULTS.allowUnassignedParticipants,
 }
 
 const DIMENSION_LABEL: Record<string, string> = {

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -69,7 +69,7 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     setExplaining(true)
     setError(null)
     try {
-      const res = await apiSend<{ explanations: TeamExplanation[] }>("/api/admin/impact-lab/explain", "POST", { cohort, settings })
+      const res = await apiSend<{ explanations: TeamExplanation[] }>("/api/admin/impact-lab/explain", "POST", { cohort, settings, expectedSignature: data?.signature })
       setExplanations(res.explanations)
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to explain")
@@ -83,7 +83,7 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     setSaving(true)
     setError(null)
     try {
-      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings })
+      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings, expectedSignature: data?.signature })
       setRunName("")
       onSaved()
     } catch (e) {

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -1,0 +1,227 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { Loader2, Play, Sparkles, Save } from "lucide-react"
+import { apiSend } from "./api"
+import type { DirectoryParticipant, MatchResponse, TeamExplanation } from "./types"
+
+interface MatchingTabProps {
+  cohort: string
+  onSaved: () => void
+}
+
+const DEFAULT_SETTINGS = {
+  desiredTeamSize: 4,
+  minTeamSize: 3,
+  maxTeamSize: 5,
+  requireBuilder: true,
+  requirePresenter: true,
+  preventBeginnerOnlyTeams: true,
+  distributeAdvancedParticipants: true,
+  allowUnassignedParticipants: true,
+}
+
+const DIMENSION_LABEL: Record<string, string> = {
+  roleCoverage: "Role coverage",
+  skillBalance: "Skill diversity",
+  experienceBalance: "Experience balance",
+  interestAlignment: "Shared interests",
+  availabilityOverlap: "Availability",
+  participantPreferences: "Preferences",
+}
+
+export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS)
+  const [data, setData] = useState<MatchResponse | null>(null)
+  const [explanations, setExplanations] = useState<TeamExplanation[] | null>(null)
+  const [generating, setGenerating] = useState(false)
+  const [explaining, setExplaining] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [runName, setRunName] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const directory = useMemo(() => {
+    const map = new Map<string, DirectoryParticipant>()
+    data?.participants.forEach((p) => map.set(p.id, p))
+    return map
+  }, [data])
+
+  const explByTeam = useMemo(() => {
+    const map = new Map<string, TeamExplanation>()
+    explanations?.forEach((e) => map.set(e.teamId, e))
+    return map
+  }, [explanations])
+
+  async function generate() {
+    setGenerating(true)
+    setError(null)
+    setExplanations(null)
+    try {
+      setData(await apiSend<MatchResponse>("/api/admin/impact-lab/match", "POST", { cohort, settings }))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to generate")
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  async function explain() {
+    setExplaining(true)
+    setError(null)
+    try {
+      const res = await apiSend<{ explanations: TeamExplanation[] }>("/api/admin/impact-lab/explain", "POST", { cohort, settings })
+      setExplanations(res.explanations)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to explain")
+    } finally {
+      setExplaining(false)
+    }
+  }
+
+  async function save() {
+    if (!runName.trim()) return
+    setSaving(true)
+    setError(null)
+    try {
+      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings })
+      setRunName("")
+      onSaved()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="p-4 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg space-y-3">
+        <p className="text-[10px] font-mono text-[#555] uppercase tracking-wider">Settings</p>
+        <div className="grid grid-cols-3 gap-3">
+          <Num label="Desired size" value={settings.desiredTeamSize} onChange={(v) => setSettings({ ...settings, desiredTeamSize: v })} />
+          <Num label="Min size" value={settings.minTeamSize} onChange={(v) => setSettings({ ...settings, minTeamSize: v })} />
+          <Num label="Max size" value={settings.maxTeamSize} onChange={(v) => setSettings({ ...settings, maxTeamSize: v })} />
+        </div>
+        <div className="flex flex-wrap gap-4">
+          <Toggle label="Require builder" checked={settings.requireBuilder} onChange={(v) => setSettings({ ...settings, requireBuilder: v })} />
+          <Toggle label="Require presenter" checked={settings.requirePresenter} onChange={(v) => setSettings({ ...settings, requirePresenter: v })} />
+          <Toggle label="No beginner-only teams" checked={settings.preventBeginnerOnlyTeams} onChange={(v) => setSettings({ ...settings, preventBeginnerOnlyTeams: v })} />
+          <Toggle label="Distribute advanced" checked={settings.distributeAdvancedParticipants} onChange={(v) => setSettings({ ...settings, distributeAdvancedParticipants: v })} />
+          <Toggle label="Allow unassigned" checked={settings.allowUnassignedParticipants} onChange={(v) => setSettings({ ...settings, allowUnassignedParticipants: v })} />
+        </div>
+        <div className="flex items-center gap-2 pt-1">
+          <button onClick={generate} disabled={generating} className="flex items-center gap-1.5 px-4 py-2 bg-[#00ff41]/10 hover:bg-[#00ff41]/20 border border-[#00ff41]/30 rounded text-[11px] font-mono font-semibold text-[#00ff41] disabled:opacity-40">
+            {generating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5" />} Generate teams
+          </button>
+          {data && (
+            <button onClick={explain} disabled={explaining} className="flex items-center gap-1.5 px-4 py-2 bg-[#00d4ff]/10 hover:bg-[#00d4ff]/20 border border-[#00d4ff]/30 rounded text-[11px] font-mono text-[#00d4ff] disabled:opacity-40">
+              {explaining ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Sparkles className="w-3.5 h-3.5" />} Explain with Claude
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>}
+
+      {data && (
+        <>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <p className="text-xs font-mono text-[#888]">
+              {data.result.teams.length} teams · avg score {data.result.averageScore}/100
+              {data.result.unassignedIds.length > 0 && ` · ${data.result.unassignedIds.length} unassigned`}
+            </p>
+            <div className="flex items-center gap-2">
+              <input value={runName} onChange={(e) => setRunName(e.target.value)} placeholder="Run name…" className="bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0] w-40" />
+              <button onClick={save} disabled={saving || !runName.trim()} className="flex items-center gap-1.5 px-3 py-1.5 bg-[#ffb000]/10 hover:bg-[#ffb000]/20 border border-[#ffb000]/30 rounded text-[11px] font-mono text-[#ffb000] disabled:opacity-40">
+                {saving ? <Loader2 className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />} Save run
+              </button>
+            </div>
+          </div>
+
+          {data.result.warnings.length > 0 && (
+            <div className="p-3 bg-[#ffb000]/5 border border-[#ffb000]/20 rounded text-[11px] font-mono text-[#ffb000] space-y-1">
+              {data.result.warnings.map((w, i) => <div key={i}>⚠ {w}</div>)}
+            </div>
+          )}
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            {data.result.teams.map((team) => {
+              const expl = explByTeam.get(team.id)
+              return (
+                <div key={team.id} className="p-4 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div className="text-sm font-mono text-[#e0e0e0]">{team.name}{team.locked && <span className="ml-2 text-[10px] text-[#ffb000]">[locked]</span>}</div>
+                    <div className="text-sm font-mono font-bold text-[#00ff41]">{team.score.total}<span className="text-[#444] text-xs">/100</span></div>
+                  </div>
+
+                  <div className="space-y-1.5">
+                    {team.memberIds.map((id) => {
+                      const p = directory.get(id)
+                      const role = expl?.suggestedInternalRoles?.[id]
+                      return (
+                        <div key={id} className="flex items-center justify-between text-[11px] font-mono">
+                          <span className="text-[#aaa]">{p?.fullName ?? id}</span>
+                          <span className="text-[#555]">{role ?? p?.primaryRole}{p ? ` · ${p.experienceLevel.toLowerCase()}` : ""}</span>
+                        </div>
+                      )
+                    })}
+                  </div>
+
+                  <div className="space-y-1 pt-1">
+                    {team.score.dimensions.map((d) => (
+                      <div key={d.key} className="flex items-center gap-2">
+                        <span className="text-[10px] font-mono text-[#555] w-28 flex-shrink-0">{DIMENSION_LABEL[d.key]}</span>
+                        <div className="flex-1 h-1.5 bg-[#161616] rounded overflow-hidden">
+                          <div className="h-full bg-[#00ff41]/60" style={{ width: `${Math.round(d.raw * 100)}%` }} />
+                        </div>
+                        <span className="text-[10px] font-mono text-[#666] w-8 text-right">{Math.round(d.raw * 100)}%</span>
+                      </div>
+                    ))}
+                  </div>
+
+                  {team.score.penalties.length > 0 && (
+                    <div className="text-[10px] font-mono text-[#ff3333]/80 space-y-0.5">
+                      {team.score.penalties.map((p, i) => <div key={i}>−{p.points} {p.reason}</div>)}
+                    </div>
+                  )}
+
+                  {expl && (
+                    <div className="pt-2 border-t border-[#161616] space-y-1.5 text-[11px] font-mono">
+                      <p className="text-[#888]">{expl.summary}</p>
+                      {expl.suggestedProjectDirection && <p className="text-[#00d4ff]">{expl.suggestedProjectDirection}</p>}
+                      {expl.source === "deterministic" && <p className="text-[10px] text-[#444]">(deterministic summary)</p>}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+
+          {data.result.unassignedIds.length > 0 && (
+            <div className="p-3 bg-[#0d0d0d] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888]">
+              <span className="text-[#555]">Unassigned:</span> {data.result.unassignedIds.map((id) => directory.get(id)?.fullName ?? id).join(", ")}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function Num({ label, value, onChange }: { label: string; value: number; onChange: (v: number) => void }) {
+  return (
+    <div>
+      <label className="block text-[10px] font-mono text-[#555] mb-1 uppercase">{label}</label>
+      <input type="number" value={value} onChange={(e) => onChange(Number(e.target.value))} className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0]" />
+    </div>
+  )
+}
+
+function Toggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label className="flex items-center gap-2 text-[11px] font-mono text-[#888] cursor-pointer">
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="accent-[#00ff41]" />
+      {label}
+    </label>
+  )
+}

--- a/src/components/admin/impact-lab/ParticipantsTab.tsx
+++ b/src/components/admin/impact-lab/ParticipantsTab.tsx
@@ -1,0 +1,295 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { Loader2, Plus, Trash2, Upload, Download } from "lucide-react"
+import { apiGet, apiSend } from "./api"
+import type { ParticipantRow } from "./types"
+
+const EXPERIENCE = ["BEGINNER", "INTERMEDIATE", "ADVANCED"] as const
+
+const LEVEL_COLOR: Record<string, string> = {
+  BEGINNER: "#8a8a8a",
+  INTERMEDIATE: "#00d4ff",
+  ADVANCED: "#00ff41",
+}
+
+/** Quote-aware CSV parser — good enough for Luma / Google Form exports. */
+function parseCsv(text: string): string[][] {
+  const rows: string[][] = []
+  let row: string[] = []
+  let field = ""
+  let quoted = false
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i]
+    if (quoted) {
+      if (c === '"') {
+        if (text[i + 1] === '"') { field += '"'; i++ } else quoted = false
+      } else field += c
+    } else if (c === '"') quoted = true
+    else if (c === ",") { row.push(field); field = "" }
+    else if (c === "\n") { row.push(field); rows.push(row); row = []; field = "" }
+    else if (c !== "\r") field += c
+  }
+  if (field.length || row.length) { row.push(field); rows.push(row) }
+  return rows.filter((r) => r.some((c) => c.trim() !== ""))
+}
+
+const splitMulti = (v: string): string[] =>
+  v.split(/[;,]/).map((s) => s.trim()).filter(Boolean)
+const parseBool = (v: string): boolean => /^(true|yes|1|y)$/i.test(v.trim())
+
+interface ParticipantsTabProps {
+  cohort: string
+}
+
+const EMPTY_FORM = {
+  fullName: "",
+  email: "",
+  primaryRole: "",
+  experienceLevel: "BEGINNER" as (typeof EXPERIENCE)[number],
+  technicalSkills: "",
+  interests: "",
+  availability: "",
+  preferredTeammates: "",
+  blockedTeammates: "",
+  consentToMatch: true,
+  consentToShareContact: false,
+}
+
+export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
+  const [participants, setParticipants] = useState<ParticipantRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [importMsg, setImportMsg] = useState<string | null>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setParticipants(await apiGet<ParticipantRow[]>(`/api/admin/impact-lab/participants?cohort=${cohort}`))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => { void load() }, [load])
+
+  async function addParticipant() {
+    setBusy(true)
+    setError(null)
+    try {
+      await apiSend(`/api/admin/impact-lab/participants?cohort=${cohort}`, "POST", {
+        fullName: form.fullName,
+        email: form.email,
+        primaryRole: form.primaryRole,
+        experienceLevel: form.experienceLevel,
+        technicalSkills: splitMulti(form.technicalSkills),
+        interests: splitMulti(form.interests),
+        availability: splitMulti(form.availability),
+        preferredTeammates: splitMulti(form.preferredTeammates),
+        blockedTeammates: splitMulti(form.blockedTeammates),
+        consentToMatch: form.consentToMatch,
+        consentToShareContact: form.consentToShareContact,
+      })
+      setForm(EMPTY_FORM)
+      setShowForm(false)
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(id: string) {
+    setBusy(true)
+    try {
+      await apiSend(`/api/admin/impact-lab/participants/${id}`, "DELETE")
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    setBusy(true)
+    setImportMsg(null)
+    try {
+      const rows = parseCsv(await file.text())
+      if (rows.length < 2) throw new Error("CSV has no data rows")
+      const headers = rows[0].map((h) => h.trim().toLowerCase())
+      const idx = (name: string) => headers.indexOf(name.toLowerCase())
+      const drafts = rows.slice(1).map((r) => {
+        const get = (name: string) => (idx(name) >= 0 ? r[idx(name)] ?? "" : "")
+        return {
+          fullName: get("fullName"),
+          email: get("email"),
+          phone: get("phone") || null,
+          institution: get("institution") || null,
+          experienceLevel: (get("experienceLevel").toUpperCase() || "BEGINNER"),
+          primaryRole: get("primaryRole"),
+          secondaryRoles: splitMulti(get("secondaryRoles")),
+          technicalSkills: splitMulti(get("technicalSkills")),
+          interests: splitMulti(get("interests")),
+          availability: splitMulti(get("availability")),
+          preferredTeammates: splitMulti(get("preferredTeammates")),
+          blockedTeammates: splitMulti(get("blockedTeammates")),
+          consentToMatch: parseBool(get("consentToMatch")),
+          consentToShareContact: parseBool(get("consentToShareContact")),
+        }
+      })
+      const result = await apiSend<{ created: number; updated: number; failed: number }>(
+        "/api/admin/impact-lab/participants/import",
+        "POST",
+        { cohort, participants: drafts }
+      )
+      setImportMsg(`${result.created} added, ${result.updated} updated, ${result.failed} skipped.`)
+      await load()
+    } catch (err) {
+      setImportMsg(err instanceof Error ? err.message : "Import failed")
+    } finally {
+      setBusy(false)
+      if (fileRef.current) fileRef.current.value = ""
+    }
+  }
+
+  const consenting = participants.filter((p) => p.consentToMatch).length
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-xs font-mono text-[#555]">
+          {participants.length} participants · {consenting} consenting
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowForm((s) => !s)}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#00ff41]/10 hover:bg-[#00ff41]/20 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] transition-all"
+          >
+            <Plus className="w-3 h-3" /> Add
+          </button>
+          <button
+            onClick={() => fileRef.current?.click()}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888] transition-all"
+          >
+            <Upload className="w-3 h-3" /> Import CSV
+          </button>
+          <a
+            href={`/api/admin/impact-lab/participants/export?cohort=${cohort}`}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888] transition-all"
+          >
+            <Download className="w-3 h-3" /> Export
+          </a>
+          <input ref={fileRef} type="file" accept=".csv" onChange={onFile} className="hidden" />
+        </div>
+      </div>
+
+      {importMsg && (
+        <div className="p-2 bg-[#00d4ff]/10 border border-[#00d4ff]/30 rounded text-[11px] font-mono text-[#00d4ff]">{importMsg}</div>
+      )}
+      {error && (
+        <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>
+      )}
+
+      {showForm && (
+        <div className="p-4 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg grid grid-cols-2 gap-3">
+          <Input label="Full name" value={form.fullName} onChange={(v) => setForm({ ...form, fullName: v })} />
+          <Input label="Email" value={form.email} onChange={(v) => setForm({ ...form, email: v })} />
+          <Input label="Primary role" value={form.primaryRole} onChange={(v) => setForm({ ...form, primaryRole: v })} />
+          <div>
+            <label className="block text-[10px] font-mono text-[#555] mb-1 uppercase">Experience</label>
+            <select
+              value={form.experienceLevel}
+              onChange={(e) => setForm({ ...form, experienceLevel: e.target.value as (typeof EXPERIENCE)[number] })}
+              className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0]"
+            >
+              {EXPERIENCE.map((l) => <option key={l} value={l}>{l}</option>)}
+            </select>
+          </div>
+          <Input label="Skills (; or ,)" value={form.technicalSkills} onChange={(v) => setForm({ ...form, technicalSkills: v })} />
+          <Input label="Interests (; or ,)" value={form.interests} onChange={(v) => setForm({ ...form, interests: v })} />
+          <Input label="Availability (; or ,)" value={form.availability} onChange={(v) => setForm({ ...form, availability: v })} />
+          <Input label="Preferred teammates (emails)" value={form.preferredTeammates} onChange={(v) => setForm({ ...form, preferredTeammates: v })} />
+          <div className="col-span-2 flex items-center gap-4">
+            <Check label="Consent to match" checked={form.consentToMatch} onChange={(v) => setForm({ ...form, consentToMatch: v })} />
+            <Check label="Consent to share contact" checked={form.consentToShareContact} onChange={(v) => setForm({ ...form, consentToShareContact: v })} />
+            <button
+              onClick={addParticipant}
+              disabled={busy || !form.fullName || !form.email || !form.primaryRole}
+              className="ml-auto flex items-center gap-1.5 px-3 py-1.5 bg-[#00ff41]/10 hover:bg-[#00ff41]/20 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] disabled:opacity-40"
+            >
+              {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />} Save
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="p-8 text-center"><Loader2 className="w-5 h-5 animate-spin text-[#333] mx-auto" /></div>
+        ) : participants.length === 0 ? (
+          <div className="p-8 text-center text-sm font-mono text-[#555]">No participants yet — add or import.</div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[#1e1e1e]">
+                {["Name", "Role", "Level", "Skills", "Consent", ""].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#141414]">
+              {participants.map((p) => (
+                <tr key={p.id} className="hover:bg-[#111]">
+                  <td className="px-4 py-3">
+                    <div className="text-sm font-mono text-[#e0e0e0]">{p.fullName}</div>
+                    <div className="text-[11px] font-mono text-[#444]">{p.email}</div>
+                  </td>
+                  <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{p.primaryRole}</td>
+                  <td className="px-4 py-3">
+                    <span className="text-[10px] font-mono px-2 py-0.5 rounded border" style={{ color: LEVEL_COLOR[p.experienceLevel], borderColor: `${LEVEL_COLOR[p.experienceLevel]}40` }}>{p.experienceLevel}</span>
+                  </td>
+                  <td className="px-4 py-3 text-[11px] font-mono text-[#666] max-w-xs truncate">{p.technicalSkills.join(", ")}</td>
+                  <td className="px-4 py-3 text-[11px] font-mono">
+                    <span className={p.consentToMatch ? "text-[#00ff41]" : "text-[#ff3333]"}>{p.consentToMatch ? "yes" : "no"}</span>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <button onClick={() => remove(p.id)} disabled={busy} className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function Input({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label className="block text-[10px] font-mono text-[#555] mb-1 uppercase">{label}</label>
+      <input value={value} onChange={(e) => onChange(e.target.value)} className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0]" />
+    </div>
+  )
+}
+
+function Check({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+  return (
+    <label className="flex items-center gap-2 text-[11px] font-mono text-[#888] cursor-pointer">
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="accent-[#00ff41]" />
+      {label}
+    </label>
+  )
+}

--- a/src/components/admin/impact-lab/ParticipantsTab.tsx
+++ b/src/components/admin/impact-lab/ParticipantsTab.tsx
@@ -128,7 +128,20 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
       const rows = parseCsv(await file.text())
       if (rows.length < 2) throw new Error("CSV has no data rows")
       const headers = rows[0].map((h) => h.trim().toLowerCase())
-      const idx = (name: string) => headers.indexOf(name.toLowerCase())
+      // Accept a few common header spellings so a raw Luma/Google Forms export
+      // doesn't silently import zero rows.
+      const ALIASES: Record<string, string[]> = {
+        fullname: ["fullname", "full name", "name"],
+        email: ["email", "e-mail", "email address"],
+      }
+      const idx = (name: string) => {
+        const candidates = ALIASES[name.toLowerCase()] ?? [name.toLowerCase()]
+        for (const c of candidates) {
+          const i = headers.indexOf(c)
+          if (i >= 0) return i
+        }
+        return -1
+      }
       const drafts = rows.slice(1).map((r) => {
         const get = (name: string) => (idx(name) >= 0 ? r[idx(name)] ?? "" : "")
         return {
@@ -194,6 +207,10 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
         </div>
       </div>
 
+      <p className="text-[10px] font-mono text-[#444]">
+        Import expects comma-delimited UTF-8 with headers matching the Export
+        format (fullName, email, primaryRole, …); multi-value cells split on ; or ,.
+      </p>
       {importMsg && (
         <div className="p-2 bg-[#00d4ff]/10 border border-[#00d4ff]/30 rounded text-[11px] font-mono text-[#00d4ff]">{importMsg}</div>
       )}

--- a/src/components/admin/impact-lab/RunsTab.tsx
+++ b/src/components/admin/impact-lab/RunsTab.tsx
@@ -1,0 +1,109 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Loader2, Trash2, Download, CheckCircle2 } from "lucide-react"
+import { apiGet, apiSend } from "./api"
+import type { RunSummary } from "./types"
+
+interface RunsTabProps {
+  cohort: string
+  refreshKey: number
+}
+
+export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
+  const [runs, setRuns] = useState<RunSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setRuns(await apiGet<RunSummary[]>(`/api/admin/impact-lab/runs?cohort=${cohort}`))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => { void load() }, [load, refreshKey])
+
+  async function markFinal(id: string) {
+    setBusy(true)
+    setError(null)
+    try {
+      await apiSend(`/api/admin/impact-lab/runs/${id}`, "PATCH", { isFinal: true })
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to mark final")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function remove(id: string) {
+    setBusy(true)
+    try {
+      await apiSend(`/api/admin/impact-lab/runs/${id}`, "DELETE")
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to delete")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>}
+      <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        {loading ? (
+          <div className="p-8 text-center"><Loader2 className="w-5 h-5 animate-spin text-[#333] mx-auto" /></div>
+        ) : runs.length === 0 ? (
+          <div className="p-8 text-center text-sm font-mono text-[#555]">No saved runs yet — generate and save from the Matching tab.</div>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[#1e1e1e]">
+                {["Name", "Teams", "Avg", "Unassigned", "Status", ""].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#141414]">
+              {runs.map((run) => (
+                <tr key={run.id} className="hover:bg-[#111]">
+                  <td className="px-4 py-3">
+                    <div className="text-sm font-mono text-[#e0e0e0]">{run.name}</div>
+                    {run.notes && <div className="text-[11px] font-mono text-[#444]">{run.notes}</div>}
+                  </td>
+                  <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.teamCount}</td>
+                  <td className="px-4 py-3 text-[11px] font-mono text-[#00ff41]">{run.averageScore}</td>
+                  <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.unassignedCount}</td>
+                  <td className="px-4 py-3">
+                    {run.isFinal ? (
+                      <span className="text-[10px] font-mono px-2 py-0.5 rounded bg-[#00ff41]/10 border border-[#00ff41]/30 text-[#00ff41]">FINAL</span>
+                    ) : (
+                      <span className="text-[10px] font-mono text-[#555]">draft</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-2">
+                      {!run.isFinal && (
+                        <button onClick={() => markFinal(run.id)} disabled={busy} title="Mark final" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40"><CheckCircle2 className="w-3.5 h-3.5" /></button>
+                      )}
+                      <a href={`/api/admin/impact-lab/runs/${run.id}/export`} title="Export teams CSV" className="text-[#00d4ff]/70 hover:text-[#00d4ff]"><Download className="w-3.5 h-3.5" /></a>
+                      <button onClick={() => remove(run.id)} disabled={busy} title="Delete" className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/api.ts
+++ b/src/components/admin/impact-lab/api.ts
@@ -1,0 +1,35 @@
+/** Thin client helpers for the Impact Lab admin API — CSRF token + JSON. */
+
+async function mutatingHeaders(): Promise<Record<string, string>> {
+  const res = await fetch("/api/csrf-token")
+  const { csrfToken } = await res.json()
+  return { "Content-Type": "application/json", "x-csrf-token": csrfToken }
+}
+
+interface ApiEnvelope<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export async function apiGet<T>(url: string): Promise<T> {
+  const res = await fetch(url)
+  const json: ApiEnvelope<T> = await res.json()
+  if (!res.ok || !json.success) throw new Error(json.error || "Request failed")
+  return json.data as T
+}
+
+export async function apiSend<T>(
+  url: string,
+  method: "POST" | "PATCH" | "DELETE",
+  body?: unknown
+): Promise<T> {
+  const res = await fetch(url, {
+    method,
+    headers: await mutatingHeaders(),
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+  const json: ApiEnvelope<T> = await res.json()
+  if (!res.ok || !json.success) throw new Error(json.error || "Request failed")
+  return json.data as T
+}

--- a/src/components/admin/impact-lab/types.ts
+++ b/src/components/admin/impact-lab/types.ts
@@ -36,6 +36,8 @@ export interface DirectoryParticipant {
 export interface MatchResponse {
   result: MatchResult
   participants: DirectoryParticipant[]
+  /** Content signature of the generated result, echoed back on save/explain. */
+  signature: string
 }
 
 export interface RunSummary {

--- a/src/components/admin/impact-lab/types.ts
+++ b/src/components/admin/impact-lab/types.ts
@@ -1,0 +1,50 @@
+import type { MatchResult, TeamExplanation } from "@/lib/matching"
+
+export type { MatchResult, TeamExplanation }
+
+/** A participant row as returned by GET /participants (the Prisma shape we use). */
+export interface ParticipantRow {
+  id: string
+  cohort: string
+  fullName: string
+  email: string
+  phone: string | null
+  institution: string | null
+  experienceLevel: "BEGINNER" | "INTERMEDIATE" | "ADVANCED"
+  primaryRole: string
+  secondaryRoles: string[]
+  technicalSkills: string[]
+  interests: string[]
+  availability: string[]
+  projectIdeas: string | null
+  preferredTeammates: string[]
+  blockedTeammates: string[]
+  consentToMatch: boolean
+  consentToShareContact: boolean
+}
+
+/** Slim participant directory returned alongside a match result. */
+export interface DirectoryParticipant {
+  id: string
+  fullName: string
+  email: string
+  primaryRole: string
+  experienceLevel: string
+  consentToShareContact: boolean
+}
+
+export interface MatchResponse {
+  result: MatchResult
+  participants: DirectoryParticipant[]
+}
+
+export interface RunSummary {
+  id: string
+  name: string
+  notes: string | null
+  isFinal: boolean
+  createdAt: string
+  teamCount: number
+  averageScore: number
+  unassignedCount: number
+}

--- a/src/lib/impact-lab/constants.ts
+++ b/src/lib/impact-lab/constants.ts
@@ -1,0 +1,2 @@
+/** The default (and, for now, only) Impact Lab cohort. */
+export const DEFAULT_COHORT = "impact-lab-2026-07"

--- a/src/lib/impact-lab/constants.ts
+++ b/src/lib/impact-lab/constants.ts
@@ -1,2 +1,15 @@
 /** The default (and, for now, only) Impact Lab cohort. */
 export const DEFAULT_COHORT = "impact-lab-2026-07"
+
+const COHORT_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/i
+
+/**
+ * Coerce user-supplied cohort input to a safe slug. Anything with characters
+ * outside [a-z0-9-] (CR/LF, quotes, etc.) falls back to the default — this is
+ * what keeps the cohort safe to interpolate into a Content-Disposition header
+ * and into queries.
+ */
+export function safeCohort(input: string | null | undefined): string {
+  const value = (input ?? "").trim()
+  return COHORT_PATTERN.test(value) ? value : DEFAULT_COHORT
+}

--- a/src/lib/impact-lab/csv.ts
+++ b/src/lib/impact-lab/csv.ts
@@ -1,0 +1,17 @@
+/**
+ * Minimal, dependency-free CSV serialization for participant and team exports.
+ * Values containing a comma, quote, or newline are quoted and inner quotes
+ * doubled, per RFC 4180.
+ */
+
+export type CsvCell = string | number | boolean | null | undefined
+
+function escapeCell(value: CsvCell): string {
+  const text = value == null ? "" : String(value)
+  return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
+}
+
+export function toCsv(headers: string[], rows: CsvCell[][]): string {
+  const lines = [headers, ...rows].map((row) => row.map(escapeCell).join(","))
+  return lines.join("\r\n")
+}

--- a/src/lib/impact-lab/csv.ts
+++ b/src/lib/impact-lab/csv.ts
@@ -7,7 +7,12 @@
 export type CsvCell = string | number | boolean | null | undefined
 
 function escapeCell(value: CsvCell): string {
-  const text = value == null ? "" : String(value)
+  let text = value == null ? "" : String(value)
+  // Neutralize spreadsheet formula injection: a cell starting with =, +, -, @,
+  // or a control char is evaluated as a formula by Excel/Sheets on open (e.g. a
+  // participant named `=HYPERLINK(...)`). Prefix a single quote so it stays
+  // literal text. Applied before RFC-4180 quoting.
+  if (/^[=+\-@\t\r]/.test(text)) text = `'${text}`
   return /[",\n\r]/.test(text) ? `"${text.replace(/"/g, '""')}"` : text
 }
 

--- a/src/lib/impact-lab/mappers.ts
+++ b/src/lib/impact-lab/mappers.ts
@@ -1,0 +1,27 @@
+/**
+ * Maps Prisma rows into the matching engine's plain input types. This is the
+ * boundary the engine's purity depends on: the DB layer knows about the engine's
+ * types, never the other way round.
+ */
+
+import type { ImpactLabParticipant } from "@/generated/prisma/client"
+import type { ExperienceLevel, MatchParticipant } from "@/lib/matching"
+
+export function toMatchParticipant(
+  row: ImpactLabParticipant
+): MatchParticipant {
+  return {
+    id: row.id,
+    fullName: row.fullName,
+    email: row.email,
+    experienceLevel: row.experienceLevel as ExperienceLevel,
+    primaryRole: row.primaryRole,
+    secondaryRoles: row.secondaryRoles,
+    technicalSkills: row.technicalSkills,
+    interests: row.interests,
+    availability: row.availability,
+    preferredTeammates: row.preferredTeammates,
+    blockedTeammates: row.blockedTeammates,
+    consentToMatch: row.consentToMatch,
+  }
+}

--- a/src/lib/impact-lab/participant-schema.ts
+++ b/src/lib/impact-lab/participant-schema.ts
@@ -1,0 +1,61 @@
+/**
+ * Validation + sanitization for a participant record, shared by the create,
+ * edit, and CSV-import routes. Arrays arrive already split (the CSV importer maps
+ * columns and splits multi-value cells client-side); here we validate and clean.
+ */
+
+import { z } from "zod"
+import {
+  zodSanitizeEmail,
+  zodSanitizeMultilineText,
+  zodSanitizeString,
+} from "@/lib/input-sanitization"
+
+const tokenArray = z
+  .array(z.string().max(80))
+  .max(30)
+  .default([])
+  .transform((values) => values.map((v) => v.trim()).filter(Boolean))
+
+const emailArray = z
+  .array(z.string().max(254))
+  .max(30)
+  .default([])
+  .transform((values) =>
+    values.map((v) => zodSanitizeEmail(v)).filter(Boolean)
+  )
+
+export const participantDraftSchema = z.object({
+  fullName: z.string().min(1).max(120).transform(zodSanitizeString),
+  email: z.string().email().max(254).transform(zodSanitizeEmail),
+  phone: z.string().max(30).optional().nullable(),
+  institution: z
+    .string()
+    .max(120)
+    .optional()
+    .nullable()
+    .transform((v) => (v ? zodSanitizeString(v) : null)),
+  experienceLevel: z
+    .enum(["BEGINNER", "INTERMEDIATE", "ADVANCED"])
+    .default("BEGINNER"),
+  primaryRole: z.string().min(1).max(60).transform(zodSanitizeString),
+  secondaryRoles: tokenArray,
+  technicalSkills: tokenArray,
+  interests: tokenArray,
+  availability: tokenArray,
+  projectIdeas: z
+    .string()
+    .max(2000)
+    .optional()
+    .nullable()
+    .transform((v) => (v ? zodSanitizeMultilineText(2000)(v) : null)),
+  preferredTeammates: emailArray,
+  blockedTeammates: emailArray,
+  consentToMatch: z.boolean().default(false),
+  consentToShareContact: z.boolean().default(false),
+})
+
+/** Same fields, all optional — for PATCH (edit) requests. */
+export const participantUpdateSchema = participantDraftSchema.partial()
+
+export type ParticipantDraft = z.infer<typeof participantDraftSchema>

--- a/src/lib/impact-lab/settings.ts
+++ b/src/lib/impact-lab/settings.ts
@@ -46,11 +46,17 @@ export const settingsSchema = z
  */
 export function resolveSettings(input: unknown): MatchSettings {
   const parsed = settingsSchema.parse(input ?? {})
-  return {
+  const resolved: MatchSettings = {
     ...DEFAULT_SETTINGS,
     ...parsed,
     numberOfTeams: parsed.numberOfTeams ?? null,
     lockedTeams: parsed.lockedTeams ?? DEFAULT_SETTINGS.lockedTeams,
     weights: { ...DEFAULT_WEIGHTS, ...(parsed.weights ?? {}) },
   }
+  // Cross-field check zod can't express when a bound is omitted: an inverted
+  // range silently produces garbage teams, so reject it here (routes → 400).
+  if (resolved.minTeamSize > resolved.maxTeamSize) {
+    throw new Error("minTeamSize cannot exceed maxTeamSize")
+  }
+  return resolved
 }

--- a/src/lib/impact-lab/settings.ts
+++ b/src/lib/impact-lab/settings.ts
@@ -1,0 +1,56 @@
+/**
+ * Validates organiser-supplied match settings and merges them over the engine
+ * defaults, so a partial settings object from the admin form always resolves to
+ * a complete, valid MatchSettings the engine can run.
+ */
+
+import { z } from "zod"
+import { DEFAULT_SETTINGS, DEFAULT_WEIGHTS, type MatchSettings } from "@/lib/matching"
+
+const weightsSchema = z
+  .object({
+    roleCoverage: z.number().min(0).max(10),
+    skillBalance: z.number().min(0).max(10),
+    experienceBalance: z.number().min(0).max(10),
+    interestAlignment: z.number().min(0).max(10),
+    availabilityOverlap: z.number().min(0).max(10),
+    participantPreferences: z.number().min(0).max(10),
+  })
+  .partial()
+
+const lockedTeamSchema = z.object({
+  name: z.string().max(80).optional(),
+  memberEmails: z.array(z.string().email()).max(10),
+})
+
+export const settingsSchema = z
+  .object({
+    desiredTeamSize: z.number().int().min(2).max(8),
+    minTeamSize: z.number().int().min(1).max(8),
+    maxTeamSize: z.number().int().min(2).max(10),
+    numberOfTeams: z.number().int().min(1).max(200).nullable(),
+    allowUnassignedParticipants: z.boolean(),
+    requireBuilder: z.boolean(),
+    requirePresenter: z.boolean(),
+    preventBeginnerOnlyTeams: z.boolean(),
+    distributeAdvancedParticipants: z.boolean(),
+    lockedTeams: z.array(lockedTeamSchema),
+    weights: weightsSchema,
+  })
+  .partial()
+
+/**
+ * Merge a validated partial settings object over the engine defaults. Weights
+ * and lockedTeams merge explicitly so a partial weights map keeps the default
+ * values for the weights the organiser didn't touch.
+ */
+export function resolveSettings(input: unknown): MatchSettings {
+  const parsed = settingsSchema.parse(input ?? {})
+  return {
+    ...DEFAULT_SETTINGS,
+    ...parsed,
+    numberOfTeams: parsed.numberOfTeams ?? null,
+    lockedTeams: parsed.lockedTeams ?? DEFAULT_SETTINGS.lockedTeams,
+    weights: { ...DEFAULT_WEIGHTS, ...(parsed.weights ?? {}) },
+  }
+}

--- a/src/lib/impact-lab/signature.ts
+++ b/src/lib/impact-lab/signature.ts
@@ -1,0 +1,22 @@
+/**
+ * A stable content signature of a match result — its team compositions and
+ * unassigned list. Because the engine is deterministic, the same participants +
+ * settings always produce the same signature; if a participant is edited between
+ * "Generate" and "Save"/"Explain", the recomputed signature differs, which is how
+ * we detect that the organiser is about to freeze something other than what they
+ * reviewed.
+ */
+
+import { createHash } from "crypto"
+import type { MatchResult } from "@/lib/matching"
+
+export function resultSignature(result: MatchResult): string {
+  const canonical = JSON.stringify({
+    teams: result.teams.map((t) => ({
+      name: t.name,
+      members: [...t.memberIds].sort(),
+    })),
+    unassigned: [...result.unassignedIds].sort(),
+  })
+  return createHash("sha256").update(canonical).digest("hex").slice(0, 32)
+}

--- a/src/lib/matching/ai-explanations.ts
+++ b/src/lib/matching/ai-explanations.ts
@@ -153,6 +153,10 @@ export async function explainWithAi(
         if (memberIds.has(participantId)) roles[participantId] = role
       }
 
+      // Merge the engine's penalty-derived warnings (e.g. "No builder on the
+      // team") with the AI's, deduped — don't let the model's warnings silently
+      // replace hard signals from the deterministic scorer.
+      const engineWarnings = team.score.penalties.map((p) => p.reason)
       return {
         teamId: team.id,
         summary: ai.summary,
@@ -160,7 +164,7 @@ export async function explainWithAi(
         weaknesses: ai.weaknesses,
         suggestedProjectDirection: ai.suggestedProjectDirection,
         suggestedInternalRoles: roles,
-        warnings: ai.warnings,
+        warnings: [...new Set([...engineWarnings, ...ai.warnings])],
         source: "ai",
       }
     })
@@ -172,7 +176,10 @@ export async function explainWithAi(
     }
 
     return { explanations, warnings, usedFallback }
-  } catch {
+  } catch (error) {
+    // Log the cause (invalid key vs billing vs bug are otherwise
+    // indistinguishable) before degrading to the deterministic explanations.
+    console.error("[impact-lab] AI explanation failed; using deterministic fallback:", error)
     return allFallback(
       "AI explanations failed; showing deterministic summaries instead."
     )

--- a/src/lib/matching/ai-explanations.ts
+++ b/src/lib/matching/ai-explanations.ts
@@ -1,0 +1,180 @@
+/**
+ * Impact Lab matching — Claude explanation layer.
+ *
+ * This is the ONLY part of the matcher that touches an LLM, and it is strictly
+ * additive: teams are already assigned by the deterministic engine. Claude only
+ * *explains* the finished assignment — it can never change who is on a team.
+ *
+ * Unlike the engine, this module is not pure (it calls the network). It is kept
+ * out of the engine's index barrel for that reason; callers import it directly.
+ *
+ * Safety properties enforced here:
+ *   - Only matching-relevant fields are sent (names, roles, skills, levels,
+ *     availability). No phone numbers, no emails, no blockedTeammates.
+ *   - Every AI suggestion is validated: unknown team ids are dropped, and role
+ *     suggestions must map to a participant actually on that team.
+ *   - Any failure (no API key, rate limit, network, invalid output) falls back
+ *     to the deterministic explanations. The caller never sees an error page.
+ */
+
+import { generateObject } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { z } from "zod"
+import { explainTeam } from "./explanations"
+import type {
+  MatchResult,
+  NormalizedParticipant,
+  TeamExplanation,
+} from "./types"
+
+const MODEL = "claude-sonnet-5"
+
+const anthropic = createAnthropic()
+
+const SYSTEM_INSTRUCTION =
+  "Teams were already assigned by a deterministic algorithm. Your job is to " +
+  "explain the assignments so organisers understand each team's strengths and " +
+  "gaps. Never propose changing team membership. Only reference the participants " +
+  "supplied for each team. Suggested internal roles must use the given " +
+  "participant ids and only participants already on that team."
+
+const aiTeamSchema = z.object({
+  teamId: z.string(),
+  summary: z.string(),
+  strengths: z.array(z.string()),
+  weaknesses: z.array(z.string()),
+  suggestedProjectDirection: z.string().optional(),
+  suggestedInternalRoles: z.array(
+    z.object({ participantId: z.string(), role: z.string() })
+  ),
+  warnings: z.array(z.string()),
+})
+
+const aiResponseSchema = z.object({ teams: z.array(aiTeamSchema) })
+
+/** The slim, privacy-safe view of a participant sent to the model. */
+interface AiParticipantView {
+  id: string
+  fullName: string
+  roles: string[]
+  experienceLevel: string
+  skills: string[]
+  availability: string[]
+}
+
+function buildPayload(
+  result: MatchResult,
+  byId: Map<string, NormalizedParticipant>
+): { teamId: string; name: string; members: AiParticipantView[] }[] {
+  return result.teams.map((team) => ({
+    teamId: team.id,
+    name: team.name,
+    members: team.memberIds
+      .map((id) => byId.get(id))
+      .filter((p): p is NormalizedParticipant => Boolean(p))
+      .map((p) => ({
+        id: p.id,
+        fullName: p.fullName,
+        roles: p.roles,
+        experienceLevel: p.experienceLevel,
+        skills: p.skills,
+        availability: p.availability,
+      })),
+  }))
+}
+
+function deterministicFor(
+  result: MatchResult,
+  byId: Map<string, NormalizedParticipant>,
+  team: MatchResult["teams"][number]
+): TeamExplanation {
+  return explainTeam(
+    team,
+    team.memberIds.map((id) => byId.get(id)!).filter(Boolean)
+  )
+}
+
+export interface AiExplanationResult {
+  explanations: TeamExplanation[]
+  warnings: string[]
+  /** True when some or all teams fell back to deterministic explanations. */
+  usedFallback: boolean
+}
+
+/**
+ * Explain a match result with Claude, validated and with deterministic fallback.
+ * `participants` are the consenting, normalized participants (the engine's view).
+ */
+export async function explainWithAi(
+  result: MatchResult,
+  participants: NormalizedParticipant[]
+): Promise<AiExplanationResult> {
+  const byId = new Map(participants.map((p) => [p.id, p]))
+
+  const allFallback = (message: string): AiExplanationResult => ({
+    explanations: result.teams.map((team) =>
+      deterministicFor(result, byId, team)
+    ),
+    warnings: [message],
+    usedFallback: true,
+  })
+
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return allFallback(
+      "AI explanations are disabled (no API key); showing deterministic summaries."
+    )
+  }
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic(MODEL),
+      schema: aiResponseSchema,
+      system: SYSTEM_INSTRUCTION,
+      prompt:
+        "Explain each team below. Return one entry per team.\n\n" +
+        JSON.stringify(buildPayload(result, byId), null, 2),
+    })
+
+    const aiByTeam = new Map(object.teams.map((t) => [t.teamId, t]))
+    const warnings: string[] = []
+    let usedFallback = false
+
+    const explanations = result.teams.map((team): TeamExplanation => {
+      const ai = aiByTeam.get(team.id)
+      if (!ai) {
+        usedFallback = true
+        return deterministicFor(result, byId, team)
+      }
+
+      // Role suggestions must reference a participant on this team.
+      const memberIds = new Set(team.memberIds)
+      const roles: Record<string, string> = {}
+      for (const { participantId, role } of ai.suggestedInternalRoles) {
+        if (memberIds.has(participantId)) roles[participantId] = role
+      }
+
+      return {
+        teamId: team.id,
+        summary: ai.summary,
+        strengths: ai.strengths,
+        weaknesses: ai.weaknesses,
+        suggestedProjectDirection: ai.suggestedProjectDirection,
+        suggestedInternalRoles: roles,
+        warnings: ai.warnings,
+        source: "ai",
+      }
+    })
+
+    if (usedFallback) {
+      warnings.push(
+        "Some teams fell back to deterministic explanations (the AI omitted them)."
+      )
+    }
+
+    return { explanations, warnings, usedFallback }
+  } catch {
+    return allFallback(
+      "AI explanations failed; showing deterministic summaries instead."
+    )
+  }
+}

--- a/src/lib/matching/algorithm.ts
+++ b/src/lib/matching/algorithm.ts
@@ -1,0 +1,418 @@
+/**
+ * Impact Lab matching engine — the algorithm.
+ *
+ * Orchestrates the full pipeline and produces a `MatchResult`. Every step is
+ * deterministic: iteration orders are fixed (participants arrive id-sorted from
+ * normalization), and ties always break on id. Same input → identical output.
+ *
+ * Pipeline:
+ *   1. partition by consent          (constraints)
+ *   2. normalize                     (normalization)
+ *   3. resolve locked teams          (constraints)
+ *   4. size the run — how many teams
+ *   5. seed each team with a scarce / high-impact role
+ *   6. distribute advanced participants round-robin
+ *   7. greedy fill by marginal contribution
+ *   8. (optimization pass — wired in optimization.ts)
+ *   9. assemble scored teams + warnings
+ */
+
+import {
+  EXPERIENCE_WEIGHT,
+  PREFERRED_TEAMMATE_BONUS,
+  ROLE_PRIORITY,
+  SIZE_BALANCE_PENALTY_PER_MEMBER,
+} from "./constants"
+import {
+  canPlace,
+  hasBlockConflict,
+  partitionByConsent,
+  resolveLockedTeams,
+} from "./constraints"
+import { normalizeParticipants } from "./normalization"
+import { scoreTeam, scoreTeamTotal, type ScoringContext } from "./scoring"
+import type {
+  CanonicalRole,
+  MatchParticipant,
+  MatchResult,
+  MatchSettings,
+  NormalizedParticipant,
+  Team,
+} from "./types"
+
+/** Mutable team used while building an assignment. Ids only; members via byId. */
+interface WorkingTeam {
+  name?: string
+  locked: boolean
+  memberIds: string[]
+}
+
+// ─── Context ─────────────────────────────────────────────────────────────────
+
+function buildContext(
+  participants: NormalizedParticipant[],
+  settings: MatchSettings
+): ScoringContext {
+  return {
+    settings,
+    eligibleEmails: new Set(participants.map((p) => p.email)),
+  }
+}
+
+function membersOf(
+  team: WorkingTeam,
+  byId: Map<string, NormalizedParticipant>
+): NormalizedParticipant[] {
+  return team.memberIds.map((id) => byId.get(id)!)
+}
+
+// ─── Placement scoring ───────────────────────────────────────────────────────
+
+/** True if the candidate and any current member named each other as preferred. */
+function hasPreferredConnection(
+  candidate: NormalizedParticipant,
+  members: NormalizedParticipant[]
+): boolean {
+  return members.some(
+    (m) =>
+      candidate.preferredTeammates.includes(m.email) ||
+      m.preferredTeammates.includes(candidate.email)
+  )
+}
+
+/**
+ * How much placing `candidate` on this team improves things: the team's score
+ * gain, minus a per-member size penalty (nudges toward balanced sizes), plus a
+ * bonus when a preferred teammate is already there. This is the quantity the
+ * greedy fill maximizes.
+ */
+function marginalContribution(
+  team: WorkingTeam,
+  candidate: NormalizedParticipant,
+  byId: Map<string, NormalizedParticipant>,
+  context: ScoringContext
+): number {
+  const members = membersOf(team, byId)
+  const scoreWithout = scoreTeamTotal(members, context)
+  const scoreWith = scoreTeamTotal([...members, candidate], context)
+  const sizePenalty = SIZE_BALANCE_PENALTY_PER_MEMBER * members.length
+  const bonus = hasPreferredConnection(candidate, members)
+    ? PREFERRED_TEAMMATE_BONUS
+    : 0
+  return scoreWith - scoreWithout - sizePenalty + bonus
+}
+
+// ─── Step 4: how many teams ──────────────────────────────────────────────────
+
+/**
+ * Number of *non-locked* teams to form from the unlocked pool. Locked teams are
+ * additional. The desired-size target is clamped so no team is forced above max
+ * and we never make more teams than we have people.
+ */
+function targetTeamCount(poolSize: number, settings: MatchSettings): number {
+  if (poolSize === 0) return 0
+  let count =
+    settings.numberOfTeams ?? Math.ceil(poolSize / settings.desiredTeamSize)
+  count = Math.max(1, count)
+  // Enough teams that everyone fits under maxTeamSize.
+  count = Math.max(count, Math.ceil(poolSize / settings.maxTeamSize))
+  // Never more teams than people.
+  count = Math.min(count, poolSize)
+  return count
+}
+
+// ─── Step 5: seeding ─────────────────────────────────────────────────────────
+
+function rolePriorityIndex(role: CanonicalRole | null): number {
+  if (!role) return ROLE_PRIORITY.length // unmapped primary → seed last
+  const index = ROLE_PRIORITY.indexOf(role)
+  return index === -1 ? ROLE_PRIORITY.length : index
+}
+
+/**
+ * Order the pool for seeding. Highest-priority role first (presenter → builder),
+ * then scarcest primary role, then most experienced, then id. Taking the first N
+ * of this order spreads the scarce high-impact roles across the N teams: if there
+ * are 4 presenters and 5 teams, four teams get a presenter and the fifth gets the
+ * next-best role.
+ */
+function seedOrder(
+  pool: NormalizedParticipant[],
+  roleCounts: Map<CanonicalRole | null, number>
+): NormalizedParticipant[] {
+  return [...pool].sort((a, b) => {
+    const pa = rolePriorityIndex(a.primaryRole)
+    const pb = rolePriorityIndex(b.primaryRole)
+    if (pa !== pb) return pa - pb
+    const sa = roleCounts.get(a.primaryRole) ?? 0
+    const sb = roleCounts.get(b.primaryRole) ?? 0
+    if (sa !== sb) return sa - sb // rarer role first
+    const ea = EXPERIENCE_WEIGHT[a.experienceLevel]
+    const eb = EXPERIENCE_WEIGHT[b.experienceLevel]
+    if (ea !== eb) return eb - ea // more experienced first
+    return a.id < b.id ? -1 : 1
+  })
+}
+
+function countPrimaryRoles(
+  pool: NormalizedParticipant[]
+): Map<CanonicalRole | null, number> {
+  const counts = new Map<CanonicalRole | null, number>()
+  for (const p of pool) {
+    counts.set(p.primaryRole, (counts.get(p.primaryRole) ?? 0) + 1)
+  }
+  return counts
+}
+
+// ─── Placement selection ─────────────────────────────────────────────────────
+
+/** Non-locked teams the candidate can legally join (block-free + under max). */
+function legalTeams(
+  candidate: NormalizedParticipant,
+  teams: WorkingTeam[],
+  byId: Map<string, NormalizedParticipant>,
+  settings: MatchSettings
+): WorkingTeam[] {
+  return teams.filter(
+    (t) => !t.locked && canPlace(candidate, membersOf(t, byId), settings)
+  )
+}
+
+/** Non-locked teams with no block conflict, ignoring size (over-max fallback). */
+function blockLegalTeams(
+  candidate: NormalizedParticipant,
+  teams: WorkingTeam[],
+  byId: Map<string, NormalizedParticipant>
+): WorkingTeam[] {
+  return teams.filter(
+    (t) => !t.locked && !hasBlockConflict(candidate, membersOf(t, byId))
+  )
+}
+
+/**
+ * Choose the greedy-fill team: highest marginal contribution, breaking ties
+ * toward the smaller team then lower index. Returns null only when the candidate
+ * cannot be placed and unassigned participants are allowed.
+ */
+function chooseFillTeam(
+  candidate: NormalizedParticipant,
+  teams: WorkingTeam[],
+  byId: Map<string, NormalizedParticipant>,
+  context: ScoringContext
+): WorkingTeam | null {
+  const legal = legalTeams(candidate, teams, byId, context.settings)
+  const pickFrom =
+    legal.length > 0
+      ? legal
+      : context.settings.allowUnassignedParticipants
+        ? []
+        : blockLegalTeams(candidate, teams, byId)
+
+  if (pickFrom.length === 0) return null
+
+  let best = pickFrom[0]
+  let bestScore = marginalContribution(best, candidate, byId, context)
+  for (let i = 1; i < pickFrom.length; i++) {
+    const team = pickFrom[i]
+    const score = marginalContribution(team, candidate, byId, context)
+    if (
+      score > bestScore ||
+      (score === bestScore && team.memberIds.length < best.memberIds.length)
+    ) {
+      best = team
+      bestScore = score
+    }
+  }
+  return best
+}
+
+// ─── Step 6: distribute advanced participants ────────────────────────────────
+
+function advancedCount(
+  team: WorkingTeam,
+  byId: Map<string, NormalizedParticipant>
+): number {
+  return membersOf(team, byId).filter((m) => m.experienceLevel === "ADVANCED")
+    .length
+}
+
+/**
+ * Spread advanced participants across teams: each goes to a legal team with the
+ * fewest advanced members already, breaking ties by marginal contribution then
+ * index. Prevents all the senior people clustering onto one super-team.
+ */
+function distributeAdvanced(
+  advanced: NormalizedParticipant[],
+  teams: WorkingTeam[],
+  byId: Map<string, NormalizedParticipant>,
+  context: ScoringContext
+): NormalizedParticipant[] {
+  const placed = new Set<string>()
+  for (const candidate of advanced) {
+    const legal = legalTeams(candidate, teams, byId, context.settings)
+    if (legal.length === 0) continue // handled by the general fill
+
+    let best = legal[0]
+    let bestAdv = advancedCount(best, byId)
+    let bestMarginal = marginalContribution(best, candidate, byId, context)
+    for (let i = 1; i < legal.length; i++) {
+      const team = legal[i]
+      const adv = advancedCount(team, byId)
+      const marginal = marginalContribution(team, candidate, byId, context)
+      if (adv < bestAdv || (adv === bestAdv && marginal > bestMarginal)) {
+        best = team
+        bestAdv = adv
+        bestMarginal = marginal
+      }
+    }
+    best.memberIds.push(candidate.id)
+    placed.add(candidate.id)
+  }
+  return advanced.filter((p) => !placed.has(p.id))
+}
+
+// ─── Assembly ────────────────────────────────────────────────────────────────
+
+function assembleTeams(
+  working: WorkingTeam[],
+  byId: Map<string, NormalizedParticipant>,
+  context: ScoringContext
+): Team[] {
+  return working
+    .filter((t) => t.memberIds.length > 0)
+    .map((t, index) => ({
+      id: `team-${index + 1}`,
+      name: t.name ?? `Team ${index + 1}`,
+      memberIds: [...t.memberIds].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+      locked: t.locked,
+      score: scoreTeam(membersOf(t, byId), context),
+    }))
+}
+
+function buildWarnings(
+  teams: Team[],
+  unassignedIds: string[],
+  excludedIds: string[],
+  lockedWarnings: string[],
+  settings: MatchSettings
+): string[] {
+  const warnings: string[] = [...lockedWarnings]
+  if (excludedIds.length > 0) {
+    warnings.push(
+      `${excludedIds.length} participant(s) excluded — no consent to match.`
+    )
+  }
+  if (unassignedIds.length > 0) {
+    warnings.push(`${unassignedIds.length} participant(s) could not be placed.`)
+  }
+  const undersized = teams.filter(
+    (t) => t.memberIds.length < settings.minTeamSize
+  ).length
+  if (undersized > 0) {
+    warnings.push(
+      `${undersized} team(s) are below the minimum size of ${settings.minTeamSize}.`
+    )
+  }
+  return warnings
+}
+
+function averageScore(teams: Team[]): number {
+  if (teams.length === 0) return 0
+  const sum = teams.reduce((acc, t) => acc + t.score.total, 0)
+  return Math.round((sum / teams.length) * 100) / 100
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+/**
+ * Run the full matcher. Pure and deterministic — no clock, no randomness, all
+ * orders fixed. The optimization pass (step 8) is applied by a caller-provided
+ * `optimize` hook so this module stays independent of optimization.ts; the public
+ * `runMatching` in index.ts wires the real optimizer in.
+ */
+export function assign(
+  participants: MatchParticipant[],
+  settings: MatchSettings,
+  optimize?: (
+    teams: Team[],
+    byId: Map<string, NormalizedParticipant>,
+    context: ScoringContext
+  ) => Team[]
+): MatchResult {
+  const { eligible, excludedIds } = partitionByConsent(participants)
+  const normalized = normalizeParticipants(eligible)
+  const byId = new Map(normalized.map((p) => [p.id, p]))
+  const byEmail = new Map(normalized.map((p) => [p.email, p]))
+  const context = buildContext(normalized, settings)
+
+  // Step 3: locked teams pass through untouched.
+  const {
+    teams: resolvedLocked,
+    lockedIds,
+    warnings: lockedWarnings,
+  } = resolveLockedTeams(settings.lockedTeams, byEmail)
+
+  const lockedWorking: WorkingTeam[] = resolvedLocked.map((t) => ({
+    name: t.name,
+    locked: true,
+    memberIds: [...t.memberIds],
+  }))
+
+  const pool = normalized.filter((p) => !lockedIds.has(p.id))
+
+  // Step 4: size the run.
+  const count = targetTeamCount(pool.length, settings)
+  const generated: WorkingTeam[] = Array.from({ length: count }, () => ({
+    locked: false,
+    memberIds: [],
+  }))
+  const teams: WorkingTeam[] = [...lockedWorking, ...generated]
+
+  // Step 5: seed one scarce/high-impact-role participant per generated team.
+  const seeded = new Set<string>()
+  if (count > 0) {
+    const order = seedOrder(pool, countPrimaryRoles(pool))
+    for (let i = 0; i < count && i < order.length; i++) {
+      generated[i].memberIds.push(order[i].id)
+      seeded.add(order[i].id)
+    }
+  }
+
+  let remaining = pool.filter((p) => !seeded.has(p.id))
+
+  // Step 6: distribute advanced participants first (if enabled).
+  if (settings.distributeAdvancedParticipants) {
+    const advanced = remaining.filter((p) => p.experienceLevel === "ADVANCED")
+    const stillUnplaced = distributeAdvanced(advanced, teams, byId, context)
+    const placedAdvanced = new Set(
+      advanced.filter((p) => !stillUnplaced.includes(p)).map((p) => p.id)
+    )
+    remaining = remaining.filter((p) => !placedAdvanced.has(p.id))
+  }
+
+  // Step 7: greedy fill by marginal contribution (id order = deterministic).
+  const unassignedIds: string[] = []
+  for (const candidate of remaining) {
+    const team = chooseFillTeam(candidate, teams, byId, context)
+    if (team) team.memberIds.push(candidate.id)
+    else unassignedIds.push(candidate.id)
+  }
+
+  // Steps 8–9: optimize (optional), then assemble scored teams.
+  let assembled = assembleTeams(teams, byId, context)
+  if (optimize) assembled = optimize(assembled, byId, context)
+
+  return {
+    teams: assembled,
+    unassignedIds: unassignedIds.sort((a, b) => (a < b ? -1 : 1)),
+    warnings: buildWarnings(
+      assembled,
+      unassignedIds,
+      excludedIds,
+      lockedWarnings,
+      settings
+    ),
+    averageScore: averageScore(assembled),
+    settingsUsed: settings,
+  }
+}

--- a/src/lib/matching/constants.ts
+++ b/src/lib/matching/constants.ts
@@ -157,3 +157,10 @@ export const PREFERRED_TEAMMATE_BONUS = 6
 
 /** Maximum pairwise-swap improvement passes before the optimizer stops. */
 export const MAX_SWAP_PASSES = 3
+
+/**
+ * A swap is kept only if the two teams' combined score improves by more than
+ * this. A small positive epsilon (rather than `> 0`) stops floating-point noise
+ * from registering as an improvement and churning equivalent arrangements.
+ */
+export const SWAP_IMPROVEMENT_EPSILON = 1e-9

--- a/src/lib/matching/constants.ts
+++ b/src/lib/matching/constants.ts
@@ -1,0 +1,159 @@
+/**
+ * Impact Lab matching engine — tunable constants.
+ *
+ * Every weight, size bound, penalty and bonus lives here as a named constant.
+ * Nothing in the engine hardcodes a magic number: reading this file tells you
+ * exactly how the matcher is tuned, and changing behaviour means changing a
+ * value here or overriding it through `MatchSettings`.
+ */
+
+import type {
+  CanonicalRole,
+  ExperienceLevel,
+  MatchSettings,
+  MatchWeights,
+} from "./types"
+
+// ─── Roles ───────────────────────────────────────────────────────────────────
+
+export const CANONICAL_ROLES: readonly CanonicalRole[] = [
+  "builder",
+  "designer",
+  "presenter",
+  "data",
+  "product",
+] as const
+
+/**
+ * Seeding priority: scarcer / higher-impact roles are placed onto teams first so
+ * every team gets one before the common roles are distributed. A hackathon can
+ * survive a missing extra builder; it cannot survive having no one to present.
+ * Order = most to least prioritised.
+ */
+export const ROLE_PRIORITY: readonly CanonicalRole[] = [
+  "presenter",
+  "designer",
+  "data",
+  "product",
+  "builder",
+] as const
+
+/**
+ * Synonyms → canonical role slug. Raw role strings are lowercased and trimmed
+ * before lookup. Anything not found here contributes no canonical role (it may
+ * still count as a skill). Keep this list conservative and explicit — silent
+ * mis-mapping is worse than an unmapped role.
+ */
+export const ROLE_SYNONYMS: Readonly<Record<string, CanonicalRole>> = {
+  builder: "builder",
+  developer: "builder",
+  dev: "builder",
+  engineer: "builder",
+  programmer: "builder",
+  coder: "builder",
+  "software engineer": "builder",
+  "full stack": "builder",
+  fullstack: "builder",
+  frontend: "builder",
+  backend: "builder",
+
+  designer: "designer",
+  design: "designer",
+  "ui designer": "designer",
+  "ux designer": "designer",
+  "ui/ux": "designer",
+  uiux: "designer",
+
+  presenter: "presenter",
+  pitcher: "presenter",
+  pitch: "presenter",
+  speaker: "presenter",
+  storyteller: "presenter",
+  communicator: "presenter",
+
+  data: "data",
+  "data scientist": "data",
+  "data analyst": "data",
+  analyst: "data",
+  ml: "data",
+  "ml engineer": "data",
+  "machine learning": "data",
+  ai: "data",
+
+  product: "product",
+  "product manager": "product",
+  pm: "product",
+  "project manager": "product",
+  strategist: "product",
+  business: "product",
+}
+
+// ─── Experience ──────────────────────────────────────────────────────────────
+
+/**
+ * Numeric weight per experience level, used for balancing teams and for
+ * experience-weighted seeding. Advanced participants carry the most weight so a
+ * team stacked with them scores as imbalanced against one that has none.
+ */
+export const EXPERIENCE_WEIGHT: Readonly<Record<ExperienceLevel, number>> = {
+  BEGINNER: 1,
+  INTERMEDIATE: 2,
+  ADVANCED: 3,
+}
+
+// ─── Weights & size defaults ─────────────────────────────────────────────────
+
+export const DEFAULT_WEIGHTS: MatchWeights = {
+  roleCoverage: 2,
+  skillBalance: 1.5,
+  experienceBalance: 1.4,
+  interestAlignment: 1,
+  availabilityOverlap: 1,
+  participantPreferences: 0.8,
+}
+
+export const DEFAULT_DESIRED_TEAM_SIZE = 4
+export const DEFAULT_MIN_TEAM_SIZE = 3
+export const DEFAULT_MAX_TEAM_SIZE = 5
+
+export const DEFAULT_SETTINGS: MatchSettings = {
+  desiredTeamSize: DEFAULT_DESIRED_TEAM_SIZE,
+  minTeamSize: DEFAULT_MIN_TEAM_SIZE,
+  maxTeamSize: DEFAULT_MAX_TEAM_SIZE,
+  numberOfTeams: null,
+  allowUnassignedParticipants: true,
+  requireBuilder: true,
+  requirePresenter: true,
+  preventBeginnerOnlyTeams: true,
+  distributeAdvancedParticipants: true,
+  lockedTeams: [],
+  weights: DEFAULT_WEIGHTS,
+}
+
+// ─── Penalties (points subtracted from a team's 0–100 score) ─────────────────
+
+export const PENALTY_BEGINNER_ONLY_TEAM = 20
+export const PENALTY_MISSING_REQUIRED_BUILDER = 15
+export const PENALTY_MISSING_REQUIRED_PRESENTER = 15
+export const PENALTY_SIZE_VIOLATION = 12
+
+// ─── Greedy-fill marginal-contribution tuning ────────────────────────────────
+
+/**
+ * Penalty (in raw score points) per member already on a team, applied when
+ * choosing where to place the next participant. Nudges the greedy fill toward
+ * balanced team sizes instead of piling everyone onto the first strong team.
+ */
+export const SIZE_BALANCE_PENALTY_PER_MEMBER = 1.5
+
+/**
+ * Bonus (in raw score points) added when a candidate team already contains
+ * someone this participant listed as a preferred teammate. Soft: it steers
+ * placement without ever overriding score or hard constraints.
+ */
+export const PREFERRED_TEAMMATE_BONUS = 6
+
+// ─── Optimization ────────────────────────────────────────────────────────────
+
+/** Maximum pairwise-swap improvement passes before the optimizer stops. */
+export const MAX_SWAP_PASSES = 3

--- a/src/lib/matching/constants.ts
+++ b/src/lib/matching/constants.ts
@@ -164,3 +164,14 @@ export const MAX_SWAP_PASSES = 3
  * from registering as an improvement and churning equivalent arrangements.
  */
 export const SWAP_IMPROVEMENT_EPSILON = 1e-9
+
+// ─── Explanations ────────────────────────────────────────────────────────────
+
+/** A dimension's raw score at or above this reads as a team strength. */
+export const EXPLANATION_STRENGTH_THRESHOLD = 0.66
+
+/** A dimension's raw score at or below this reads as a team weakness. */
+export const EXPLANATION_WEAKNESS_THRESHOLD = 0.4
+
+/** An interest shared by at least this many members can anchor a project idea. */
+export const EXPLANATION_SHARED_INTEREST_MIN = 2

--- a/src/lib/matching/constraints.ts
+++ b/src/lib/matching/constraints.ts
@@ -1,0 +1,141 @@
+/**
+ * Impact Lab matching engine — hard constraints.
+ *
+ * Hard constraints are inviolable: no score, however high, may break them. They
+ * are checked *before* a placement is ever considered, so the scorer only ever
+ * ranks assignments that are already legal.
+ *
+ * The four hard constraints:
+ *   1. Consent      — only consentToMatch participants enter the engine.
+ *   2. Blocks       — two participants who block each other never share a team.
+ *   3. Locked teams — organiser-pinned teams pass through untouched.
+ *   4. Size         — team size stays within [minTeamSize, maxTeamSize].
+ */
+
+import type {
+  LockedTeam,
+  MatchParticipant,
+  MatchSettings,
+  NormalizedParticipant,
+} from "./types"
+
+// ─── 1. Consent ──────────────────────────────────────────────────────────────
+
+/**
+ * Split raw participants into those who consented to matching and those who did
+ * not. Consent is filtered here, on raw input, so that after normalization every
+ * participant in the engine has — by construction — already consented. Excluded
+ * ids are returned so the caller can surface them as a warning.
+ */
+export function partitionByConsent(participants: MatchParticipant[]): {
+  eligible: MatchParticipant[]
+  excludedIds: string[]
+} {
+  const eligible: MatchParticipant[] = []
+  const excludedIds: string[] = []
+  for (const participant of participants) {
+    if (participant.consentToMatch) eligible.push(participant)
+    else excludedIds.push(participant.id)
+  }
+  return { eligible, excludedIds }
+}
+
+// ─── 2. Blocks ───────────────────────────────────────────────────────────────
+
+/**
+ * Two participants conflict if *either* blocked the other. Blocks are treated as
+ * symmetric: if A doesn't want to work with B, keeping them apart doesn't depend
+ * on B having reciprocated.
+ */
+export function participantsConflict(
+  a: NormalizedParticipant,
+  b: NormalizedParticipant
+): boolean {
+  return (
+    a.blockedTeammates.includes(b.email) ||
+    b.blockedTeammates.includes(a.email)
+  )
+}
+
+/** Does adding `candidate` to `members` break any block constraint? */
+export function hasBlockConflict(
+  candidate: NormalizedParticipant,
+  members: NormalizedParticipant[]
+): boolean {
+  return members.some((member) => participantsConflict(candidate, member))
+}
+
+// ─── 3 & 4. Placement legality ───────────────────────────────────────────────
+
+/**
+ * Can `candidate` legally join a team currently holding `members`? True only
+ * when it introduces no block conflict AND the team is below its max size. This
+ * is the single gate every placement passes through in the algorithm.
+ */
+export function canPlace(
+  candidate: NormalizedParticipant,
+  members: NormalizedParticipant[],
+  settings: MatchSettings
+): boolean {
+  if (members.length >= settings.maxTeamSize) return false
+  return !hasBlockConflict(candidate, members)
+}
+
+/** Is a finished team's size within the configured [min, max] bounds? */
+export function isValidTeamSize(
+  size: number,
+  settings: MatchSettings
+): boolean {
+  return size >= settings.minTeamSize && size <= settings.maxTeamSize
+}
+
+// ─── 3. Locked teams ─────────────────────────────────────────────────────────
+
+export interface ResolvedLockedTeam {
+  name?: string
+  memberIds: string[]
+}
+
+/**
+ * Resolve organiser-pinned teams (given by email) to participant ids. Emails
+ * that don't match a known eligible participant are skipped with a warning; a
+ * participant claimed by two locked teams stays in the first and is dropped from
+ * the rest, again with a warning. The returned `lockedIds` set lets the
+ * algorithm exclude these participants from the pool it distributes.
+ */
+export function resolveLockedTeams(
+  lockedTeams: LockedTeam[],
+  byEmail: Map<string, NormalizedParticipant>
+): {
+  teams: ResolvedLockedTeam[]
+  lockedIds: Set<string>
+  warnings: string[]
+} {
+  const teams: ResolvedLockedTeam[] = []
+  const lockedIds = new Set<string>()
+  const warnings: string[] = []
+
+  lockedTeams.forEach((team, index) => {
+    const label = team.name ?? `locked team ${index + 1}`
+    const memberIds: string[] = []
+
+    for (const rawEmail of team.memberEmails) {
+      const email = rawEmail.toLowerCase().trim()
+      const participant = byEmail.get(email)
+      if (!participant) {
+        warnings.push(`${label}: no eligible participant for "${rawEmail}" — skipped.`)
+        continue
+      }
+      if (lockedIds.has(participant.id)) {
+        warnings.push(`${label}: ${participant.fullName} is already in another locked team — skipped.`)
+        continue
+      }
+      lockedIds.add(participant.id)
+      memberIds.push(participant.id)
+    }
+
+    if (memberIds.length > 0) teams.push({ name: team.name, memberIds })
+  })
+
+  return { teams, lockedIds, warnings }
+}

--- a/src/lib/matching/constraints.ts
+++ b/src/lib/matching/constraints.ts
@@ -118,6 +118,7 @@ export function resolveLockedTeams(
   lockedTeams.forEach((team, index) => {
     const label = team.name ?? `locked team ${index + 1}`
     const memberIds: string[] = []
+    const members: NormalizedParticipant[] = []
 
     for (const rawEmail of team.memberEmails) {
       const email = rawEmail.toLowerCase().trim()
@@ -132,6 +133,19 @@ export function resolveLockedTeams(
       }
       lockedIds.add(participant.id)
       memberIds.push(participant.id)
+      members.push(participant)
+    }
+
+    // Blocks are unconditional — but a locked team is passed through untouched,
+    // so a block inside one can't be auto-resolved. Surface it loudly instead.
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        if (participantsConflict(members[i], members[j])) {
+          warnings.push(
+            `${label}: ${members[i].fullName} and ${members[j].fullName} blocked each other but are pinned together.`
+          )
+        }
+      }
     }
 
     if (memberIds.length > 0) teams.push({ name: team.name, memberIds })

--- a/src/lib/matching/explanations.ts
+++ b/src/lib/matching/explanations.ts
@@ -1,0 +1,173 @@
+/**
+ * Impact Lab matching engine — deterministic explanations.
+ *
+ * Turns a scored team into human-readable notes (strengths, weaknesses,
+ * suggested internal roles, a project direction) built entirely from the score
+ * breakdown and the team's members. No LLM, no I/O — same input, same words.
+ *
+ * This is the *fallback*: when the Claude layer (ai-explanations.ts) is disabled
+ * or errors, these explanations are what organisers see. They must stand alone,
+ * so they're written to be genuinely useful, not placeholder text.
+ */
+
+import {
+  EXPLANATION_SHARED_INTEREST_MIN,
+  EXPLANATION_STRENGTH_THRESHOLD,
+  EXPLANATION_WEAKNESS_THRESHOLD,
+} from "./constants"
+import type {
+  CanonicalRole,
+  MatchResult,
+  MatchWeightKey,
+  NormalizedParticipant,
+  Team,
+  TeamExplanation,
+} from "./types"
+
+const DIMENSION_LABELS: Record<MatchWeightKey, string> = {
+  roleCoverage: "role coverage",
+  skillBalance: "skill diversity",
+  experienceBalance: "experience balance",
+  interestAlignment: "shared interests",
+  availabilityOverlap: "availability overlap",
+  participantPreferences: "teammate preferences",
+}
+
+const ROLE_LABELS: Record<CanonicalRole, string> = {
+  builder: "Developer",
+  designer: "Designer",
+  presenter: "Presenter",
+  data: "Data / ML lead",
+  product: "Product lead",
+}
+
+const EXPERIENCE_LABELS: Record<NormalizedParticipant["experienceLevel"], string> =
+  {
+    BEGINNER: "beginner",
+    INTERMEDIATE: "intermediate",
+    ADVANCED: "advanced",
+  }
+
+function pct(raw: number): number {
+  return Math.round(raw * 100)
+}
+
+/** Most experienced member wins the lead role; id breaks ties. */
+function teamLead(members: NormalizedParticipant[]): NormalizedParticipant | null {
+  if (members.length === 0) return null
+  const order = { ADVANCED: 3, INTERMEDIATE: 2, BEGINNER: 1 } as const
+  return [...members].sort((a, b) => {
+    const diff = order[b.experienceLevel] - order[a.experienceLevel]
+    if (diff !== 0) return diff
+    return a.id < b.id ? -1 : 1
+  })[0]
+}
+
+/**
+ * Suggest an internal role per member: the most experienced is the coordinator;
+ * everyone else is labelled by their primary role (generalist if unmapped).
+ */
+function suggestInternalRoles(
+  members: NormalizedParticipant[]
+): Record<string, string> {
+  const lead = teamLead(members)
+  const roles: Record<string, string> = {}
+  for (const member of members) {
+    if (lead && member.id === lead.id) {
+      roles[member.id] = "Team lead & coordinator"
+      continue
+    }
+    roles[member.id] = member.primaryRole
+      ? ROLE_LABELS[member.primaryRole]
+      : "Generalist"
+  }
+  return roles
+}
+
+/** The interest shared by the most members (if enough share one). */
+function sharedProjectInterest(
+  members: NormalizedParticipant[]
+): string | null {
+  const counts = new Map<string, number>()
+  for (const member of members) {
+    for (const interest of member.interests) {
+      counts.set(interest, (counts.get(interest) ?? 0) + 1)
+    }
+  }
+  let best: string | null = null
+  let bestCount = 0
+  // Sort keys for deterministic tie-breaking (alphabetical).
+  for (const interest of [...counts.keys()].sort()) {
+    const count = counts.get(interest)!
+    if (count > bestCount) {
+      best = interest
+      bestCount = count
+    }
+  }
+  return bestCount >= EXPLANATION_SHARED_INTEREST_MIN ? best : null
+}
+
+function experienceSpread(members: NormalizedParticipant[]): string {
+  const counts = { beginner: 0, intermediate: 0, advanced: 0 }
+  for (const member of members) counts[EXPERIENCE_LABELS[member.experienceLevel] as keyof typeof counts]++
+  const parts: string[] = []
+  if (counts.advanced) parts.push(`${counts.advanced} advanced`)
+  if (counts.intermediate) parts.push(`${counts.intermediate} intermediate`)
+  if (counts.beginner) parts.push(`${counts.beginner} beginner`)
+  return parts.join(", ")
+}
+
+/** Build the deterministic explanation for one scored team. */
+export function explainTeam(
+  team: Team,
+  members: NormalizedParticipant[]
+): TeamExplanation {
+  const strengths: string[] = []
+  const weaknesses: string[] = []
+
+  for (const dimension of team.score.dimensions) {
+    const label = DIMENSION_LABELS[dimension.key]
+    if (dimension.raw >= EXPLANATION_STRENGTH_THRESHOLD) {
+      strengths.push(`Strong ${label} (${pct(dimension.raw)}%).`)
+    } else if (dimension.raw <= EXPLANATION_WEAKNESS_THRESHOLD) {
+      weaknesses.push(`Limited ${label} (${pct(dimension.raw)}%).`)
+    }
+  }
+  for (const penalty of team.score.penalties) {
+    weaknesses.push(`${penalty.reason} (−${penalty.points}).`)
+  }
+
+  const interest = sharedProjectInterest(members)
+  const summary =
+    `${team.name} scored ${team.score.total}/100 with ${members.length} member(s): ` +
+    `${experienceSpread(members) || "no experience data"}.`
+
+  return {
+    teamId: team.id,
+    summary,
+    strengths,
+    weaknesses,
+    suggestedProjectDirection: interest
+      ? `A project in the "${interest}" space would play to this team's shared interest.`
+      : undefined,
+    suggestedInternalRoles: suggestInternalRoles(members),
+    warnings: team.score.penalties.map((p) => p.reason),
+    source: "deterministic",
+  }
+}
+
+/**
+ * Deterministic explanations for every team in a result. `byId` maps participant
+ * ids to their normalized records (the API layer and verify script both have it).
+ */
+export function explainResult(
+  result: MatchResult,
+  byId: Map<string, NormalizedParticipant>
+): TeamExplanation[] {
+  return result.teams.map((team) =>
+    explainTeam(
+      team,
+      team.memberIds.map((id) => byId.get(id)!).filter(Boolean)
+    )
+  )
+}

--- a/src/lib/matching/index.ts
+++ b/src/lib/matching/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Impact Lab matching engine — public surface.
+ *
+ * Callers (API routes, the verify script) import from here, not from individual
+ * modules. `runMatching` is the one function most callers need.
+ */
+
+export * from "./types"
+export {
+  DEFAULT_SETTINGS,
+  DEFAULT_WEIGHTS,
+  DEFAULT_DESIRED_TEAM_SIZE,
+  DEFAULT_MIN_TEAM_SIZE,
+  DEFAULT_MAX_TEAM_SIZE,
+  CANONICAL_ROLES,
+} from "./constants"
+export { scoreTeam, type ScoringContext } from "./scoring"
+export { assign } from "./algorithm"
+
+import { assign } from "./algorithm"
+import type { MatchParticipant, MatchResult, MatchSettings } from "./types"
+
+/**
+ * Run the matcher end-to-end. The pairwise-swap optimizer is wired in here
+ * (optimization.ts) so callers get an optimized result by default.
+ */
+export function runMatching(
+  participants: MatchParticipant[],
+  settings: MatchSettings
+): MatchResult {
+  // Optimizer injected in the optimization commit; until then, the greedy
+  // assignment is returned as-is.
+  return assign(participants, settings)
+}

--- a/src/lib/matching/index.ts
+++ b/src/lib/matching/index.ts
@@ -17,6 +17,8 @@ export {
 export { scoreTeam, type ScoringContext } from "./scoring"
 export { assign } from "./algorithm"
 export { optimizeAssignment } from "./optimization"
+export { explainTeam, explainResult } from "./explanations"
+export { normalizeParticipants } from "./normalization"
 
 import { assign } from "./algorithm"
 import { optimizeAssignment } from "./optimization"

--- a/src/lib/matching/index.ts
+++ b/src/lib/matching/index.ts
@@ -16,8 +16,10 @@ export {
 } from "./constants"
 export { scoreTeam, type ScoringContext } from "./scoring"
 export { assign } from "./algorithm"
+export { optimizeAssignment } from "./optimization"
 
 import { assign } from "./algorithm"
+import { optimizeAssignment } from "./optimization"
 import type { MatchParticipant, MatchResult, MatchSettings } from "./types"
 
 /**
@@ -28,7 +30,5 @@ export function runMatching(
   participants: MatchParticipant[],
   settings: MatchSettings
 ): MatchResult {
-  // Optimizer injected in the optimization commit; until then, the greedy
-  // assignment is returned as-is.
-  return assign(participants, settings)
+  return assign(participants, settings, optimizeAssignment)
 }

--- a/src/lib/matching/normalization.ts
+++ b/src/lib/matching/normalization.ts
@@ -1,0 +1,117 @@
+/**
+ * Impact Lab matching engine — normalization.
+ *
+ * Turns raw, human-entered `MatchParticipant` data into the canonical
+ * `NormalizedParticipant` shape the rest of the engine operates on. This is the
+ * single place free-text is cleaned up, so every downstream module can assume
+ * roles are canonical and skills are lowercased and deduped.
+ */
+
+import { ROLE_SYNONYMS } from "./constants"
+import type {
+  CanonicalRole,
+  MatchParticipant,
+  NormalizedParticipant,
+} from "./types"
+
+/** Lowercase, trim, and collapse internal whitespace to single spaces. */
+export function normalizeToken(value: string): string {
+  return value.toLowerCase().trim().replace(/\s+/g, " ")
+}
+
+/** Lowercase + trim + strip whitespace — the email normal form used for matching. */
+export function normalizeEmail(value: string): string {
+  return value.toLowerCase().trim().replace(/\s/g, "")
+}
+
+/**
+ * Map a raw role string to a canonical role, or null if it maps to nothing
+ * known. Unmapped roles are dropped rather than guessed — see 02-engine-design.
+ */
+export function canonicalizeRole(raw: string): CanonicalRole | null {
+  const token = normalizeToken(raw)
+  if (!token) return null
+  return ROLE_SYNONYMS[token] ?? null
+}
+
+/**
+ * Normalize a list of free-text tokens: clean each, drop empties, dedupe while
+ * preserving first-seen order (so output is deterministic w.r.t. input order).
+ */
+export function normalizeTokenList(values: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    const token = normalizeToken(value)
+    if (!token || seen.has(token)) continue
+    seen.add(token)
+    result.push(token)
+  }
+  return result
+}
+
+/** Normalize + dedupe a list of emails, preserving first-seen order. */
+export function normalizeEmailList(values: string[]): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    const email = normalizeEmail(value)
+    if (!email || seen.has(email)) continue
+    seen.add(email)
+    result.push(email)
+  }
+  return result
+}
+
+/**
+ * Canonicalize a participant's primary + secondary roles into a deduped list,
+ * primary first. Roles that map to nothing known are dropped.
+ */
+function canonicalizeRoles(participant: MatchParticipant): CanonicalRole[] {
+  const ordered: CanonicalRole[] = []
+  const seen = new Set<CanonicalRole>()
+
+  const push = (role: CanonicalRole | null): void => {
+    if (!role || seen.has(role)) return
+    seen.add(role)
+    ordered.push(role)
+  }
+
+  push(canonicalizeRole(participant.primaryRole))
+  for (const secondary of participant.secondaryRoles) {
+    push(canonicalizeRole(secondary))
+  }
+  return ordered
+}
+
+/** Normalize a single participant into the engine's working shape. */
+export function normalizeParticipant(
+  participant: MatchParticipant
+): NormalizedParticipant {
+  return {
+    id: participant.id,
+    fullName: participant.fullName.trim(),
+    email: normalizeEmail(participant.email),
+    experienceLevel: participant.experienceLevel,
+    roles: canonicalizeRoles(participant),
+    primaryRole: canonicalizeRole(participant.primaryRole),
+    skills: normalizeTokenList(participant.technicalSkills),
+    interests: normalizeTokenList(participant.interests),
+    availability: normalizeTokenList(participant.availability),
+    preferredTeammates: normalizeEmailList(participant.preferredTeammates),
+    blockedTeammates: normalizeEmailList(participant.blockedTeammates),
+  }
+}
+
+/**
+ * Normalize a list of participants, sorted by id. Sorting here fixes iteration
+ * order for the entire pipeline: every later stage that walks participants
+ * inherits a stable order, which is the backbone of the engine's determinism.
+ */
+export function normalizeParticipants(
+  participants: MatchParticipant[]
+): NormalizedParticipant[] {
+  return [...participants]
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map(normalizeParticipant)
+}

--- a/src/lib/matching/optimization.ts
+++ b/src/lib/matching/optimization.ts
@@ -1,0 +1,109 @@
+/**
+ * Impact Lab matching engine — pairwise swap optimization.
+ *
+ * The greedy fill places each participant well *at the moment they're placed*,
+ * but can't see later arrivals. A local-search pass fixes that: try swapping
+ * members between every pair of teams and keep any swap that strictly improves
+ * the two teams' combined score. Size-preserving by construction, so it never
+ * unbalances team sizes; capped at MAX_SWAP_PASSES so it always terminates.
+ *
+ * Deterministic: teams and members are visited in fixed order, and swaps use
+ * first-improvement (apply the first improving swap found, keep scanning).
+ */
+
+import { MAX_SWAP_PASSES, SWAP_IMPROVEMENT_EPSILON } from "./constants"
+import { participantsConflict } from "./constraints"
+import { scoreTeam, scoreTeamTotal, type ScoringContext } from "./scoring"
+import type { NormalizedParticipant, Team } from "./types"
+
+/** Does any pair of the given members block each other? */
+function teamHasConflict(
+  ids: string[],
+  byId: Map<string, NormalizedParticipant>
+): boolean {
+  const members = ids.map((id) => byId.get(id)!)
+  for (let i = 0; i < members.length; i++) {
+    for (let j = i + 1; j < members.length; j++) {
+      if (participantsConflict(members[i], members[j])) return true
+    }
+  }
+  return false
+}
+
+/**
+ * Improve an assignment with pairwise swaps. Locked teams are never touched.
+ * Returns freshly scored, id-sorted `Team` objects in the original order.
+ */
+export function optimizeAssignment(
+  teams: Team[],
+  byId: Map<string, NormalizedParticipant>,
+  context: ScoringContext
+): Team[] {
+  // Mutable id lists for the non-locked teams, in their original order.
+  const editable: { index: number; ids: string[] }[] = []
+  teams.forEach((team, index) => {
+    if (!team.locked) editable.push({ index, ids: [...team.memberIds] })
+  })
+
+  const scoreIds = (ids: string[]): number =>
+    scoreTeamTotal(
+      ids.map((id) => byId.get(id)!),
+      context
+    )
+
+  const scores = editable.map((t) => scoreIds(t.ids))
+
+  for (let pass = 0; pass < MAX_SWAP_PASSES; pass++) {
+    let improved = false
+
+    for (let i = 0; i < editable.length; i++) {
+      for (let j = i + 1; j < editable.length; j++) {
+        for (let ai = 0; ai < editable[i].ids.length; ai++) {
+          for (let bj = 0; bj < editable[j].ids.length; bj++) {
+            const idsI = editable[i].ids.map((id, idx) =>
+              idx === ai ? editable[j].ids[bj] : id
+            )
+            const idsJ = editable[j].ids.map((id, idx) =>
+              idx === bj ? editable[i].ids[ai] : id
+            )
+
+            // A swap can create a block conflict that wasn't there before.
+            if (teamHasConflict(idsI, byId) || teamHasConflict(idsJ, byId)) {
+              continue
+            }
+
+            const newScoreI = scoreIds(idsI)
+            const newScoreJ = scoreIds(idsJ)
+            const delta = newScoreI + newScoreJ - (scores[i] + scores[j])
+
+            if (delta > SWAP_IMPROVEMENT_EPSILON) {
+              editable[i].ids = idsI
+              editable[j].ids = idsJ
+              scores[i] = newScoreI
+              scores[j] = newScoreJ
+              improved = true
+            }
+          }
+        }
+      }
+    }
+
+    if (!improved) break
+  }
+
+  // Reassemble in original order: locked teams as-is, non-locked re-scored.
+  const editedByIndex = new Map(editable.map((t) => [t.index, t.ids]))
+  return teams.map((team, index) => {
+    const edited = editedByIndex.get(index)
+    if (!edited) return team // locked
+    const ids = [...edited].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
+    return {
+      ...team,
+      memberIds: ids,
+      score: scoreTeam(
+        ids.map((id) => byId.get(id)!),
+        context
+      ),
+    }
+  })
+}

--- a/src/lib/matching/scoring.ts
+++ b/src/lib/matching/scoring.ts
@@ -1,0 +1,268 @@
+/**
+ * Impact Lab matching engine — scoring.
+ *
+ * Scores a team on six weighted dimensions, each a pure function returning a raw
+ * [0, 1] sub-score. The weighted sum is normalized to [0, 100], then named
+ * penalties are subtracted. Every number is traceable: the returned
+ * `ScoreBreakdown` is exactly what the UI renders so an organiser can see WHY.
+ *
+ * Scoring never checks hard constraints — by the time a team is scored, the
+ * algorithm has already guaranteed it is legal (see 04-constraints).
+ */
+
+import {
+  CANONICAL_ROLES,
+  PENALTY_BEGINNER_ONLY_TEAM,
+  PENALTY_MISSING_REQUIRED_BUILDER,
+  PENALTY_MISSING_REQUIRED_PRESENTER,
+  PENALTY_SIZE_VIOLATION,
+} from "./constants"
+import { isValidTeamSize } from "./constraints"
+import type {
+  CanonicalRole,
+  DimensionScore,
+  MatchSettings,
+  MatchWeightKey,
+  NormalizedParticipant,
+  PenaltyEntry,
+  ScoreBreakdown,
+} from "./types"
+
+/**
+ * Context every scoring call needs beyond the team itself. `eligibleEmails` lets
+ * preference scoring ignore preferred teammates who never registered — only
+ * preferences that *could* be satisfied count against a team.
+ */
+export interface ScoringContext {
+  settings: MatchSettings
+  eligibleEmails: Set<string>
+}
+
+// ─── Small numeric helpers ───────────────────────────────────────────────────
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+/** Jaccard similarity of two token lists: |A ∩ B| / |A ∪ B|, in [0, 1]. */
+function jaccard(a: string[], b: string[]): number {
+  const setA = new Set(a)
+  const setB = new Set(b)
+  if (setA.size === 0 && setB.size === 0) return 0
+  let intersection = 0
+  for (const token of setA) if (setB.has(token)) intersection++
+  const union = setA.size + setB.size - intersection
+  return union === 0 ? 0 : intersection / union
+}
+
+// ─── Dimension 1: role coverage ──────────────────────────────────────────────
+
+/** Fraction of the five canonical roles present anywhere on the team. */
+export function scoreRoleCoverage(members: NormalizedParticipant[]): number {
+  const roles = new Set<CanonicalRole>()
+  for (const member of members) for (const role of member.roles) roles.add(role)
+  return roles.size / CANONICAL_ROLES.length
+}
+
+// ─── Dimension 2: skill balance (complementarity) ────────────────────────────
+
+/**
+ * Rewards a complementary, non-redundant skill set. distinct / total-mentions is
+ * 1 when everyone brings different skills and drops toward 0 as the team piles up
+ * on the same few. Measures breadth, not depth.
+ */
+export function scoreSkillBalance(members: NormalizedParticipant[]): number {
+  let totalMentions = 0
+  const distinct = new Set<string>()
+  for (const member of members) {
+    totalMentions += member.skills.length
+    for (const skill of member.skills) distinct.add(skill)
+  }
+  return totalMentions === 0 ? 0 : distinct.size / totalMentions
+}
+
+// ─── Dimension 3: experience balance ─────────────────────────────────────────
+
+/**
+ * Rewards a spread of experience *and* the presence of at least one non-beginner
+ * (someone who can unblock the team). Half the score is spread across levels, half
+ * is "has a mentor". An all-advanced team scores mid — mixed, but top-heavy.
+ */
+export function scoreExperienceBalance(members: NormalizedParticipant[]): number {
+  if (members.length === 0) return 0
+  const levels = new Set(members.map((m) => m.experienceLevel))
+  const spread = (levels.size - 1) / 2 // 0 (uniform) → 1 (all three present)
+  const hasExperienced = members.some((m) => m.experienceLevel !== "BEGINNER")
+  return 0.5 * spread + 0.5 * (hasExperienced ? 1 : 0)
+}
+
+// ─── Dimension 4: interest alignment ─────────────────────────────────────────
+
+/**
+ * Average pairwise interest overlap. Some shared interest helps a team converge
+ * on a project direction; this rewards it. Single-member teams score 0 (nothing
+ * to align).
+ */
+export function scoreInterestAlignment(members: NormalizedParticipant[]): number {
+  if (members.length < 2) return 0
+  let sum = 0
+  let pairs = 0
+  for (let i = 0; i < members.length; i++) {
+    for (let j = i + 1; j < members.length; j++) {
+      sum += jaccard(members[i].interests, members[j].interests)
+      pairs++
+    }
+  }
+  return pairs === 0 ? 0 : sum / pairs
+}
+
+// ─── Dimension 5: availability overlap ───────────────────────────────────────
+
+/**
+ * Fraction of availability slots shared by *every* member who stated any. Members
+ * who left availability blank are ignored rather than treated as available-never,
+ * so one blank entry doesn't tank an otherwise-overlapping team.
+ */
+export function scoreAvailabilityOverlap(
+  members: NormalizedParticipant[]
+): number {
+  const stated = members.filter((m) => m.availability.length > 0)
+  if (stated.length === 0) return 0
+  const union = new Set<string>()
+  for (const member of stated) for (const slot of member.availability) union.add(slot)
+  if (union.size === 0) return 0
+  let common = 0
+  for (const slot of union) {
+    if (stated.every((m) => m.availability.includes(slot))) common++
+  }
+  return common / union.size
+}
+
+// ─── Dimension 6: participant preferences ────────────────────────────────────
+
+/**
+ * Average satisfaction of preferred-teammate wishes. For each member who named at
+ * least one *registerable* preferred teammate, the fraction of those now on their
+ * team. Members with no resolvable preferences are excluded; a team where nobody
+ * asked for anyone scores 1 (nothing left unsatisfied).
+ */
+export function scoreParticipantPreferences(
+  members: NormalizedParticipant[],
+  eligibleEmails: Set<string>
+): number {
+  const emailsInTeam = new Set(members.map((m) => m.email))
+  let satisfactionSum = 0
+  let counted = 0
+  for (const member of members) {
+    const resolvable = member.preferredTeammates.filter(
+      (email) => email !== member.email && eligibleEmails.has(email)
+    )
+    if (resolvable.length === 0) continue
+    const satisfied = resolvable.filter((email) => emailsInTeam.has(email)).length
+    satisfactionSum += satisfied / resolvable.length
+    counted++
+  }
+  return counted === 0 ? 1 : satisfactionSum / counted
+}
+
+// ─── Penalties ───────────────────────────────────────────────────────────────
+
+function computePenalties(
+  members: NormalizedParticipant[],
+  settings: MatchSettings
+): PenaltyEntry[] {
+  const penalties: PenaltyEntry[] = []
+  if (members.length === 0) return penalties
+
+  if (
+    settings.preventBeginnerOnlyTeams &&
+    members.every((m) => m.experienceLevel === "BEGINNER")
+  ) {
+    penalties.push({
+      reason: "Team is beginner-only",
+      points: PENALTY_BEGINNER_ONLY_TEAM,
+    })
+  }
+  if (settings.requireBuilder && !members.some((m) => m.roles.includes("builder"))) {
+    penalties.push({
+      reason: "No builder on the team",
+      points: PENALTY_MISSING_REQUIRED_BUILDER,
+    })
+  }
+  if (
+    settings.requirePresenter &&
+    !members.some((m) => m.roles.includes("presenter"))
+  ) {
+    penalties.push({
+      reason: "No presenter on the team",
+      points: PENALTY_MISSING_REQUIRED_PRESENTER,
+    })
+  }
+  if (!isValidTeamSize(members.length, settings)) {
+    penalties.push({
+      reason: `Team size ${members.length} is outside [${settings.minTeamSize}, ${settings.maxTeamSize}]`,
+      points: PENALTY_SIZE_VIOLATION,
+    })
+  }
+  return penalties
+}
+
+// ─── Aggregate ───────────────────────────────────────────────────────────────
+
+function dimension(
+  key: MatchWeightKey,
+  raw: number,
+  weight: number
+): DimensionScore {
+  return { key, raw: round2(raw), weight, weighted: round2(raw * weight) }
+}
+
+/**
+ * Full team score: weighted sum of the six dimensions normalized to [0, 100],
+ * minus penalties, clamped to [0, 100]. The returned breakdown is the single
+ * source of truth the UI and explanations both read.
+ */
+export function scoreTeam(
+  members: NormalizedParticipant[],
+  context: ScoringContext
+): ScoreBreakdown {
+  const w = context.settings.weights
+  const dimensions: DimensionScore[] = [
+    dimension("roleCoverage", scoreRoleCoverage(members), w.roleCoverage),
+    dimension("skillBalance", scoreSkillBalance(members), w.skillBalance),
+    dimension("experienceBalance", scoreExperienceBalance(members), w.experienceBalance),
+    dimension("interestAlignment", scoreInterestAlignment(members), w.interestAlignment),
+    dimension("availabilityOverlap", scoreAvailabilityOverlap(members), w.availabilityOverlap),
+    dimension(
+      "participantPreferences",
+      scoreParticipantPreferences(members, context.eligibleEmails),
+      w.participantPreferences
+    ),
+  ]
+
+  const sumWeighted = dimensions.reduce((sum, d) => sum + d.raw * d.weight, 0)
+  const maxWeighted = dimensions.reduce((sum, d) => sum + d.weight, 0)
+  const base = maxWeighted === 0 ? 0 : (sumWeighted / maxWeighted) * 100
+
+  const penalties = computePenalties(members, context.settings)
+  const penaltyTotal = penalties.reduce((sum, p) => sum + p.points, 0)
+
+  return {
+    total: round2(clamp(base - penaltyTotal, 0, 100)),
+    dimensions,
+    penalties,
+    penaltyTotal,
+  }
+}
+
+/** Convenience: just the clamped 0–100 total, used heavily by the algorithm. */
+export function scoreTeamTotal(
+  members: NormalizedParticipant[],
+  context: ScoringContext
+): number {
+  return scoreTeam(members, context).total
+}

--- a/src/lib/matching/types.ts
+++ b/src/lib/matching/types.ts
@@ -1,0 +1,176 @@
+/**
+ * Impact Lab matching engine — shared types.
+ *
+ * The engine is pure and dependency-free: it never imports Prisma or Next. The
+ * API layer maps database rows into `MatchParticipant` and persists `MatchResult`
+ * as JSON. Keeping these types here (not in the DB layer) means the shape of a
+ * saved run is owned by the algorithm, and the database is just a safe.
+ */
+
+// ─── Roles ───────────────────────────────────────────────────────────────────
+
+/**
+ * The five canonical roles every raw role string is mapped onto during
+ * normalization. Ordering here is not significant — priority lives in
+ * ROLE_PRIORITY (constants.ts).
+ */
+export type CanonicalRole =
+  | "builder"
+  | "designer"
+  | "presenter"
+  | "data"
+  | "product"
+
+export type ExperienceLevel = "BEGINNER" | "INTERMEDIATE" | "ADVANCED"
+
+// ─── Participants ────────────────────────────────────────────────────────────
+
+/**
+ * A participant as handed to the engine — raw, pre-normalization. Mirrors the
+ * matching-relevant subset of `ImpactLabParticipant`. Deliberately omits phone,
+ * institution, projectIdeas and consent-to-share: the matcher must not depend on
+ * contact details, and `blockedTeammates` is included ONLY so constraints can
+ * honour it — it is never surfaced downstream.
+ */
+export interface MatchParticipant {
+  id: string
+  fullName: string
+  email: string
+  experienceLevel: ExperienceLevel
+  primaryRole: string
+  secondaryRoles: string[]
+  technicalSkills: string[]
+  interests: string[]
+  availability: string[]
+  preferredTeammates: string[]
+  blockedTeammates: string[]
+  consentToMatch: boolean
+}
+
+/**
+ * A participant after normalization: raw role strings canonicalized and deduped,
+ * skills/interests/availability lowercased and deduped, emails normalized. This
+ * is the only participant shape the algorithm and scorer operate on.
+ */
+export interface NormalizedParticipant {
+  id: string
+  fullName: string
+  email: string
+  experienceLevel: ExperienceLevel
+  /** Canonical roles, deduped, primary role first when it maps to a canonical. */
+  roles: CanonicalRole[]
+  /** The canonical form of primaryRole, or null if it maps to nothing known. */
+  primaryRole: CanonicalRole | null
+  skills: string[]
+  interests: string[]
+  availability: string[]
+  preferredTeammates: string[]
+  blockedTeammates: string[]
+}
+
+// ─── Settings ────────────────────────────────────────────────────────────────
+
+export type MatchWeightKey =
+  | "roleCoverage"
+  | "skillBalance"
+  | "experienceBalance"
+  | "interestAlignment"
+  | "availabilityOverlap"
+  | "participantPreferences"
+
+export type MatchWeights = Record<MatchWeightKey, number>
+
+/**
+ * A team the organiser has pinned. Members are given by email (the human
+ * identifier organisers work with); the engine resolves them to ids and passes
+ * the team through matching untouched.
+ */
+export interface LockedTeam {
+  name?: string
+  memberEmails: string[]
+}
+
+export interface MatchSettings {
+  desiredTeamSize: number
+  minTeamSize: number
+  maxTeamSize: number
+  /** When set, overrides the computed team count (ceil(eligible/desired)). */
+  numberOfTeams: number | null
+  allowUnassignedParticipants: boolean
+  requireBuilder: boolean
+  requirePresenter: boolean
+  preventBeginnerOnlyTeams: boolean
+  distributeAdvancedParticipants: boolean
+  lockedTeams: LockedTeam[]
+  weights: MatchWeights
+}
+
+// ─── Scores ──────────────────────────────────────────────────────────────────
+
+export interface DimensionScore {
+  key: MatchWeightKey
+  /** Normalized sub-score in [0, 1]. */
+  raw: number
+  weight: number
+  /** raw * weight — the contribution before global normalization to 0–100. */
+  weighted: number
+}
+
+export interface PenaltyEntry {
+  reason: string
+  /** Positive number of points subtracted from the team's 0–100 score. */
+  points: number
+}
+
+/**
+ * A team's full score breakdown. The UI renders this directly — every number a
+ * team scored is traceable to a dimension or a named penalty. That transparency
+ * is the whole point: organisers must be able to see WHY, then defend it.
+ */
+export interface ScoreBreakdown {
+  /** Final team score, clamped to [0, 100]. */
+  total: number
+  dimensions: DimensionScore[]
+  penalties: PenaltyEntry[]
+  /** Sum of penalty points (positive). */
+  penaltyTotal: number
+}
+
+// ─── Results ─────────────────────────────────────────────────────────────────
+
+export interface Team {
+  /** Deterministic id, e.g. "team-1". Stable across identical inputs. */
+  id: string
+  name: string
+  memberIds: string[]
+  locked: boolean
+  score: ScoreBreakdown
+}
+
+export interface MatchResult {
+  teams: Team[]
+  unassignedIds: string[]
+  warnings: string[]
+  /** Mean of team totals, [0, 100]. A single headline number for the run. */
+  averageScore: number
+  settingsUsed: MatchSettings
+}
+
+// ─── Explanations ────────────────────────────────────────────────────────────
+
+/**
+ * Per-team explanation. Produced deterministically from the score breakdown
+ * (explanations.ts) and optionally rewritten by the Claude layer
+ * (ai-explanations.ts). `source` records which produced it.
+ */
+export interface TeamExplanation {
+  teamId: string
+  summary: string
+  strengths: string[]
+  weaknesses: string[]
+  suggestedProjectDirection?: string
+  /** participantId → suggested internal role within the team. */
+  suggestedInternalRoles?: Record<string, string>
+  warnings: string[]
+  source: "deterministic" | "ai"
+}

--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -20,6 +20,7 @@ export type AdminResource =
   | "community"
   | "team"
   | "photos"
+  | "impact-lab"
 
 export type Action = "view" | "create" | "edit" | "delete" | "approve"
 
@@ -43,6 +44,7 @@ const rolePermissions: Record<
     community: ["view", "create", "edit", "delete", "approve"],
     team: ["view", "create", "edit", "delete"],
     photos: ["view", "create", "edit", "delete"],
+    "impact-lab": ["view", "create", "edit", "delete", "approve"],
   },
   ADMIN: {
     dashboard: ["view"],
@@ -60,6 +62,7 @@ const rolePermissions: Record<
     community: ["view", "edit", "approve"],
     team: ["view", "edit"],
     photos: ["view", "create", "edit", "delete"],
+    "impact-lab": ["view", "create", "edit", "delete"],
   },
   MODERATOR: {
     dashboard: ["view"],
@@ -77,6 +80,7 @@ const rolePermissions: Record<
     community: ["view", "approve"],
     team: ["view"],
     photos: ["view"],
+    "impact-lab": ["view"],
   },
   MEMBER: {
     // "dashboard" here means the admin dashboard. MEMBER must not have access —
@@ -96,6 +100,7 @@ const rolePermissions: Record<
     community: ["view"],
     team: [],
     photos: [],
+    "impact-lab": [],
   },
 }
 


### PR DESCRIPTION
## Impact Lab team matching

Adds a deterministic hackathon team-matcher for the Impact Lab / AI Mashinani
event, with an optional Claude explanation layer. Built from
`docs/impact-lab-matching-spec.md`.

### Design in one line

A **pure, deterministic engine** (`src/lib/matching/`) behind a thin effectful
shell (Prisma, auth, UI). The engine has no database, clock, randomness, or
network — so the same input always produces byte-for-byte identical teams, it's
trivially testable, and the AI layer can only ever *explain*, never decide.

### What's included

- **Data model** — `ImpactLabParticipant` + `ImpactLabMatchRun` (frozen snapshots
  so saved runs stay reproducible), `ImpactLabExperience` enum, cohort-scoped
  email uniqueness. Migration included.
- **Engine** — normalization → hard constraints (consent, blocks, locked teams,
  size) → six weighted scoring dimensions with a transparent breakdown → seed /
  distribute-advanced / greedy-fill algorithm → pairwise-swap optimization →
  deterministic explanations.
- **Claude layer** — `claude-sonnet-5` via the existing `@ai-sdk/anthropic`,
  explains-only. Sends no phone numbers, emails, or blocked teammates; validates
  every suggestion against real team membership; falls back to the deterministic
  explanations on any error (env-gated, never fails the page).
- **API + admin UI** — participant CRUD, resilient CSV import/export, match /
  explain / run routes (server recomputes deterministically rather than trusting
  the client), and `/admin/impact-lab` with Participants / Matching / Runs tabs.
  Gated by the existing RBAC, CSRF, rate limiting, and audit logging.
- **Verification** — `npm run verify:matching` runs the engine on a fixture and
  asserts determinism (incl. invariance to input order) and full constraint
  compliance. No test framework required.

### Reviewing

- Commits are granular and ordered — each is independently understandable, and
  each ships with a doc in `docs/impact-lab/` (read `docs/impact-lab/README.md`
  first). The feature is meant to double as a learning reference.
- `npx tsc --noEmit`, `eslint`, and a full `next build` pass clean.
- `npm run verify:matching` → all checks pass.

### Before merge

Apply the migration against the database — `npm run db:migrate`. The SQL is
hand-authored to match Prisma's output format, so it applies as-is without
generating a second migration.

### Provenance

Concepts were informed by an audit of the author's own earlier private project
`best-ed/HackMatch-AI`. No code was copied — this is a clean reimplementation in
this repo's stack. Details in `docs/impact-lab-matching-spec.md`.
