### PR TITLE
feat(impact-lab): member-facing matching profile + team reveal

### DIFF
--- a/docs/superpowers/specs/2026-07-22-impact-lab-member-flow-design.md
+++ b/docs/superpowers/specs/2026-07-22-impact-lab-member-flow-design.md
@@ -1,0 +1,88 @@
+# Impact Lab member flow — design spec
+
+**Date:** 2026-07-22 · **Deadline:** build complete 2026-07-23 (event 2026-07-25/26, 120 confirmed)
+**Approach:** A — member-gated matching profile (approved by Peter)
+
+## Goal
+
+Participants who registered on Luma create accounts on claudekenya.org (existing `/signup`),
+complete a 2-minute hackathon matching profile from their dashboard, and — once teams are
+finalized — see their own team on the dashboard. Admin imports the Luma CSV, runs the
+matcher, and marks a run final (all already shipped in PR #46).
+
+## Non-goals (v2, next hackathon)
+
+- Self-serve partner browsing / team formation UI. The engine's `preferredTeammates` /
+  `blockedTeammates` fields, captured in the profile form, cover partner preference.
+- WhatsApp Business API integration. Comms go via a plain WhatsApp group, manually.
+- Public (unauthenticated) profile form.
+
+## Flow
+
+1. Admin imports Luma CSV → `ImpactLabParticipant` rows (name + email, cohort default).
+2. WhatsApp blast: "create your account with the SAME email you used on Luma, complete
+   your hackathon profile" → link to `/dashboard/impact-lab`.
+3. Member logs in → dashboard shows an **Impact Lab card** (status-aware).
+4. `/dashboard/impact-lab`: profile form (only if a participant row matches their email).
+5. Friday 6pm EAT: deadline. Admin runs match, reviews, marks run **final**.
+6. After final run exists: `/dashboard/impact-lab` switches to **team reveal** view.
+
+## New surface
+
+### API (member-authenticated, NOT admin RBAC)
+
+- `src/app/api/impact-lab/profile/route.ts`
+  - `GET` — own participant row for the active cohort, matched by
+    `session.user.email` (lowercased). Not found → `{ registered: false }` (200).
+  - `PUT` — update own row. **Only if the row already exists** (no self-registration
+    into the cohort — walk-ins are added by admins). Editable fields: `fullName`,
+    roles, skills, experience level, project interests, availability,
+    `preferredTeammates`, `blockedTeammates`, `consentToMatch`,
+    `consentToShareContact`. NOT editable: `email`, `cohort`, any team-lock fields.
+    Validate with the existing zod participant draft schema (subset), reusing
+    `src/lib/impact-lab/participant-schema.ts` sanitizers.
+- `src/app/api/impact-lab/team/route.ts`
+  - `GET` — latest run for the active cohort where `isFinal = true`; locate the team
+    containing the caller's participant id inside the frozen `result` JSON. Returns
+    team name, members (fullName, roles, suggested internal roles), strengths,
+    project direction, and teammate contact info **only for teammates with
+    `consentToShareContact = true`**. No final run → `{ status: "pending" }`.
+    **Do not return the numeric team score** — show strengths/direction only.
+
+### UI
+
+- `src/app/dashboard/impact-lab/page.tsx` + client components. Single page, four states:
+  1. **Not registered** — friendly "we couldn't find a hackathon registration under
+     {email}" + note to use the Luma email or contact organizers (Discord/WhatsApp links).
+  2. **Profile form** — pre-filled from the imported row; save button; completion state.
+  3. **Waiting** — profile saved, teams not final: "Teams drop Saturday morning."
+  4. **Team reveal** — teammates, roles, suggested internal role per member, strengths,
+     suggested project direction, teammate contacts (consent-gated).
+- Dashboard card on `/dashboard/page.tsx` linking to the page, showing the same state.
+- UI must match existing dashboard component patterns/design tokens exactly.
+
+## Security & rules
+
+- Session required on both routes (same helper pattern as existing member/dashboard APIs —
+  scout and mirror exactly, including CSRF handling on mutations if the dashboard
+  profile editor uses it).
+- **Require verified email** (`emailVerified`) before showing/accepting the hackathon
+  profile — otherwise an unverified account could claim someone else's Luma email.
+  Reuse the existing `VerifyEmailBanner` flow to prompt.
+- Rate-limit the PUT (existing `rateLimit` util, standard bucket).
+- Email matching is case-insensitive on both sides.
+- All strings sanitized via existing zod sanitizers; arrays length-capped per the
+  existing participant schema.
+
+## Constants
+
+- Active cohort: reuse the cohort default/constant from `src/lib/impact-lab/`
+  (scout confirms the exact export; do not hardcode a second copy).
+
+## Testing / verification
+
+- `npx tsc --noEmit` clean, `npm run verify:matching` still green, `eslint` clean on
+  new files. Build compiles (local full build breaks on missing Supabase env in an
+  unrelated pre-existing route — not a gate).
+- Review pass: guard parity on the two new routes vs existing member API baseline;
+  correctness of team extraction from the frozen run JSON; consent gating on contacts.

--- a/src/app/api/impact-lab/profile/route.ts
+++ b/src/app/api/impact-lab/profile/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import {
+  checkMemberAccess,
+  memberProfileSchema,
+  toMemberProfile,
+} from "@/lib/impact-lab/member"
+
+/**
+ * A member's own hackathon matching profile for the active cohort, matched by
+ * session email. Members can only EDIT a row the admin Luma import created —
+ * there is no self-registration into the cohort (walk-ins are added by admins).
+ */
+
+export async function GET() {
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const row = await prisma.impactLabParticipant.findUnique({
+    where: { cohort_email: { cohort: DEFAULT_COHORT, email: check.email } },
+  })
+  if (!row) {
+    return NextResponse.json({ success: true, registered: false })
+  }
+
+  return NextResponse.json({
+    success: true,
+    registered: true,
+    profile: toMemberProfile(row),
+  })
+}
+
+export async function PUT(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Please try again later." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request" }, { status: 400 })
+  }
+
+  const parsed = memberProfileSchema.safeParse(body)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    return NextResponse.json(
+      { success: false, error: issue?.message ?? "Invalid input" },
+      { status: 400 }
+    )
+  }
+
+  const where = { cohort_email: { cohort: DEFAULT_COHORT, email: check.email } }
+  const existing = await prisma.impactLabParticipant.findUnique({
+    where,
+    select: { id: true },
+  })
+  if (!existing) {
+    return NextResponse.json(
+      {
+        success: false,
+        registered: false,
+        error: "No hackathon registration found for this account.",
+      },
+      { status: 404 }
+    )
+  }
+
+  const updated = await prisma.impactLabParticipant.update({
+    where,
+    data: parsed.data,
+  })
+
+  return NextResponse.json({
+    success: true,
+    message: "Profile saved.",
+    profile: toMemberProfile(updated),
+  })
+}

