### PR TITLE
fix(admin): CSRF token on all admin mutations + sticky collapsible sidebar

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -67,7 +67,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     <AdminProviders>
       <div className="flex min-h-screen bg-[#0a0a0a]">
         <AdminSidebar />
-        <main className="flex-1 overflow-auto">{children}</main>
+        <main className="flex-1 min-w-0">{children}</main>
       </div>
     </AdminProviders>
   )

--- a/src/app/admin/photos/[id]/PhotoEditForm.tsx
+++ b/src/app/admin/photos/[id]/PhotoEditForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { AlertTriangle, Loader2, Trash2 } from "lucide-react"
+import { csrfHeaders, csrfToken } from "@/lib/csrf-client"
 
 interface EventOption {
   id: string
@@ -48,7 +49,7 @@ export function PhotoEditForm({ photo, events }: { photo: Photo; events: EventOp
     startTransition(async () => {
       const res = await fetch(`/api/admin/photos/${photo.id}`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: await csrfHeaders(),
         body: JSON.stringify(body),
       })
       const json = await res.json()
@@ -63,7 +64,10 @@ export function PhotoEditForm({ photo, events }: { photo: Photo; events: EventOp
   function handleDelete() {
     if (!window.confirm("Delete this photo? This is permanent.")) return
     startDelete(async () => {
-      await fetch(`/api/admin/photos/${photo.id}`, { method: "DELETE" })
+      await fetch(`/api/admin/photos/${photo.id}`, {
+        method: "DELETE",
+        headers: { "x-csrf-token": await csrfToken() },
+      })
       router.push("/admin/photos")
     })
   }

--- a/src/app/admin/photos/new/PhotoUploadForm.tsx
+++ b/src/app/admin/photos/new/PhotoUploadForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { AlertTriangle, Loader2, CheckCircle2 } from "lucide-react"
+import { csrfToken } from "@/lib/csrf-client"
 
 interface EventOption {
   id: string
@@ -32,6 +33,7 @@ export function PhotoUploadForm({ events }: { events: EventOption[] }) {
     startTransition(async () => {
       const res = await fetch("/api/admin/photos/upload", {
         method: "POST",
+        headers: { "x-csrf-token": await csrfToken() },
         body: data,
       })
       const json = (await res.json()) as { success: boolean; error?: string; data?: UploadResult }

--- a/src/app/admin/team/[id]/TeamMemberEditForm.tsx
+++ b/src/app/admin/team/[id]/TeamMemberEditForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { AlertTriangle, Loader2, Trash2 } from "lucide-react"
+import { csrfHeaders, csrfToken } from "@/lib/csrf-client"
 
 interface TeamMember {
   id: string
@@ -55,7 +56,7 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
     startTransition(async () => {
       const res = await fetch(`/api/admin/team/${member.id}`, {
         method: "PATCH",
-        headers: { "Content-Type": "application/json" },
+        headers: await csrfHeaders(),
         body: JSON.stringify(body),
       })
       const json = await res.json()
@@ -70,7 +71,10 @@ export function TeamMemberEditForm({ member }: { member: TeamMember }) {
   function handleDelete() {
     if (!confirm(`Delete ${member.name}? This cannot be undone.`)) return
     startDelete(async () => {
-      await fetch(`/api/admin/team/${member.id}`, { method: "DELETE" })
+      await fetch(`/api/admin/team/${member.id}`, {
+        method: "DELETE",
+        headers: { "x-csrf-token": await csrfToken() },
+      })
       router.push("/admin/team")
     })
   }

--- a/src/app/admin/team/new/TeamMemberNewForm.tsx
+++ b/src/app/admin/team/new/TeamMemberNewForm.tsx
@@ -3,6 +3,7 @@
 import { useState, useTransition } from "react"
 import { useRouter } from "next/navigation"
 import { AlertTriangle, Loader2 } from "lucide-react"
+import { csrfHeaders } from "@/lib/csrf-client"
 
 export function TeamMemberNewForm() {
   const router = useRouter()
@@ -35,7 +36,7 @@ export function TeamMemberNewForm() {
     startTransition(async () => {
       const res = await fetch("/api/admin/team", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: await csrfHeaders(),
         body: JSON.stringify(body),
       })
       const json = await res.json()

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
@@ -22,6 +23,8 @@ import {
   Sparkles,
   Camera,
   Network,
+  PanelLeftClose,
+  PanelLeftOpen,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -43,8 +46,26 @@ const navItems = [
   { href: "/admin/settings", label: "Settings", icon: Settings },
 ]
 
+const COLLAPSED_KEY = "cck-admin-sidebar-collapsed"
+
 export function AdminSidebar() {
   const pathname = usePathname()
+  const [collapsed, setCollapsed] = useState(false)
+  // localStorage is read after mount — reading it during render would make the
+  // server and client HTML disagree and trigger a hydration error.
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setCollapsed(localStorage.getItem(COLLAPSED_KEY) === "1")
+    setHydrated(true)
+  }, [])
+
+  function toggleCollapsed() {
+    setCollapsed((prev) => {
+      localStorage.setItem(COLLAPSED_KEY, prev ? "0" : "1")
+      return !prev
+    })
+  }
 
   function isActive(href: string, exact?: boolean) {
     if (exact) return pathname === href
@@ -52,58 +73,108 @@ export function AdminSidebar() {
   }
 
   return (
-    <aside className="w-64 min-h-screen bg-bg-secondary border-r border-border-default flex flex-col">
-      {/* Logo */}
-      <div className="p-5 border-b border-border-default">
-        <Link href="/admin" className="flex items-center gap-2.5 group">
-          <div className="w-8 h-8 rounded bg-green-primary/10 border border-green-primary/30 flex items-center justify-center">
+    <aside
+      className={cn(
+        "sticky top-0 h-screen shrink-0 bg-bg-secondary border-r border-border-default flex flex-col",
+        hydrated && "transition-[width] duration-200 motion-reduce:transition-none",
+        collapsed ? "w-16" : "w-64"
+      )}
+    >
+      {/* Logo + collapse toggle */}
+      <div
+        className={cn(
+          "border-b border-border-default flex items-center",
+          collapsed ? "p-3 justify-center" : "p-5 justify-between"
+        )}
+      >
+        <Link
+          href="/admin"
+          className="flex items-center gap-2.5 group"
+          title={collapsed ? "CCK Admin Panel" : undefined}
+        >
+          <div className="w-8 h-8 rounded bg-green-primary/10 border border-green-primary/30 flex items-center justify-center shrink-0">
             <Terminal className="w-4 h-4 text-green-primary" />
           </div>
-          <div>
-            <div className="text-xs font-mono font-bold text-green-primary leading-none">CCK</div>
-            <div className="text-[10px] font-mono text-text-dim leading-none mt-0.5">Admin Panel</div>
-          </div>
+          {!collapsed && (
+            <div>
+              <div className="text-xs font-mono font-bold text-green-primary leading-none">CCK</div>
+              <div className="text-[10px] font-mono text-text-dim leading-none mt-0.5">Admin Panel</div>
+            </div>
+          )}
         </Link>
+        {!collapsed && (
+          <button
+            onClick={toggleCollapsed}
+            aria-label="Collapse sidebar"
+            aria-expanded="true"
+            className="p-1.5 rounded text-text-dim hover:text-text-primary hover:bg-bg-card transition-colors"
+          >
+            <PanelLeftClose className="w-4 h-4" />
+          </button>
+        )}
       </div>
 
-      {/* Navigation */}
-      <nav className="flex-1 p-3 space-y-0.5">
+      {/* Expand button when collapsed */}
+      {collapsed && (
+        <div className="p-3 border-b border-border-default flex justify-center">
+          <button
+            onClick={toggleCollapsed}
+            aria-label="Expand sidebar"
+            aria-expanded="false"
+            title="Expand sidebar"
+            className="p-1.5 rounded text-text-dim hover:text-text-primary hover:bg-bg-card transition-colors"
+          >
+            <PanelLeftOpen className="w-4 h-4" />
+          </button>
+        </div>
+      )}
+
+      {/* Navigation — scrolls internally, the rail itself stays pinned */}
+      <nav className={cn("flex-1 overflow-y-auto p-3 space-y-0.5", collapsed && "p-2")}>
         {navItems.map(({ href, label, icon: Icon, exact }) => {
           const active = isActive(href, exact)
           return (
             <Link
               key={href}
               href={href}
+              title={collapsed ? label : undefined}
               className={cn(
-                "flex items-center gap-3 px-3 py-2.5 rounded text-sm font-mono transition-all group",
+                "flex items-center gap-3 rounded text-sm font-mono transition-all group",
+                collapsed ? "px-0 py-2.5 justify-center" : "px-3 py-2.5",
                 active
                   ? "bg-green-primary/10 text-green-primary border border-green-primary/20"
                   : "text-text-secondary hover:text-text-primary hover:bg-bg-card border border-transparent"
               )}
             >
               <Icon className={cn("w-4 h-4 flex-shrink-0", active ? "text-green-primary" : "text-current")} />
-              <span className="flex-1">{label}</span>
-              {active && <ChevronRight className="w-3 h-3 text-green-primary" />}
+              {!collapsed && <span className="flex-1">{label}</span>}
+              {!collapsed && active && <ChevronRight className="w-3 h-3 text-green-primary" />}
             </Link>
           )
         })}
       </nav>
 
       {/* Sign Out */}
-      <div className="p-3 border-t border-border-default">
+      <div className={cn("border-t border-border-default", collapsed ? "p-2" : "p-3")}>
         <button
           onClick={() => signOut({ callbackUrl: "/admin/login" })}
-          className="w-full flex items-center gap-3 px-3 py-2.5 rounded text-sm font-mono text-text-dim hover:text-red hover:bg-red/10 border border-transparent hover:border-red/20 transition-all"
+          title={collapsed ? "Sign Out" : undefined}
+          className={cn(
+            "w-full flex items-center gap-3 rounded text-sm font-mono text-text-dim hover:text-red hover:bg-red/10 border border-transparent hover:border-red/20 transition-all",
+            collapsed ? "px-0 py-2.5 justify-center" : "px-3 py-2.5"
+          )}
         >
           <LogOut className="w-4 h-4" />
-          <span>Sign Out</span>
+          {!collapsed && <span>Sign Out</span>}
         </button>
-        <Link
-          href="/"
-          className="mt-1 w-full flex items-center gap-3 px-3 py-2 rounded text-xs font-mono text-text-dim hover:text-text-secondary transition-colors"
-        >
-          <span>← Back to site</span>
-        </Link>
+        {!collapsed && (
+          <Link
+            href="/"
+            className="mt-1 w-full flex items-center gap-3 px-3 py-2 rounded text-xs font-mono text-text-dim hover:text-text-secondary transition-colors"
+          >
+            <span>← Back to site</span>
+          </Link>
+        )}
       </div>
     </aside>
   )

--- a/src/components/admin/AdminUserManager.tsx
+++ b/src/components/admin/AdminUserManager.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "lucide-react"
 import { formatDate } from "@/lib/utils"
+import { csrfHeaders } from "@/lib/csrf-client"
 
 interface AdminUser {
   id: string
@@ -80,7 +81,7 @@ export function AdminUserManager({
       try {
         const res = await fetch("/api/admin/settings/users", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: await csrfHeaders(),
           body: JSON.stringify(addForm),
         })
         const data = await res.json()
@@ -108,7 +109,7 @@ export function AdminUserManager({
       try {
         const res = await fetch(`/api/admin/settings/users/${userId}`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: await csrfHeaders(),
           body: JSON.stringify({ active: !currentActive }),
         })
         const data = await res.json()
@@ -131,7 +132,7 @@ export function AdminUserManager({
       try {
         const res = await fetch(`/api/admin/settings/users/${userId}`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: await csrfHeaders(),
           body: JSON.stringify({ role: newRole }),
         })
         const data = await res.json()
@@ -159,7 +160,7 @@ export function AdminUserManager({
       try {
         const res = await fetch(`/api/admin/settings/users/${userId}`, {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: await csrfHeaders(),
           body: JSON.stringify({ resetPassword: newPassword }),
         })
         const data = await res.json()

--- a/src/components/admin/ChangePasswordForm.tsx
+++ b/src/components/admin/ChangePasswordForm.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react"
 import { Lock, Loader2, CheckCircle, AlertTriangle } from "lucide-react"
+import { csrfHeaders } from "@/lib/csrf-client"
 
 export function ChangePasswordForm() {
   const [isPending, startTransition] = useTransition()
@@ -28,7 +29,7 @@ export function ChangePasswordForm() {
       try {
         const res = await fetch("/api/admin/settings/change-password", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: await csrfHeaders(),
           body: JSON.stringify({ currentPassword, newPassword }),
         })
         const data = await res.json()

--- a/src/components/admin/SiteStatsEditor.tsx
+++ b/src/components/admin/SiteStatsEditor.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useTransition } from "react"
 import { BarChart3, Save, Loader2, CheckCircle } from "lucide-react"
+import { csrfHeaders } from "@/lib/csrf-client"
 
 interface SiteStats {
   discordMembers: number
@@ -33,7 +34,7 @@ export function SiteStatsEditor({ initialStats }: { initialStats: SiteStats }) {
       try {
         const res = await fetch("/api/admin/settings/stats", {
           method: "PATCH",
-          headers: { "Content-Type": "application/json" },
+          headers: await csrfHeaders(),
           body: JSON.stringify({ ...stats, citiesActive }),
         })
         const data = await res.json()

--- a/src/lib/csrf-client.ts
+++ b/src/lib/csrf-client.ts
@@ -1,0 +1,18 @@
+/**
+ * Client-side CSRF helpers.
+ *
+ * Every state-changing request to /api/* must carry an `x-csrf-token` header —
+ * `withCsrfProtection` on the server rejects it with 403 otherwise. Use
+ * `csrfHeaders()` for JSON bodies and `csrfToken()` alone for FormData uploads
+ * (setting Content-Type manually would break the multipart boundary).
+ */
+
+export async function csrfToken(): Promise<string> {
+  const res = await fetch("/api/csrf-token")
+  const { csrfToken: token } = (await res.json()) as { csrfToken: string }
+  return token
+}
+
+export async function csrfHeaders(): Promise<Record<string, string>> {
+  return { "Content-Type": "application/json", "x-csrf-token": await csrfToken() }
+}


### PR DESCRIPTION
## What

Two admin-panel fixes:

**1. CSRF client fix (production-blocking).** Seven admin forms posted mutations without the `x-csrf-token` header the API enforces, so every one of them failed with 403 in production — including creating a new admin user:

- `AdminUserManager` (create user, toggle active, change role, reset password)
- `ChangePasswordForm`
- `SiteStatsEditor`
- Photo upload / edit / delete
- Team member new / edit / delete

Adds a shared `src/lib/csrf-client.ts` (`csrfHeaders()` for JSON bodies, `csrfToken()` alone for FormData uploads so the multipart boundary is preserved) and wires it into all seven forms.

**2. Sticky, collapsible sidebar.** The sidebar sat in normal document flow and scrolled away on any page taller than the viewport. Now pinned (`sticky top-0 h-screen`) with internal nav scroll, collapsible to an icon rail — state persisted in localStorage, tooltips on collapsed items, `aria-expanded` on the toggle, width transition disabled under `prefers-reduced-motion`. `main` gets `min-w-0` so wide tables can't stretch the layout.

## Verification

- `npx tsc --noEmit` clean
- `npm run build` clean

## Note

Prod DB migrations for Impact Lab (`20260721160000`, `20260722120000`) were applied to the VPS on 2026-07-23 — the P2021 errors on `/api/admin/impact-lab/*` are already resolved independent of this PR.

@Spidey-Acer