### PR TITLE
feat(impact-lab): import raw Luma guest exports, approved guests only

### DIFF
--- a/src/components/admin/impact-lab/ParticipantsTab.tsx
+++ b/src/components/admin/impact-lab/ParticipantsTab.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { Loader2, Plus, Trash2, Upload, Download } from "lucide-react"
 import { apiGet, apiSend } from "./api"
+import { isLumaExport, mapLumaRows } from "@/lib/impact-lab/luma"
 import type { ParticipantRow } from "./types"
 
 const EXPERIENCE = ["BEGINNER", "INTERMEDIATE", "ADVANCED"] as const
@@ -125,8 +126,30 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
     setBusy(true)
     setImportMsg(null)
     try {
-      const rows = parseCsv(await file.text())
+      // Luma exports lead with a UTF-8 BOM; strip it or the first header
+      // ("guest_id") never matches and format detection silently fails.
+      const rows = parseCsv((await file.text()).replace(/^\uFEFF/, ""))
       if (rows.length < 2) throw new Error("CSV has no data rows")
+
+      if (isLumaExport(rows[0])) {
+        const luma = mapLumaRows(rows[0], rows.slice(1))
+        if (luma.drafts.length === 0) {
+          throw new Error("No approved guests with an email found in this Luma export")
+        }
+        const result = await apiSend<{ created: number; updated: number; failed: number }>(
+          "/api/admin/impact-lab/participants/import",
+          "POST",
+          { cohort, participants: luma.drafts }
+        )
+        setImportMsg(
+          `Luma export: ${result.created} added, ${result.updated} updated, ${result.failed} skipped` +
+            ` · ${luma.notApproved} not approved ignored` +
+            (luma.missingEmail ? ` · ${luma.missingEmail} approved without email skipped` : "")
+        )
+        await load()
+        return
+      }
+
       const headers = rows[0].map((h) => h.trim().toLowerCase())
       // Accept a few common header spellings so a raw Luma/Google Forms export
       // doesn't silently import zero rows.
@@ -208,8 +231,9 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
       </div>
 
       <p className="text-[10px] font-mono text-[#444]">
-        Import expects comma-delimited UTF-8 with headers matching the Export
-        format (fullName, email, primaryRole, …); multi-value cells split on ; or ,.
+        Import accepts a raw Luma guest export (only approved guests are pulled;
+        waitlist/declined ignored) or the Export format (fullName, email,
+        primaryRole, …); multi-value cells split on ; or ,.
       </p>
       {importMsg && (
         <div className="p-2 bg-[#00d4ff]/10 border border-[#00d4ff]/30 rounded text-[11px] font-mono text-[#00d4ff]">{importMsg}</div>

--- a/src/lib/impact-lab/luma.ts
+++ b/src/lib/impact-lab/luma.ts
@@ -1,0 +1,135 @@
+/**
+ * Maps a raw Luma guest-list export onto participant drafts for the Impact Lab
+ * importer. Luma's export is one row per registrant with the event's custom
+ * registration questions as literal header strings; only guests with
+ * `approval_status === "approved"` are eligible — everyone else (waitlist,
+ * declined, pending) is dropped and counted so the organiser sees the split.
+ *
+ * All values are clamped client-side to the participant schema's limits —
+ * a single over-long free-text answer must not fail the whole row server-side.
+ */
+
+/** Columns that identify a Luma guest export (vs our own Export format). */
+const LUMA_SIGNATURE = ["guest_id", "approval_status"]
+
+/** Luma question headers we map. Matched case-insensitively by prefix so minor
+ * wording tweaks in the Luma form don't silently break the import. */
+const QUESTION_PREFIXES = {
+  experience: "what is your experience level with claude code",
+  capabilities: "which claude code capabilities are you most interested",
+  institution: "where do you work or study",
+  role: "what is your role?",
+  track: "your track - each carries one fixed problem",
+  trackSecond: "second choice, if your first track fills up",
+  demoSlice: "what will exist and work by",
+  teamStatus: "teams are 3-5 people",
+  teammates: "if you have team-mates",
+  fullNight: "can you commit to the full night",
+} as const
+
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[\w.-]+/g
+const FULL_TEAM_PREFIX = "i have a full team"
+
+// participant-schema.ts limits — kept in sync manually (the zod schema is the
+// source of truth; these only pre-clamp so rows survive validation).
+const MAX_NAME = 120
+const MAX_PHONE = 30
+const MAX_INSTITUTION = 120
+const MAX_ROLE = 60
+const MAX_TOKEN = 80
+const MAX_TOKENS = 30
+const MAX_IDEAS = 2000
+
+export interface LumaImportResult {
+  drafts: Record<string, unknown>[]
+  approved: number
+  notApproved: number
+  missingEmail: number
+}
+
+export function isLumaExport(headers: string[]): boolean {
+  const lower = headers.map((h) => h.trim().toLowerCase())
+  return LUMA_SIGNATURE.every((sig) => lower.includes(sig))
+}
+
+function clamp(value: string, max: number): string {
+  return value.trim().slice(0, max)
+}
+
+function tokens(value: string): string[] {
+  return value
+    .split(/[;,]/)
+    .map((s) => clamp(s, MAX_TOKEN))
+    .filter(Boolean)
+    .slice(0, MAX_TOKENS)
+}
+
+function mapExperience(answer: string): "BEGINNER" | "INTERMEDIATE" | "ADVANCED" {
+  const a = answer.toLowerCase()
+  if (a.startsWith("daily")) return "ADVANCED"
+  if (a.startsWith("regular")) return "INTERMEDIATE"
+  return "BEGINNER"
+}
+
+export function mapLumaRows(headers: string[], rows: string[][]): LumaImportResult {
+  const lower = headers.map((h) => h.trim().toLowerCase())
+  const col = (name: string) => lower.indexOf(name)
+  const question = (prefix: string) => lower.findIndex((h) => h.startsWith(prefix))
+
+  const iName = col("name")
+  const iEmail = col("email")
+  const iPhone = col("phone_number")
+  const iStatus = col("approval_status")
+  const q = Object.fromEntries(
+    Object.entries(QUESTION_PREFIXES).map(([key, prefix]) => [key, question(prefix)])
+  ) as Record<keyof typeof QUESTION_PREFIXES, number>
+
+  const drafts: Record<string, unknown>[] = []
+  let approved = 0
+  let notApproved = 0
+  let missingEmail = 0
+
+  for (const row of rows) {
+    const get = (i: number) => (i >= 0 ? (row[i] ?? "").trim() : "")
+
+    if (get(iStatus).toLowerCase() !== "approved") {
+      notApproved++
+      continue
+    }
+    approved++
+
+    const email = get(iEmail)
+    if (!email) {
+      missingEmail++
+      continue
+    }
+
+    const teamStatus = get(q.teamStatus).toLowerCase()
+    const interests = [get(q.track), get(q.trackSecond)]
+      .map((v) => clamp(v, MAX_TOKEN))
+      .filter(Boolean)
+
+    drafts.push({
+      fullName: clamp(get(iName), MAX_NAME) || email,
+      email,
+      phone: clamp(get(iPhone), MAX_PHONE) || null,
+      institution: clamp(get(q.institution), MAX_INSTITUTION) || null,
+      experienceLevel: mapExperience(get(q.experience)),
+      primaryRole: clamp(get(q.role), MAX_ROLE) || "Participant",
+      secondaryRoles: [],
+      technicalSkills: tokens(get(q.capabilities)),
+      interests,
+      availability: /^yes/i.test(get(q.fullNight)) ? ["full-night"] : [],
+      projectIdeas: clamp(get(q.demoSlice), MAX_IDEAS) || null,
+      preferredTeammates: (get(q.teammates).match(EMAIL_PATTERN) ?? []).slice(0, MAX_TOKENS),
+      blockedTeammates: [],
+      // Pre-formed full teams are placed manually by organisers (locked
+      // teams), so the matcher must not move them; everyone else approved
+      // registered for a team-formation event and is matchable.
+      consentToMatch: !teamStatus.startsWith(FULL_TEAM_PREFIX),
+      consentToShareContact: false,
+    })
+  }
+
+  return { drafts, approved, notApproved, missingEmail }
+}


### PR DESCRIPTION
The importer only understood its own Export headers, so a raw Luma guest-list CSV imported zero rows and had no approval filter.

## What

- New `src/lib/impact-lab/luma.ts`: detects a Luma export by its `guest_id`/`approval_status` columns and pulls **only `approval_status=approved`** rows (waitlist/declined ignored, counts shown in the import message).
- Maps registration questions → participant schema: experience (Daily→ADVANCED, Regular→INTERMEDIATE, else BEGINNER), track + second choice → interests, capabilities → technicalSkills, teammate list → preferredTeammates (emails extracted), full-night commitment → availability.
- Guests declaring **"I have a full team"** import with `consentToMatch=false` so the matcher leaves them for manual locked-team placement (@best-ed — flag if you'd rather handle that differently).
- All values clamped to schema limits client-side so one long free-text answer can't fail a row; strips the UTF-8 BOM Luma prepends (it broke header detection).

## Verification

Ran the real 2026-07-23 export through the exact pipeline (parser → mapper → `participantDraftSchema`): 293 rows → 120 approved, **120/120 valid**, 172 waitlisted ignored, 89 matchable + 31 full-team, 46 with extracted teammate emails. `tsc` + `next build` clean.

(Originally pushed to #48 as `cc56fc0` but that PR was merged moments earlier, so the commit never reached main — this PR carries it.)

@Spidey-Acer