--- a/src/app/api/impact-lab/team/route.ts
+++ b/src/app/api/impact-lab/team/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import {
+  checkMemberAccess,
+  extractFrozenTeams,
+  type TeamMemberView,
+  type TeamRevealView,
+} from "@/lib/impact-lab/member"
+import {
+  explainTeam,
+  normalizeParticipants,
+  type MatchParticipant,
+  type NormalizedParticipant,
+} from "@/lib/matching"
+
+/**
+ * Members see strengths as qualities, never numbers — strip the "(NN%)"
+ * scoring detail the deterministic explainer embeds for organisers.
+ */
+function withoutPercentages(strengths: string[]): string[] {
+  return strengths.map((s) => s.replace(/\s*\(\d+%\)/g, ""))
+}
+
+/**
+ * The caller's finalized team for the active cohort, read from the frozen run
+ * JSON. Returns no team scores, and teammate emails only where that teammate's
+ * LIVE row has consentToShareContact = true (latest consent wins — same rule
+ * as the admin CSV export).
+ */
+export async function GET() {
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const participant = await prisma.impactLabParticipant.findUnique({
+    where: { cohort_email: { cohort: DEFAULT_COHORT, email: check.email } },
+    select: { id: true },
+  })
+  if (!participant) {
+    return NextResponse.json({ success: true, status: "not_registered" })
+  }
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort: DEFAULT_COHORT, isFinal: true },
+    orderBy: { createdAt: "desc" },
+  })
+  if (!run) {
+    return NextResponse.json({ success: true, status: "pending" })
+  }
+
+  // Frozen JSON, not schema-enforced — a malformed run degrades to pending.
+  const teams = extractFrozenTeams(run.result)
+  if (!teams) {
+    return NextResponse.json({ success: true, status: "pending" })
+  }
+  const team = teams.find((t) => t.memberIds.includes(participant.id))
+  if (!team) {
+    return NextResponse.json({ success: true, status: "unassigned" })
+  }
+
+  // The snapshot holds every cohort email plus blockedTeammates — never return
+  // it raw. Explanations are derived from it (deterministic, so the reveal
+  // matches what the admin reviewed); names and consent come from live rows.
+  const snapshot = run.participantsSnapshot as unknown as MatchParticipant[]
+  const snapshotById = new Map(snapshot.map((p) => [p.id, p]))
+  const normalizedById = new Map(
+    normalizeParticipants(snapshot).map((p) => [p.id, p])
+  )
+
+  const members = team.memberIds
+    .map((id) => normalizedById.get(id))
+    .filter((p): p is NormalizedParticipant => p !== undefined)
+  const explanation = explainTeam(team, members)
+
+  const live = await prisma.impactLabParticipant.findMany({
+    where: { cohort: DEFAULT_COHORT, id: { in: team.memberIds } },
+  })
+  const liveById = new Map(live.map((p) => [p.id, p]))
+
+  const memberViews: TeamMemberView[] = team.memberIds.map((id) => {
+    const liveP = liveById.get(id)
+    const snap = snapshotById.get(id)
+    const isSelf = id === participant.id
+    const shareEmail = isSelf || Boolean(liveP?.consentToShareContact)
+    return {
+      id,
+      fullName: liveP?.fullName ?? snap?.fullName ?? id,
+      primaryRole: liveP?.primaryRole ?? snap?.primaryRole ?? "",
+      suggestedInternalRole: explanation.suggestedInternalRoles?.[id] ?? null,
+      isSelf,
+      email: shareEmail ? (liveP?.email ?? (isSelf ? check.email : null)) : null,
+    }
+  })
+
+  const teamView: TeamRevealView = {
+    teamName: team.name,
+    members: memberViews,
+    strengths: withoutPercentages(explanation.strengths),
+    projectDirection: explanation.suggestedProjectDirection ?? null,
+  }
+
+  return NextResponse.json({ success: true, status: "revealed", team: teamView })
+}

