### PR TITLE
docs(credits): credit Edwin Lungatso for the Impact Lab matching system

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,15 @@
+# Contributors
+
+The people who have built and maintain the Claude Community Kenya website.
+
+## Maintainer
+
+- **Peter Kibet** ([@Spidey-Acer](https://github.com/Spidey-Acer)) — Founder, Claude Community Kenya. Site architecture, design system, and ongoing maintenance.
+
+## Contributors
+
+- **Edwin Lungatso** ([@best-ed](https://github.com/best-ed)) — Co-organizer. Impact Lab team-matching system: deterministic matching engine (`src/lib/matching/`), Claude explanation layer, admin matching tools, and CSV import/export. Adapted from his own [HackMatch-AI](https://github.com/best-ed/HackMatch-AI) project.
+
+## How to join this list
+
+Contributions are welcome — see the [Contributing Guide](./CONTRIBUTING.md), pick an issue, and open a pull request. Meaningful contributions get credited here.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ Contributions are welcome! Please read the [Contributing Guide](./CONTRIBUTING.m
 - Request features via [GitHub Issues](https://github.com/Spidey-Acer/Claude-Community-Kenya/issues)
 - Join the community on [Discord](https://discord.gg/CkD9QWjsHm)
 
+See [CONTRIBUTORS.md](./CONTRIBUTORS.md) for the people behind the code.
+
+## Credits
+
+- **[Edwin Lungatso](https://github.com/best-ed)** (Co-organizer) — designed and built the **Impact Lab team-matching system**: the deterministic matching engine, the Claude-powered explanation layer, and the admin tooling. Based on his own [HackMatch-AI](https://github.com/best-ed/HackMatch-AI) project.
+
 ## Community Links
 
 | Platform | Link |


### PR DESCRIPTION
Adds a **Credits** section to the README and a new **CONTRIBUTORS.md** crediting Edwin Lungatso ([@best-ed](https://github.com/best-ed)) for designing and building the Impact Lab team-matching system — the deterministic matching engine, the Claude explanation layer, the admin tooling, and CSV import/export — adapted from his own [HackMatch-AI](https://github.com/best-ed/HackMatch-AI) project.

Docs only, no code changes.

@Spidey-Acer