### PR TITLE
fix(impact-lab): give the import transaction a 55s timeout

### DIFF
--- a/src/app/api/admin/impact-lab/participants/import/route.ts
+++ b/src/app/api/admin/impact-lab/participants/import/route.ts
@@ -84,17 +84,25 @@ export async function POST(request: NextRequest) {
 
   let created = 0
   let updated = 0
-  const ops = drafts.map((draft) => {
-    const id = idByEmail.get(draft.email)
-    if (id) {
-      updated++
-      return prisma.impactLabParticipant.update({ where: { id }, data: draft })
-    }
-    created++
-    return prisma.impactLabParticipant.create({ data: { ...draft, cohort } })
-  })
-
-  await prisma.$transaction(ops)
+  // Prisma's default 5s transaction timeout is too tight for a full-cohort
+  // import through PgBouncer (120 rows took ~5.2s in prod — P2028 rollback).
+  // maxDuration above is 60s; give the transaction most of that budget. The
+  // batch (array) form can't take a timeout, so this is an interactive tx.
+  await prisma.$transaction(
+    async (tx) => {
+      for (const draft of drafts) {
+        const id = idByEmail.get(draft.email)
+        if (id) {
+          await tx.impactLabParticipant.update({ where: { id }, data: draft })
+          updated++
+        } else {
+          await tx.impactLabParticipant.create({ data: { ...draft, cohort } })
+          created++
+        }
+      }
+    },
+    { timeout: 55_000, maxWait: 10_000 }
+  )
 
   await logAudit({
     userId: check.user.id,


### PR DESCRIPTION
Prod import of the real 120-guest Luma cohort failed with **P2028** — the batch `$transaction` hit Prisma's default 5s transaction timeout at ~5.2s through PgBouncer and rolled the entire import back (the route 500'd with an empty body, surfacing as "Unexpected end of JSON input" in the admin UI).

Switched to an interactive transaction with `timeout: 55_000, maxWait: 10_000` (the array form can't take a timeout), inside the route's existing `maxDuration = 60`. Semantics unchanged: all-or-nothing, same created/updated counts. Headroom covers the 500-row import cap (~22s at prod latency).

Log evidence (2026-07-23 11:45:59 UTC): `Transaction API error: ... timeout for this transaction was 5000 ms, however 5247 ms passed`.

`tsc` + `next build` clean.

@Spidey-Acer