--- a/src/app/dashboard/ProfileEditor.tsx
+++ b/src/app/dashboard/ProfileEditor.tsx
@@ -86,7 +86,7 @@ export function ProfileEditor({
       <div className="flex flex-wrap items-start gap-4 rounded-lg border border-border-default bg-bg-secondary p-5">
         <div className="flex-1 min-w-0">
           <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
-            // ./profile
+            {"// ./profile"}
           </p>
           <p className="font-mono text-sm text-text-primary">
             {initialFirstName} {initialLastName}

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AlertTriangle, Clock, Pencil, SearchX } from "lucide-react";
+import type {
+  MemberProfile,
+  MemberTeamStatus,
+  TeamRevealView,
+} from "@/lib/impact-lab/member";
+import { SOCIAL_LINKS } from "@/lib/constants";
+import { MatchProfileForm } from "./MatchProfileForm";
+import { TeamReveal } from "./TeamReveal";
+
+interface ProfileResponse {
+  success?: boolean;
+  registered?: boolean;
+  profile?: MemberProfile;
+  error?: string;
+}
+
+interface TeamResponse {
+  success?: boolean;
+  status?: MemberTeamStatus;
+  team?: TeamRevealView;
+  error?: string;
+}
+
+type Phase =
+  | "loading"
+  | "error"
+  | "not-registered"
+  | "profile"
+  | "unassigned"
+  | "revealed";
+
+/**
+ * Client state machine for /dashboard/impact-lab. The server page has already
+ * enforced session + verified email; this component derives one of the four
+ * spec states from GET /api/impact-lab/profile and GET /api/impact-lab/team:
+ * not-registered, profile form, waiting (profile saved, teams pending), reveal.
+ */
+export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [profile, setProfile] = useState<MemberProfile | null>(null);
+  const [team, setTeam] = useState<TeamRevealView | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    Promise.all([fetch("/api/impact-lab/profile"), fetch("/api/impact-lab/team")])
+      .then(async ([profileRes, teamRes]) => {
+        const profileJson: ProfileResponse = await profileRes.json();
+        const teamJson: TeamResponse = await teamRes.json();
+        if (!active) return;
+        if (!profileRes.ok || !profileJson.success || !teamRes.ok || !teamJson.success) {
+          setPhase("error");
+          return;
+        }
+
+        if (teamJson.status === "revealed" && teamJson.team) {
+          setTeam(teamJson.team);
+          setPhase("revealed");
+          return;
+        }
+        if (!profileJson.registered || !profileJson.profile) {
+          setPhase("not-registered");
+          return;
+        }
+        setProfile(profileJson.profile);
+        setPhase(teamJson.status === "unassigned" ? "unassigned" : "profile");
+      })
+      .catch(() => {
+        if (active) setPhase("error");
+      });
+    return () => {
+      active = false;
+    };
+  }, [reloadKey]);
+
+  if (phase === "loading") {
+    return (
+      <p
+        className="font-mono text-sm text-text-dim"
+        role="status"
+        aria-live="polite"
+      >
+        $ loading impact-lab<span className="animate-pulse">_</span>
+      </p>
+    );
+  }
+
+  if (phase === "error") {
+    return (
+      <div className="rounded-lg border border-red/30 bg-red/10 p-5">
+        <p className="flex items-center gap-2 font-mono text-sm text-red">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          Couldn&apos;t load your Impact Lab status.
+        </p>
+        <button
+          onClick={() => {
+            setPhase("loading");
+            setReloadKey((k) => k + 1);
+          }}
+          className="mt-3 inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-4 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === "revealed" && team) {
+    return <TeamReveal team={team} />;
+  }
+
+  if (phase === "not-registered") {
+    return (
+      <section
+        className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
+        aria-label="Registration not found"
+      >
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10">
+            <SearchX className="h-5 w-5 text-amber" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="font-mono text-base font-bold text-text-primary">
+              No hackathon registration found
+            </h2>
+            <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+              We couldn&apos;t find an Impact Lab registration under{" "}
+              <span className="font-mono text-text-primary">{sessionEmail}</span>.
+              Make sure this account uses the same email you registered with on
+              Luma. Registered with a different address, or just signed up on
+              site? Message the organizers and we&apos;ll sort it out.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <a
+                href={SOCIAL_LINKS.discord}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 text-xs font-mono font-semibold text-green-primary hover:bg-green-primary/20 transition-colors"
+              >
+                Discord
+              </a>
+              <a
+                href={SOCIAL_LINKS.whatsapp}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 text-xs font-mono font-semibold text-green-primary hover:bg-green-primary/20 transition-colors"
+              >
+                WhatsApp
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (!profile) return null;
+
+  if (phase === "unassigned") {
+    return (
+      <div className="space-y-6">
+        <section
+          className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
+          aria-label="Team status"
+        >
+          <h2 className="font-mono text-base font-bold text-text-primary">
+            Teams are finalized
+          </h2>
+          <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+            {profile.consentToMatch
+              ? "You weren't placed on a team this round. Reach out to the organizers on "
+              : "Your matching profile wasn't completed before the deadline, so the matcher couldn't include you this round. Reach out to the organizers on "}
+            <a
+              href={SOCIAL_LINKS.discord}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-primary hover:underline"
+            >
+              Discord
+            </a>{" "}
+            or{" "}
+            <a
+              href={SOCIAL_LINKS.whatsapp}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-green-primary hover:underline"
+            >
+              WhatsApp
+            </a>{" "}
+            and we&apos;ll find you a spot.
+          </p>
+        </section>
+
+        <section
+          className="rounded-lg border border-border-default bg-bg-secondary p-5"
+          aria-label="Your matching profile"
+        >
+          <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
+            {"// ./matching-profile"}
+          </p>
+          <p className="font-mono text-sm text-text-primary">
+            {profile.fullName}
+          </p>
+          <p className="mt-1 font-mono text-xs text-text-dim">
+            {profile.primaryRole} &middot;{" "}
+            {profile.experienceLevel.toLowerCase()}
+          </p>
+          {profile.technicalSkills.length > 0 && (
+            <p className="mt-1 font-mono text-xs text-text-dim">
+              {profile.technicalSkills.join(", ")}
+            </p>
+          )}
+        </section>
+      </div>
+    );
+  }
+
+  // phase === "profile": teams not final yet. A profile counts as complete
+  // once the member has opted in to matching (imported rows start at false).
+  const profileComplete = profile.consentToMatch;
+
+  if (profileComplete && !editing) {
+    return (
+      <div className="space-y-6">
+        <section
+          className="rounded-lg border border-green-primary/20 bg-bg-secondary p-6"
+          aria-label="Profile status"
+        >
+          <div className="flex flex-wrap items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-green-primary/30 bg-green-primary/10">
+              <Clock className="h-5 w-5 text-green-primary" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="font-mono text-base font-bold text-text-primary">
+                Profile saved — you&apos;re in the matching pool
+              </h2>
+              <p className="mt-1 text-sm text-text-secondary">
+                Teams drop Saturday morning. Check back here.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section
+          className="rounded-lg border border-border-default bg-bg-secondary p-5"
+          aria-label="Your matching profile"
+        >
+          <div className="flex flex-wrap items-start gap-4">
+            <div className="flex-1 min-w-0">
+              <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
+                {"// ./matching-profile"}
+              </p>
+              <p className="font-mono text-sm text-text-primary">
+                {profile.fullName}
+              </p>
+              <p className="mt-1 font-mono text-xs text-text-dim">
+                {profile.primaryRole} &middot;{" "}
+                {profile.experienceLevel.toLowerCase()}
+              </p>
+              {profile.technicalSkills.length > 0 && (
+                <p className="mt-1 font-mono text-xs text-text-dim">
+                  {profile.technicalSkills.join(", ")}
+                </p>
+              )}
+            </div>
+            <button
+              onClick={() => setEditing(true)}
+              className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-3 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
+            >
+              <Pencil className="h-3 w-3" />
+              Edit profile
+            </button>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  return (
+    <MatchProfileForm
+      profile={profile}
+      onSaved={(saved) => {
+        setProfile(saved);
+        setEditing(false);
+      }}
+      onCancel={profileComplete ? () => setEditing(false) : undefined}
+    />
+  );
+}

--- a/src/app/dashboard/impact-lab/MatchProfileForm.tsx
+++ b/src/app/dashboard/impact-lab/MatchProfileForm.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useEffect, useState, useTransition } from "react";
+import { AlertTriangle, CheckCircle2, Loader2, Save, X } from "lucide-react";
+import type {
+  MemberProfile,
+  MemberProfileInput,
+} from "@/lib/impact-lab/member";
+
+interface MatchProfileFormProps {
+  profile: MemberProfile;
+  onSaved: (profile: MemberProfile) => void;
+  /** Present only when re-editing an already-complete profile. */
+  onCancel?: () => void;
+}
+
+/** Same multi-value convention as the admin participants form: split on ; or , */
+const splitMulti = (v: string): string[] =>
+  v.split(/[;,]/).map((s) => s.trim()).filter(Boolean);
+
+const inputClass =
+  "w-full bg-bg-card border border-border-default rounded px-3 py-2 text-sm font-mono text-text-primary focus:outline-none focus:border-green-primary/50";
+const labelClass = "block text-[11px] font-mono text-text-dim mb-1.5";
+
+export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFormProps) {
+  const [csrfToken, setCsrfToken] = useState("");
+  const [fullName, setFullName] = useState(profile.fullName);
+  const [experienceLevel, setExperienceLevel] = useState(profile.experienceLevel);
+  const [primaryRole, setPrimaryRole] = useState(profile.primaryRole);
+  const [secondaryRoles, setSecondaryRoles] = useState(profile.secondaryRoles.join(", "));
+  const [technicalSkills, setTechnicalSkills] = useState(profile.technicalSkills.join(", "));
+  const [interests, setInterests] = useState(profile.interests.join(", "));
+  const [availability, setAvailability] = useState(profile.availability.join(", "));
+  const [projectIdeas, setProjectIdeas] = useState(profile.projectIdeas ?? "");
+  const [preferredTeammates, setPreferredTeammates] = useState(profile.preferredTeammates.join(", "));
+  const [blockedTeammates, setBlockedTeammates] = useState(profile.blockedTeammates.join(", "));
+  const [consentToMatch, setConsentToMatch] = useState(profile.consentToMatch);
+  const [consentToShareContact, setConsentToShareContact] = useState(profile.consentToShareContact);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  useEffect(() => {
+    fetch("/api/csrf-token")
+      .then((r) => r.json())
+      .then((d) => setCsrfToken(d.csrfToken))
+      .catch(() => {});
+  }, []);
+
+  function handleSave(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!fullName.trim() || !primaryRole.trim()) {
+      setError("Full name and primary role are required.");
+      return;
+    }
+
+    const body: MemberProfileInput = {
+      fullName: fullName.trim(),
+      experienceLevel,
+      primaryRole: primaryRole.trim(),
+      secondaryRoles: splitMulti(secondaryRoles),
+      technicalSkills: splitMulti(technicalSkills),
+      interests: splitMulti(interests),
+      availability: splitMulti(availability),
+      projectIdeas: projectIdeas.trim() || null,
+      preferredTeammates: splitMulti(preferredTeammates),
+      blockedTeammates: splitMulti(blockedTeammates),
+      consentToMatch,
+      consentToShareContact,
+    };
+
+    startTransition(async () => {
+      try {
+        const res = await fetch("/api/impact-lab/profile", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json", "x-csrf-token": csrfToken },
+          body: JSON.stringify(body),
+        });
+        const json = await res.json();
+        if (!res.ok || !json.success) {
+          setError(json.error || "Failed to save your profile.");
+          return;
+        }
+        onSaved(json.profile as MemberProfile);
+      } catch {
+        setError("Network error. Please try again.");
+      }
+    });
+  }
+
+  return (
+    <form
+      onSubmit={handleSave}
+      className="rounded-lg border border-green-primary/30 bg-bg-secondary p-5"
+    >
+      <p className="font-mono text-[11px] uppercase tracking-wider text-green-primary mb-1">
+        $ vim ./matching-profile
+      </p>
+      <p className="mb-4 text-xs text-text-secondary">
+        Two minutes. This is how we place you on the right team.
+      </p>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div>
+          <label htmlFor="il-fullName" className={labelClass}>
+            Full name
+          </label>
+          <input
+            id="il-fullName"
+            type="text"
+            required
+            maxLength={120}
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <label htmlFor="il-primaryRole" className={labelClass}>
+            Primary role
+          </label>
+          <input
+            id="il-primaryRole"
+            type="text"
+            required
+            maxLength={60}
+            value={primaryRole}
+            onChange={(e) => setPrimaryRole(e.target.value)}
+            className={inputClass}
+            list="il-role-options"
+            placeholder="e.g. Builder"
+          />
+          <datalist id="il-role-options">
+            <option value="Builder" />
+            <option value="Designer" />
+            <option value="Presenter" />
+            <option value="Data" />
+            <option value="Product" />
+          </datalist>
+        </div>
+        <div>
+          <label htmlFor="il-experienceLevel" className={labelClass}>
+            Experience level
+          </label>
+          <select
+            id="il-experienceLevel"
+            value={experienceLevel}
+            onChange={(e) =>
+              setExperienceLevel(e.target.value as MemberProfile["experienceLevel"])
+            }
+            className={inputClass}
+          >
+            <option value="BEGINNER">Beginner</option>
+            <option value="INTERMEDIATE">Intermediate</option>
+            <option value="ADVANCED">Advanced</option>
+          </select>
+        </div>
+        <div>
+          <label htmlFor="il-secondaryRoles" className={labelClass}>
+            Secondary roles (comma-separated, optional)
+          </label>
+          <input
+            id="il-secondaryRoles"
+            type="text"
+            value={secondaryRoles}
+            onChange={(e) => setSecondaryRoles(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. Designer, Presenter"
+          />
+        </div>
+        <div>
+          <label htmlFor="il-technicalSkills" className={labelClass}>
+            Technical skills (comma-separated)
+          </label>
+          <input
+            id="il-technicalSkills"
+            type="text"
+            value={technicalSkills}
+            onChange={(e) => setTechnicalSkills(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. TypeScript, Python, Figma"
+          />
+        </div>
+        <div>
+          <label htmlFor="il-interests" className={labelClass}>
+            Interests (comma-separated)
+          </label>
+          <input
+            id="il-interests"
+            type="text"
+            value={interests}
+            onChange={(e) => setInterests(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. agriculture, health, fintech"
+          />
+        </div>
+        <div>
+          <label htmlFor="il-availability" className={labelClass}>
+            Availability (comma-separated)
+          </label>
+          <input
+            id="il-availability"
+            type="text"
+            value={availability}
+            onChange={(e) => setAvailability(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. Saturday all day, Sunday morning"
+          />
+        </div>
+        <div>
+          <label htmlFor="il-preferredTeammates" className={labelClass}>
+            Teammates you&apos;d like (their emails, optional)
+          </label>
+          <input
+            id="il-preferredTeammates"
+            type="text"
+            value={preferredTeammates}
+            onChange={(e) => setPreferredTeammates(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. friend@example.com"
+          />
+        </div>
+        <div>
+          <label htmlFor="il-blockedTeammates" className={labelClass}>
+            Teammates to avoid (their emails, optional)
+          </label>
+          <input
+            id="il-blockedTeammates"
+            type="text"
+            value={blockedTeammates}
+            onChange={(e) => setBlockedTeammates(e.target.value)}
+            className={inputClass}
+          />
+          <p className="mt-1 text-[10px] font-mono text-text-dim">
+            Private — only organizers ever see this.
+          </p>
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="il-projectIdeas" className={labelClass}>
+            Project ideas (optional)
+          </label>
+          <textarea
+            id="il-projectIdeas"
+            rows={3}
+            maxLength={2000}
+            value={projectIdeas}
+            onChange={(e) => setProjectIdeas(e.target.value)}
+            className={inputClass}
+            placeholder="Anything you'd love to build this weekend"
+          />
+        </div>
+      </div>
+
+      <fieldset className="mt-5 space-y-2 rounded border border-border-default bg-bg-card p-4">
+        <legend className="px-1 font-mono text-[11px] uppercase tracking-wider text-text-dim">
+          Consent
+        </legend>
+        <label className="flex items-start gap-2.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={consentToMatch}
+            onChange={(e) => setConsentToMatch(e.target.checked)}
+            className="mt-0.5 h-4 w-4 accent-green-primary cursor-pointer"
+          />
+          <span className="text-xs text-text-secondary">
+            <span className="font-mono font-semibold text-text-primary">
+              Place me on a team.
+            </span>{" "}
+            Required — we only match participants who opt in.
+          </span>
+        </label>
+        <label className="flex items-start gap-2.5 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={consentToShareContact}
+            onChange={(e) => setConsentToShareContact(e.target.checked)}
+            className="mt-0.5 h-4 w-4 accent-green-primary cursor-pointer"
+          />
+          <span className="text-xs text-text-secondary">
+            <span className="font-mono font-semibold text-text-primary">
+              Share my email with my teammates
+            </span>{" "}
+            once teams are revealed.
+          </span>
+        </label>
+      </fieldset>
+
+      <p className="mt-3 text-[11px] font-mono text-text-dim">
+        Registered as {profile.email}
+        {profile.institution ? ` · ${profile.institution}` : ""} — contact the
+        organizers to change this.
+      </p>
+
+      {error && (
+        <div className="mt-3 flex items-center gap-2 rounded border border-red/30 bg-red/10 p-2 text-[11px] font-mono text-red">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {!consentToMatch && (
+        <div className="mt-3 flex items-center gap-2 rounded border border-amber/30 bg-amber/10 p-2 text-[11px] font-mono text-amber">
+          <CheckCircle2 className="h-3.5 w-3.5 shrink-0" />
+          Tick &quot;Place me on a team&quot; to enter the matching pool.
+        </div>
+      )}
+
+      <div className="mt-4 flex flex-wrap items-center gap-2">
+        <button
+          type="submit"
+          disabled={isPending || !csrfToken}
+          className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 text-xs font-mono font-semibold text-green-primary hover:bg-green-primary/20 transition-colors disabled:opacity-50"
+        >
+          {isPending ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : (
+            <Save className="h-3 w-3" />
+          )}
+          {isPending ? "Saving..." : "Save profile"}
+        </button>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isPending}
+            className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-4 py-1.5 text-xs font-mono text-text-secondary hover:border-red/40 hover:text-red transition-colors disabled:opacity-50"
+          >
+            <X className="h-3 w-3" />
+            Cancel
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/app/dashboard/impact-lab/TeamReveal.tsx
+++ b/src/app/dashboard/impact-lab/TeamReveal.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { Lightbulb, Mail, Users } from "lucide-react";
+import type { TeamRevealView } from "@/lib/impact-lab/member";
+
+/**
+ * The finalized team, as qualities rather than numbers — the API already
+ * strips scores; this view shows teammates, roles, strengths, and direction.
+ */
+export function TeamReveal({ team }: { team: TeamRevealView }) {
+  return (
+    <div className="space-y-6">
+      <section
+        className="rounded-lg border border-green-primary/30 bg-bg-secondary p-6"
+        aria-label="Your team"
+      >
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded border border-green-primary/30 bg-green-primary/10">
+            <Users className="h-6 w-6 text-green-primary" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="font-mono text-[11px] uppercase tracking-wider text-green-primary mb-1">
+              {"// ./your-team"}
+            </p>
+            <h2 className="font-mono text-2xl font-bold text-text-primary">
+              {team.teamName}
+            </h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              {team.members.length} members &middot; see you at the hackathon.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section aria-label="Teammates">
+        <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
+          {"// ./teammates"}
+        </h3>
+        <ul className="space-y-3">
+          {team.members.map((member) => (
+            <li
+              key={member.id}
+              className="flex flex-wrap items-center gap-3 rounded border border-border-default bg-bg-secondary px-4 py-3"
+            >
+              <span className="font-mono text-sm text-text-primary">
+                {member.fullName}
+              </span>
+              {member.isSelf && (
+                <span className="rounded border border-green-primary/30 bg-green-primary/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-green-primary">
+                  you
+                </span>
+              )}
+              {member.primaryRole && (
+                <span className="rounded border border-border-default bg-bg-card px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                  {member.primaryRole}
+                </span>
+              )}
+              {member.suggestedInternalRole && (
+                <span className="rounded border border-cyan/30 bg-cyan/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-cyan">
+                  {member.suggestedInternalRole}
+                </span>
+              )}
+              <span className="ml-auto">
+                {member.email ? (
+                  <a
+                    href={`mailto:${member.email}`}
+                    className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text-secondary hover:text-green-primary transition-colors"
+                  >
+                    <Mail className="h-3 w-3" />
+                    {member.email}
+                  </a>
+                ) : !member.isSelf ? (
+                  <span className="font-mono text-[11px] text-text-dim">
+                    contact private
+                  </span>
+                ) : null}
+              </span>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-2 font-mono text-[10px] text-text-dim">
+          Emails appear only for teammates who chose to share their contact.
+        </p>
+      </section>
+
+      {team.strengths.length > 0 && (
+        <section aria-label="Team strengths">
+          <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
+            {"// ./strengths"}
+          </h3>
+          <ul className="space-y-2 rounded-lg border border-border-default bg-bg-secondary p-5">
+            {team.strengths.map((strength) => (
+              <li
+                key={strength}
+                className="flex items-start gap-2 text-sm text-text-secondary"
+              >
+                <span aria-hidden="true" className="font-mono text-green-primary">
+                  +
+                </span>
+                {strength}
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {team.projectDirection && (
+        <section aria-label="Suggested project direction">
+          <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
+            {"// ./suggested-direction"}
+          </h3>
+          <div className="flex items-start gap-3 rounded-lg border border-amber/30 bg-amber/5 p-5">
+            <Lightbulb className="h-5 w-5 shrink-0 text-amber" />
+            <p className="text-sm text-text-secondary leading-relaxed">
+              {team.projectDirection}
+            </p>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/app/dashboard/impact-lab/page.tsx
+++ b/src/app/dashboard/impact-lab/page.tsx
@@ -1,0 +1,64 @@
+import { redirect } from "next/navigation";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowLeft } from "lucide-react";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import { VerifyEmailBanner } from "../VerifyEmailBanner";
+import { ImpactLabClient } from "./ImpactLabClient";
+
+export const metadata: Metadata = {
+  title: "Impact Lab | Claude Community Kenya",
+  description: "Your Impact Lab hackathon matching profile and team.",
+  robots: { index: false, follow: false },
+};
+
+export default async function ImpactLabPage() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    redirect("/login?callbackUrl=/dashboard/impact-lab");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { emailVerified: true },
+  });
+  if (!user) redirect("/login");
+
+  return (
+    <main className="min-h-screen bg-bg-primary pt-24 pb-24">
+      <div className="mx-auto max-w-3xl px-4">
+        <header className="mb-8 border-b border-border-default/60 pb-6">
+          <Link
+            href="/dashboard"
+            className="mb-4 inline-flex items-center gap-1.5 font-mono text-xs text-text-dim hover:text-green-primary transition-colors"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            cd ../dashboard
+          </Link>
+          <p className="font-mono text-[11px] uppercase tracking-[0.18em] text-green-primary mb-2">
+            $ cat ./impact-lab
+          </p>
+          <h1 className="font-mono text-3xl font-bold text-text-primary sm:text-4xl">
+            Impact Lab Hackathon
+          </h1>
+          <p className="mt-2 font-mono text-sm text-text-dim">
+            Complete your matching profile, then check back here for your team.
+          </p>
+        </header>
+
+        {!user.emailVerified ? (
+          <>
+            <VerifyEmailBanner />
+            <p className="font-mono text-sm text-text-secondary">
+              Verify your email to open your hackathon matching profile. This
+              confirms the email you registered with on Luma is really yours.
+            </p>
+          </>
+        ) : (
+          <ImpactLabClient sessionEmail={session.user.email} />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,7 +5,9 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { getUpcomingEvents } from "@/lib/data";
 import { SOCIAL_LINKS } from "@/lib/constants";
-import { Calendar, MessageSquare, BookOpen, Sparkles, Code2 } from "lucide-react";
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants";
+import { extractFrozenTeams } from "@/lib/impact-lab/member";
+import { Calendar, MessageSquare, BookOpen, Sparkles, Code2, FlaskConical } from "lucide-react";
 import { SignOutButton } from "./SignOutButton";
 import { VerifyEmailBanner } from "./VerifyEmailBanner";
 import { ProfileEditor } from "./ProfileEditor";
@@ -80,6 +82,41 @@ export default async function DashboardPage() {
 
   const nextEvent = upcomingEvents[0];
 
+  // Impact Lab hackathon status — mirrors the states on /dashboard/impact-lab.
+  let impactLabStatus: ImpactLabStatus = "verify";
+  if (user.emailVerified) {
+    // No .catch(() => null) here: swallowing a DB error would show a
+    // registered participant the affirmative "Registration not found" copy.
+    // A down DB surfaces via the page error boundary, same as the user query.
+    const participant = await prisma.impactLabParticipant.findUnique({
+      where: {
+        cohort_email: {
+          cohort: DEFAULT_COHORT,
+          email: user.email.toLowerCase(),
+        },
+      },
+      select: { id: true, consentToMatch: true },
+    });
+    if (!participant) {
+      impactLabStatus = "not-registered";
+    } else {
+      const finalRun = await prisma.impactLabMatchRun.findFirst({
+        where: { cohort: DEFAULT_COHORT, isFinal: true },
+        orderBy: { createdAt: "desc" },
+        select: { result: true },
+      });
+      // Frozen JSON, not schema-enforced — a malformed run degrades to waiting.
+      const teams = finalRun ? extractFrozenTeams(finalRun.result) : null;
+      if (!teams) {
+        impactLabStatus = participant.consentToMatch ? "waiting" : "profile";
+      } else {
+        impactLabStatus = teams.some((t) => t.memberIds.includes(participant.id))
+          ? "revealed"
+          : "unassigned";
+      }
+    }
+  }
+
   return (
     <main className="min-h-screen bg-bg-primary pt-24 pb-24">
       <div className="mx-auto max-w-5xl px-4">
@@ -111,6 +148,10 @@ export default async function DashboardPage() {
         </header>
 
         {!user.emailVerified && <VerifyEmailBanner />}
+
+        <section className="mb-8" aria-label="Impact Lab hackathon">
+          <ImpactLabCard status={impactLabStatus} />
+        </section>
 
         <section className="mb-8" aria-label="Profile">
           <ProfileEditor
@@ -153,7 +194,7 @@ export default async function DashboardPage() {
         {/* Quick Links Grid */}
         <section aria-label="Quick links">
           <h2 className="mb-4 font-mono text-xs uppercase tracking-wider text-text-dim">
-            // ./quick-links
+            {"// ./quick-links"}
           </h2>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             <DashboardCard
@@ -206,7 +247,7 @@ export default async function DashboardPage() {
         {totalSubmissions > 0 && (
           <section className="mt-12" aria-label="My submissions">
             <h2 className="mb-4 font-mono text-xs uppercase tracking-wider text-text-dim">
-              // ./my-submissions
+              {"// ./my-submissions"}
             </h2>
             <div className="space-y-3">
               {myIdeas.map((s) => (
@@ -246,7 +287,7 @@ export default async function DashboardPage() {
           <div className="grid gap-3 rounded-lg border border-border-default bg-bg-secondary/60 p-5 sm:grid-cols-2">
             <div>
               <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-dim mb-1">
-                // roadmap
+                {"// roadmap"}
               </p>
               <p className="font-mono text-xs text-text-secondary leading-relaxed">
                 Member features in progress: saved events, 2FA for admins, and
@@ -255,7 +296,7 @@ export default async function DashboardPage() {
             </div>
             <div className="sm:text-right">
               <p className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-dim mb-1">
-                // feedback
+                {"// feedback"}
               </p>
               <p className="font-mono text-xs text-text-secondary leading-relaxed">
                 Have an idea?{" "}
@@ -274,6 +315,80 @@ export default async function DashboardPage() {
         </section>
       </div>
     </main>
+  );
+}
+
+type ImpactLabStatus =
+  | "verify"
+  | "not-registered"
+  | "profile"
+  | "waiting"
+  | "revealed"
+  | "unassigned";
+
+const IMPACT_LAB_COPY: Record<
+  ImpactLabStatus,
+  { title: string; description: string }
+> = {
+  verify: {
+    title: "Verify your email to unlock",
+    description:
+      "Your hackathon matching profile opens once your email is verified.",
+  },
+  "not-registered": {
+    title: "Registration not found",
+    description:
+      "We couldn't match your account email to a Luma registration. Open for details.",
+  },
+  profile: {
+    title: "Complete your matching profile",
+    description: "Two minutes — it's how we place you on the right team.",
+  },
+  waiting: {
+    title: "Profile complete",
+    description: "Teams drop Saturday morning — check back here.",
+  },
+  revealed: {
+    title: "Your team is ready",
+    description: "Meet your teammates and see your suggested project direction.",
+  },
+  unassigned: {
+    title: "Teams are finalized",
+    description: "You weren't placed on a team — contact the organizers.",
+  },
+};
+
+function ImpactLabCard({ status }: { status: ImpactLabStatus }) {
+  const copy = IMPACT_LAB_COPY[status];
+  const green = status === "revealed" || status === "waiting";
+  const cardClass = green
+    ? "group flex flex-wrap items-start gap-4 rounded-lg border border-green-primary/20 bg-bg-secondary p-6 transition-all hover:border-green-primary/40"
+    : "group flex flex-wrap items-start gap-4 rounded-lg border border-amber/20 bg-bg-secondary p-6 transition-all hover:border-amber/40";
+  const iconBoxClass = green
+    ? "flex h-12 w-12 shrink-0 items-center justify-center rounded border border-green-primary/30 bg-green-primary/10"
+    : "flex h-12 w-12 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10";
+  const eyebrowClass = green
+    ? "font-mono text-[11px] uppercase tracking-wider text-green-primary mb-1"
+    : "font-mono text-[11px] uppercase tracking-wider text-amber mb-1";
+
+  return (
+    <Link href="/dashboard/impact-lab" className={cardClass}>
+      <div className={iconBoxClass}>
+        <FlaskConical
+          className={green ? "h-6 w-6 text-green-primary" : "h-6 w-6 text-amber"}
+        />
+      </div>
+      <div className="flex-1">
+        <p className={eyebrowClass}>Impact Lab hackathon</p>
+        <h2 className="font-mono text-base font-bold text-text-primary group-hover:text-green-primary transition-colors">
+          {copy.title}
+        </h2>
+        <p className="mt-1 text-sm text-text-secondary">{copy.description}</p>
+      </div>
+      <span className="font-mono text-sm text-text-dim group-hover:text-green-primary transition-colors">
+        Open &rarr;
+      </span>
+    </Link>
   );
 }
 

--- a/src/lib/impact-lab/member.ts
+++ b/src/lib/impact-lab/member.ts
@@ -1,0 +1,187 @@
+/**
+ * Member-facing Impact Lab surface: the session + email-verification gate, the
+ * member-editable subset of the participant schema, and the safe view types the
+ * member API returns. Admin routes use RBAC (`@/lib/rbac`) instead — never this.
+ *
+ * Client components may `import type` from here, but must never value-import
+ * (checkMemberAccess pulls in auth + Prisma, which are server-only).
+ */
+
+import { NextResponse } from "next/server"
+import type { z } from "zod"
+import { auth } from "@/auth"
+import { prisma } from "@/lib/prisma"
+import type { ImpactLabParticipant } from "@/generated/prisma/client"
+import type { Team } from "@/lib/matching"
+import { participantDraftSchema } from "./participant-schema"
+
+// ─── Member-editable profile ─────────────────────────────────────────────────
+
+/**
+ * The subset of the participant schema a member may edit. `email` and `cohort`
+ * are identity (set by the admin Luma import) and are deliberately excluded;
+ * phone and institution stay import-owned too.
+ */
+export const memberProfileSchema = participantDraftSchema.pick({
+  fullName: true,
+  experienceLevel: true,
+  primaryRole: true,
+  secondaryRoles: true,
+  technicalSkills: true,
+  interests: true,
+  availability: true,
+  projectIdeas: true,
+  preferredTeammates: true,
+  blockedTeammates: true,
+  consentToMatch: true,
+  consentToShareContact: true,
+})
+
+export type MemberProfileInput = z.infer<typeof memberProfileSchema>
+
+/** A member's own participant row, as returned by GET/PUT /api/impact-lab/profile. */
+export interface MemberProfile {
+  fullName: string
+  email: string
+  phone: string | null
+  institution: string | null
+  experienceLevel: ImpactLabParticipant["experienceLevel"]
+  primaryRole: string
+  secondaryRoles: string[]
+  technicalSkills: string[]
+  interests: string[]
+  availability: string[]
+  projectIdeas: string | null
+  preferredTeammates: string[]
+  blockedTeammates: string[]
+  consentToMatch: boolean
+  consentToShareContact: boolean
+}
+
+/**
+ * Explicit projection of a member's OWN row (their blocked/preferred lists are
+ * their own input, so they see them). Never use for someone else's row.
+ */
+export function toMemberProfile(row: ImpactLabParticipant): MemberProfile {
+  return {
+    fullName: row.fullName,
+    email: row.email,
+    phone: row.phone,
+    institution: row.institution,
+    experienceLevel: row.experienceLevel,
+    primaryRole: row.primaryRole,
+    secondaryRoles: row.secondaryRoles,
+    technicalSkills: row.technicalSkills,
+    interests: row.interests,
+    availability: row.availability,
+    projectIdeas: row.projectIdeas,
+    preferredTeammates: row.preferredTeammates,
+    blockedTeammates: row.blockedTeammates,
+    consentToMatch: row.consentToMatch,
+    consentToShareContact: row.consentToShareContact,
+  }
+}
+
+// ─── Team reveal views ───────────────────────────────────────────────────────
+
+/** Discriminator for GET /api/impact-lab/team responses. */
+export type MemberTeamStatus =
+  | "not_registered"
+  | "pending"
+  | "unassigned"
+  | "revealed"
+
+export interface TeamMemberView {
+  id: string
+  fullName: string
+  primaryRole: string
+  suggestedInternalRole: string | null
+  isSelf: boolean
+  /** Only set for self, or for teammates with consentToShareContact = true. */
+  email: string | null
+}
+
+/** A member's finalized team — no scores, no snapshot leakage. */
+export interface TeamRevealView {
+  teamName: string
+  members: TeamMemberView[]
+  strengths: string[]
+  projectDirection: string | null
+}
+
+/**
+ * The frozen run `result` column is admin-authored JSON, not schema-enforced —
+ * guard the shape the member surface reads (teams as arrays of string
+ * memberIds) before use, so a drifted or legacy run degrades to the pending /
+ * waiting state instead of throwing during render. Returns null when malformed.
+ */
+export function extractFrozenTeams(result: unknown): Team[] | null {
+  if (typeof result !== "object" || result === null) return null
+  const teams = (result as { teams?: unknown }).teams
+  if (!Array.isArray(teams)) return null
+  for (const team of teams) {
+    if (typeof team !== "object" || team === null) return null
+    const memberIds = (team as { memberIds?: unknown }).memberIds
+    if (!Array.isArray(memberIds) || memberIds.some((id) => typeof id !== "string")) {
+      return null
+    }
+  }
+  return teams as Team[]
+}
+
+// ─── Access gate ─────────────────────────────────────────────────────────────
+
+export type MemberAccessResult =
+  | {
+      authorized: true
+      /** Session email, lowercased — participant emails are stored sanitized. */
+      email: string
+    }
+  | { authorized: false; response: NextResponse }
+
+/**
+ * Session + verified-email gate for the member Impact Lab routes. Verification
+ * is required so an unverified account cannot claim someone else's Luma email.
+ * The 403 carries `code: "EMAIL_UNVERIFIED"` so the UI can show the verify flow.
+ */
+export async function checkMemberAccess(): Promise<MemberAccessResult> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return {
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Not authenticated" },
+        { status: 401 }
+      ),
+    }
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { emailVerified: true },
+  })
+  if (!user) {
+    return {
+      authorized: false,
+      response: NextResponse.json(
+        { success: false, error: "Not authenticated" },
+        { status: 401 }
+      ),
+    }
+  }
+  if (!user.emailVerified) {
+    return {
+      authorized: false,
+      response: NextResponse.json(
+        {
+          success: false,
+          error: "Please verify your email address first.",
+          code: "EMAIL_UNVERIFIED",
+        },
+        { status: 403 }
+      ),
+    }
+  }
+
+  return { authorized: true, email: session.user.email.toLowerCase() }
+}


### PR DESCRIPTION
## Summary

Approach A for Saturday's hackathon (120 confirmed): Luma registrants create accounts, complete a 2-minute matching profile from the dashboard, and see their team once a run is marked final. Built against the approved spec in `docs/superpowers/specs/2026-07-22-impact-lab-member-flow-design.md`.

## Surface

- **`GET/PUT /api/impact-lab/profile`** — own row only (session email, lowercased), verified-email gate, CSRF + rate-limit on PUT, 12 member-editable fields validated via the existing participant schema. No self-registration: no imported row → not registered (walk-ins stay admin-added).
- **`GET /api/impact-lab/team`** — team from the latest `isFinal` run. Numeric scores stripped (including embedded percentages in strength strings); teammate contacts only where `consentToShareContact`; frozen-run JSON shape-validated before use.
- **`/dashboard/impact-lab`** — states: not-registered / profile form (pre-filled) / waiting / unassigned / team reveal. Unverified email → `VerifyEmailBanner`, client never mounts.
- **Dashboard card** — status-aware, links to the page.

## Review & verification

- Built by a 5-phase orchestrated workflow (scout → implement → verify → adversarial security + correctness reviews → fix). 3 confirmed findings (all minor: unvalidated frozen-JSON cast, DB-error/not-registered conflation, +1) — all fixed.
- `npx tsc --noEmit` clean · `eslint` clean on new surface · `npm run verify:matching` ALL CHECKS PASSED.
- Local full `next build` blocked only by missing Supabase env in a pre-existing unrelated route; Vercel build expected green.

## Before Saturday

1. `npx prisma migrate deploy` against prod (PR #46 tables) — still pending.
2. Admin: import Luma CSV → blast WhatsApp group → profiles due Fri 6pm EAT → run match Fri night → mark final.