### PR TITLE
feat(impact-lab): event-ready matching — keep declared teammates together, consent off, dashboards elevated

### DIFF
--- a/docs/impact-lab/04-constraints.md
+++ b/docs/impact-lab/04-constraints.md
@@ -32,6 +32,11 @@ want to work with B, we keep them apart whether or not B reciprocated. Blocks ar
 the one place `blockedTeammates` is read — and it's read only here, never passed
 to scoring, explanations, or the AI layer. Privacy by data-flow, not by promise.
 
+Blocks reach one step further than placement: `groups.ts` ([06](./06-algorithm.md))
+calls this same `participantsConflict` before turning a declared preferred-teammate
+into a keep-together edge, so a blocked pair can never be unioned into the same
+group either. Blocks beat preferences at every stage, not just at placement time.
+
 ### 3. Locked teams — pass through untouched
 
 `resolveLockedTeams` maps organiser-pinned teams (given by email, the identifier

--- a/docs/impact-lab/05-scoring.md
+++ b/docs/impact-lab/05-scoring.md
@@ -33,8 +33,11 @@ total       = clamp(base − Σ penalties, 0, 100)
 Normalizing by `maxWeighted` means the total is always on a 0–100 scale
 regardless of how the weights are set — an organiser can double a weight without
 blowing the scale. Default weights (role coverage 2, skill 1.5, experience 1.4,
-interest 1, availability 1, preferences 0.8) come straight from the spec and live
-in `constants.ts`.
+interest 2.5, availability 1, preferences 0.8) live in `constants.ts`.
+`interestAlignment` was raised from the spec's original 1 to sit alongside
+`roleCoverage` at the top: for this event, interests carry each participant's
+declared track choice, and each track is one fixed problem, so aligning on
+interests now means aligning on the actual problem a team will build.
 
 ## Penalties are separate from dimensions — deliberately
 

--- a/docs/impact-lab/06-algorithm.md
+++ b/docs/impact-lab/06-algorithm.md
@@ -9,8 +9,9 @@ the locally best legal move, then (next commit) polish with swaps.
 ## The pipeline
 
 ```
-consent filter → normalize → resolve locked teams → size the run
-   → seed → distribute advanced → greedy fill → optimize → assemble
+consent filter → normalize → resolve locked teams → resolve together-groups
+   → size the run → place groups → seed remaining empties → distribute advanced
+   → greedy fill → optimize → assemble
 ```
 
 ### Step 4 — sizing the run
@@ -21,11 +22,26 @@ teams that nobody is forced above `maxTeamSize`, and (b) we never make more team
 than we have people. Locked teams are *additional* — the count sizes only the
 unlocked pool.
 
-### Step 5 — seeding (the clever bit)
+### Step 5 — together-groups, then seeding (the clever bit)
 
-We sort the pool by, in order: **role priority** (presenter → builder),
-**scarcity** (rarer primary role first), **experience** (advanced first), then
-id. Then we drop the first *N* onto the *N* teams, one each.
+**Together-groups place first.** When `keepPreferredTogether` is on (the
+default), participants who declared each other as preferred teammates were
+already resolved, before sizing, into whole groups by a union-find over the
+unlocked pool ([groups.ts](../../src/lib/matching/groups.ts)) — blocked pairs
+never link (see [04](./04-constraints.md)), and a chain longer than
+`maxTeamSize` was already split, deterministically in id order, into
+max-sized chunks with a warning. Each group lands here, as a unit, on the
+team — among those it doesn't block-conflict with — with the best summed
+marginal contribution, ties broken by smaller team then team index. Groups
+place *before* seeding so they claim empty teams first; a group that
+block-conflicts with every team goes unassigned with a warning rather than
+sit next to a blocker. With the flag off, declared preferences revert to the
+old soft `+6` bonus applied during greedy fill below.
+
+**Then seeding.** We sort whatever's left of the pool by, in order: **role
+priority** (presenter → builder), **scarcity** (rarer primary role first),
+**experience** (advanced first), then id. Then we drop the first *N* onto the
+*N* teams still empty, one each.
 
 Why this spreads scarce roles correctly: if presenters are both high-priority and
 scarce, they sort to the front, so the first few teams each get one presenter —
@@ -53,7 +69,10 @@ marginal = score(team + candidate) − score(team)     // how much they help
 
 The size penalty is what keeps teams balanced instead of everyone landing on the
 one strong team. The preferred-teammate bonus is soft — it steers ties, it never
-overrides score or a hard constraint.
+overrides score or a hard constraint. Grouped members never reach this step at
+all (they were already placed in Step 5); the bonus only fires for a
+preference that didn't resolve into a group — a teammate outside the pool, or
+`keepPreferredTogether` turned off.
 
 If nobody's a legal home: unassigned (when allowed), else the least-bad
 block-legal team even if it goes over max — the size penalty then shows up

--- a/docs/impact-lab/07-optimization.md
+++ b/docs/impact-lab/07-optimization.md
@@ -38,6 +38,12 @@ Two properties make this safe:
    and skips illegal ones. Hard constraints still win, always.
 2. **Locked teams must not move.** They're filtered out before optimization and
    spliced back untouched in their original positions.
+3. **Together-group members must not move either.** A group is a hard unit from
+   placement onward, so a swap that pulled one member out would silently break
+   it. Unlike locked teams, grouped members stay in the optimizable pool — the
+   loop just skips any candidate found in `context.pinnedTogetherIds`
+   ([groups.ts](../../src/lib/matching/groups.ts)), the same set the algorithm
+   populated in [06, Step 5](./06-algorithm.md).
 
 ## Determinism, again
 

--- a/docs/impact-lab/09-verification.md
+++ b/docs/impact-lab/09-verification.md
@@ -32,11 +32,25 @@ Exit 0 = all checks passed; exit 1 = something regressed.
 - the locked team keeps exactly its pinned members,
 - every score lands in `[0, 100]`.
 
+**Together-groups** — the keep-together mechanism from [06](./06-algorithm.md):
+- a declared pair and a declared trio each land on one team,
+- someone who both asked for and blocked the same person never joins them —
+  blocks beat preferences even at group-forming time,
+- a run reports how many declared groups it kept together,
+- a preference chain longer than `maxTeamSize` is split with an explicit
+  warning, and no resulting team exceeds the max,
+- with `keepPreferredTogether` off, no keep-together warnings appear, and that
+  soft-preference run is itself still deterministic.
+
 ## The fixture is chosen to exercise the hard paths
 
 It isn't random data. It deliberately includes:
 - a **block** (Felix blocks Amina) — the run proves they never share a team,
-- a **preference** (Cynthia wants Amina) — visibly satisfied in the output,
+  and that his preference for her never unions them into a group either,
+- a declared-teammate **pair** (Cynthia → Amina) and **trio** (James, David,
+  Grace) — proven to land on one team each, now a hard keep-together rather
+  than a soft nudge; a separate 8-person chain fixture proves an over-length
+  chain is split into `maxTeamSize` chunks with a warning,
 - three **advanced** participants — to show they get distributed, not clustered,
 - a **locked pair** — pinned, undersized, and correctly penalised rather than
   quietly "fixed",

--- a/docs/impact-lab/11-api.md
+++ b/docs/impact-lab/11-api.md
@@ -49,6 +49,28 @@ Import upserts on `(cohort, email)` — re-importing a corrected sheet updates
 existing people instead of duplicating them, which the scoped unique index makes
 safe.
 
+## Luma guest-list import is auto-detected
+
+`isLumaExport(headers)` ([`luma.ts`](../../src/lib/impact-lab/luma.ts)) flags a
+CSV as a Luma export by the presence of Luma's own `guest_id` and
+`approval_status` columns. When detected, `mapLumaRows` maps Luma's custom
+registration questions onto participant drafts by case-insensitive header
+**prefix**, so a minor wording tweak in the Luma form doesn't silently break
+the import; only `approval_status === "approved"` rows become participants,
+with `notApproved` and `missingEmail` counted so the organiser sees the split
+rather than a silently truncated list.
+
+Every approved, emailed guest now imports with `consentToMatch: true` and
+`consentToShareContact: true` — an organiser decision (2026-07-24) that
+everyone who registered for a team-formation event is matchable and may share
+contact details with teammates, with an opt-out still available from the
+participant's own profile afterward. This replaces the earlier behaviour of
+importing full-team declarers with `consentToMatch: false` for manual locked
+placement: pre-formed teams named in the "if you have team-mates" question now
+stay together automatically through the together-groups mechanism
+([06](./06-algorithm.md)) instead of requiring the organiser to hand-build a
+locked team.
+
 ## Why `blockedTeammates` is in export but not the AI payload
 
 The participant CSV export includes `blockedTeammates` because it's the

--- a/docs/impact-lab/README.md
+++ b/docs/impact-lab/README.md
@@ -28,12 +28,12 @@ output.
 | 03 | [Normalization](./03-normalization.md) | Canonicalizing messy input; the determinism backbone |
 | 04 | [Constraints](./04-constraints.md) | The four hard rules; hard vs soft |
 | 05 | [Scoring](./05-scoring.md) | Six weighted dimensions; penalties; the transparent breakdown |
-| 06 | [Algorithm](./06-algorithm.md) | Seed → distribute → greedy fill; the seeding sort trick |
+| 06 | [Algorithm](./06-algorithm.md) | Together-groups → seed → distribute → greedy fill; the seeding sort trick |
 | 07 | [Optimization](./07-optimization.md) | Pairwise-swap local search; keeping constraints safe |
 | 08 | [Explanations](./08-explanations.md) | The deterministic fallback, built first |
 | 09 | [Verification](./09-verification.md) | Asserting determinism + constraint compliance without a test runner |
 | 10 | [AI layer](./10-ai-layer.md) | Claude explains-only; privacy by data-flow; fail-open |
-| 11 | [API layer](./11-api.md) | Routes, shared helpers, resilient CSV import |
+| 11 | [API layer](./11-api.md) | Routes, shared helpers, resilient CSV + Luma import |
 | 12 | [Admin UI](./12-admin-ui.md) | The three tabs; rendering the score breakdown |
 | 13 | [Audit hardening](./13-hardening.md) | Security/perf fixes from the PR review, and why |
 

--- a/scripts/verify-matching.ts
+++ b/scripts/verify-matching.ts
@@ -74,6 +74,7 @@ const PARTICIPANTS: MatchParticipant[] = [
     technicalSkills: ["roadmapping"],
     interests: ["fintech"],
     blockedTeammates: ["amina@x.io"], // Felix should never be with Amina
+    preferredTeammates: ["amina@x.io"], // …even though he asked for her: blocks win
   }),
   p("u07", "Grace", "grace@x.io", "BEGINNER", "Designer", {
     technicalSkills: ["design"],
@@ -90,6 +91,9 @@ const PARTICIPANTS: MatchParticipant[] = [
   p("u10", "James", "james@x.io", "BEGINNER", "Developer", {
     technicalSkills: ["html", "css"],
     interests: ["health"],
+    // Declared trio — James named both; neither named him back. One-way
+    // declarations are the Luma norm (one member fills the form for the team).
+    preferredTeammates: ["david@x.io", "grace@x.io"],
   }),
   p("u11", "Khadija", "khadija@x.io", "INTERMEDIATE", "Data analyst", {
     technicalSkills: ["sql", "viz"],
@@ -227,6 +231,65 @@ assert(alpha != null, "the pinned locked team is present in the result")
 assert(
   JSON.stringify(alphaIds) === JSON.stringify([emailToId.get("maria@x.io"), emailToId.get("noah@x.io")].sort()),
   "locked team contains exactly its pinned members, unchanged"
+)
+
+console.log("\nDeclared-teammate groups (keepPreferredTogether)")
+function teamOf(run: typeof runA, id: string): string | null {
+  return run.teams.find((t) => t.memberIds.includes(id))?.id ?? null
+}
+assert(
+  teamOf(runA, "u03") !== null && teamOf(runA, "u03") === teamOf(runA, "u01"),
+  "Cynthia is on Amina's team — a declared preference is a hard keep-together"
+)
+assert(
+  teamOf(runA, "u10") !== null &&
+    teamOf(runA, "u10") === teamOf(runA, "u04") &&
+    teamOf(runA, "u10") === teamOf(runA, "u07"),
+  "James's declared trio (James, David, Grace) shares one team"
+)
+assert(
+  teamOf(runA, "u06") !== teamOf(runA, "u01"),
+  "Felix asked for Amina but blocked her — blocks beat preferences"
+)
+assert(
+  runA.warnings.some((w) => w.includes("kept together")),
+  "run reports how many declared groups were kept together"
+)
+
+// With the flag off, preferences are soft again: run must still succeed and
+// carry no keep-together warning.
+const softRun = runMatching(PARTICIPANTS, {
+  ...SETTINGS,
+  keepPreferredTogether: false,
+})
+assert(
+  !softRun.warnings.some((w) => w.includes("kept together")),
+  "keepPreferredTogether=false produces no keep-together warnings"
+)
+assert(
+  JSON.stringify(softRun) ===
+    JSON.stringify(runMatching(PARTICIPANTS, { ...SETTINGS, keepPreferredTogether: false })),
+  "soft-preference mode is still deterministic"
+)
+
+// A preference chain longer than maxTeamSize must be split with a warning,
+// and no resulting team may exceed the max.
+const CHAIN: MatchParticipant[] = [
+  "c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8",
+].map((id, i) =>
+  p(id, `Chain${i + 1}`, `${id}@x.io`, "INTERMEDIATE", "Developer", {
+    // c1→c2→…→c6 declared in a line: unions into one 6-person group (> max 5).
+    preferredTeammates: i < 5 ? [`c${i + 2}@x.io`] : [],
+  })
+)
+const chainRun = runMatching(CHAIN, { ...DEFAULT_SETTINGS, lockedTeams: [] })
+assert(
+  chainRun.warnings.some((w) => w.includes("was split")),
+  "an oversized declared chain is split with an explicit warning"
+)
+assert(
+  chainRun.teams.every((t) => t.memberIds.length <= DEFAULT_SETTINGS.maxTeamSize),
+  "no team exceeds maxTeamSize even with an oversized declared chain"
 )
 
 console.log("\nScores in range")

--- a/scripts/verify-matching.ts
+++ b/scripts/verify-matching.ts
@@ -292,6 +292,31 @@ assert(
   "no team exceeds maxTeamSize even with an oversized declared chain"
 )
 
+console.log("\nRole canonicalization (free text)")
+// Real Luma answers are job titles and sentences, not slugs — the canonicalizer
+// must find role words in free text without matching inside other words.
+import { canonicalizeRole } from "../src/lib/matching/normalization"
+assert(
+  canonicalizeRole("Lead Machine Learning Engineer, Student") === "data",
+  'free text "Lead Machine Learning Engineer, Student" maps to data (longest key wins)'
+)
+assert(
+  canonicalizeRole("Software developer") === "builder",
+  'free text "Software developer" maps to builder'
+)
+assert(
+  canonicalizeRole("Solutions Architecture Intern") === "builder",
+  'free text "Solutions Architecture Intern" maps to builder'
+)
+assert(
+  canonicalizeRole("Student") === null,
+  '"Student" carries no role signal and stays unmapped'
+)
+assert(
+  canonicalizeRole("email specialist") === null,
+  'short keys like "ai"/"ml" never match inside other words'
+)
+
 console.log("\nScores in range")
 assert(
   runA.teams.every((t) => t.score.total >= 0 && t.score.total <= 100),

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -1,7 +1,16 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { AlertTriangle, Clock, Pencil, SearchX } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock,
+  Laptop,
+  Pencil,
+  SearchX,
+  Sparkles,
+  Users,
+} from "lucide-react";
 import type {
   MemberProfile,
   MemberTeamStatus,
@@ -133,7 +142,8 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
               <span className="font-mono text-text-primary">{sessionEmail}</span>.
               Make sure this account uses the same email you registered with on
               Luma. Registered with a different address, or just signed up on
-              site? Message the organizers and we&apos;ll sort it out.
+              site? Message the organizers below and we&apos;ll sort it out
+              before the event.
             </p>
             <div className="mt-4 flex flex-wrap gap-2">
               <a
@@ -168,32 +178,39 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
           className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
           aria-label="Team status"
         >
-          <h2 className="font-mono text-base font-bold text-text-primary">
-            Teams are finalized
-          </h2>
-          <p className="mt-2 text-sm text-text-secondary leading-relaxed">
-            {profile.consentToMatch
-              ? "You weren't placed on a team this round. Reach out to the organizers on "
-              : "Your matching profile wasn't completed before the deadline, so the matcher couldn't include you this round. Reach out to the organizers on "}
-            <a
-              href={SOCIAL_LINKS.discord}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-green-primary hover:underline"
-            >
-              Discord
-            </a>{" "}
-            or{" "}
-            <a
-              href={SOCIAL_LINKS.whatsapp}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-green-primary hover:underline"
-            >
-              WhatsApp
-            </a>{" "}
-            and we&apos;ll find you a spot.
-          </p>
+          <div className="flex flex-wrap items-start gap-4">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10">
+              <Users className="h-5 w-5 text-amber" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <h2 className="font-mono text-base font-bold text-text-primary">
+                Teams are finalized
+              </h2>
+              <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+                {profile.consentToMatch
+                  ? "You weren't placed on a team this round. That's on us, not you — find an organizer at the venue, or reach out on "
+                  : "Your matching profile wasn't completed before the deadline, so the matcher couldn't include you this round. Find an organizer at the venue, or reach out on "}
+                <a
+                  href={SOCIAL_LINKS.discord}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green-primary hover:underline"
+                >
+                  Discord
+                </a>{" "}
+                or{" "}
+                <a
+                  href={SOCIAL_LINKS.whatsapp}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green-primary hover:underline"
+                >
+                  WhatsApp
+                </a>{" "}
+                and we&apos;ll find you a spot on a team.
+              </p>
+            </div>
+          </div>
         </section>
 
         <section
@@ -240,10 +257,72 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
                 Profile saved — you&apos;re in the matching pool
               </h2>
               <p className="mt-1 text-sm text-text-secondary">
-                Teams drop Saturday morning. Check back here.
+                Teams drop Saturday morning, during the event. This page
+                updates itself the moment your team is ready — no need to
+                refresh on the hour.
               </p>
             </div>
           </div>
+        </section>
+
+        <section
+          aria-label="What happens next"
+          className="rounded-lg border border-border-default bg-bg-secondary p-5"
+        >
+          <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
+            <Sparkles className="h-3.5 w-3.5 text-amber" />
+            {"// ./whats-next"}
+          </h3>
+          <ol className="space-y-2.5 text-sm text-text-secondary">
+            <li className="flex items-start gap-2.5">
+              <span className="mt-0.5 font-mono text-xs text-green-primary">1.</span>
+              <span>
+                Organizers run the matcher against everyone&apos;s profile —
+                roles, skills, and interests get grouped into balanced teams.
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <span className="mt-0.5 font-mono text-xs text-green-primary">2.</span>
+              <span>
+                Teams are finalized and revealed here on 25–26 July, during
+                AI Mashinani itself — not before.
+              </span>
+            </li>
+            <li className="flex items-start gap-2.5">
+              <span className="mt-0.5 font-mono text-xs text-green-primary">3.</span>
+              <span>
+                This page flips straight to your team, teammates, and
+                suggested project direction. No separate announcement to
+                chase.
+              </span>
+            </li>
+          </ol>
+        </section>
+
+        <section
+          aria-label="What to bring"
+          className="rounded-lg border border-border-default bg-bg-secondary p-5"
+        >
+          <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
+            <Laptop className="h-3.5 w-3.5 text-cyan" />
+            {"// ./bring-checklist"}
+          </h3>
+          <ul className="grid gap-2 sm:grid-cols-2">
+            {[
+              "Laptop + charger",
+              "Anthropic / Claude account signed in and ready",
+              "A project idea or two — even half-formed",
+              "Comfort with your team meeting as strangers",
+            ].map((item) => (
+              <li
+                key={item}
+                className="flex items-start gap-2 text-sm text-text-secondary"
+              >
+                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-green-primary" />
+                {item}
+              </li>
+            ))}
+          </ul>
         </section>
 
         <section
@@ -276,6 +355,10 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
               Edit profile
             </button>
           </div>
+          <p className="mt-3 text-[11px] font-mono text-text-dim">
+            Changed your mind about a skill or track? You can edit up until
+            teams are matched.
+          </p>
         </section>
       </div>
     );

--- a/src/app/dashboard/impact-lab/MatchProfileForm.tsx
+++ b/src/app/dashboard/impact-lab/MatchProfileForm.tsx
@@ -97,10 +97,16 @@ export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFor
       <p className="font-mono text-[11px] uppercase tracking-wider text-green-primary mb-1">
         $ vim ./matching-profile
       </p>
-      <p className="mb-4 text-xs text-text-secondary">
-        Two minutes. This is how we place you on the right team.
+      <p className="mb-1 text-xs text-text-secondary">
+        Two minutes. Every field here feeds the matcher that builds your team —
+        the more accurate, the better the fit.
+      </p>
+      <p className="mb-5 text-[11px] font-mono text-text-dim">
+        We pre-filled what you told us on Luma. Check it over and fix anything
+        that&apos;s changed.
       </p>
 
+      <SectionHeading eyebrow="01" title="About you" />
       <div className="grid gap-4 sm:grid-cols-2">
         <div>
           <label htmlFor="il-fullName" className={labelClass}>
@@ -116,6 +122,44 @@ export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFor
             className={inputClass}
           />
         </div>
+        <div>
+          <label htmlFor="il-experienceLevel" className={labelClass}>
+            Experience level
+          </label>
+          <select
+            id="il-experienceLevel"
+            value={experienceLevel}
+            onChange={(e) =>
+              setExperienceLevel(e.target.value as MemberProfile["experienceLevel"])
+            }
+            className={inputClass}
+          >
+            <option value="BEGINNER">Beginner</option>
+            <option value="INTERMEDIATE">Intermediate</option>
+            <option value="ADVANCED">Advanced</option>
+          </select>
+        </div>
+        <div className="sm:col-span-2">
+          <label htmlFor="il-availability" className={labelClass}>
+            Availability (comma-separated)
+          </label>
+          <input
+            id="il-availability"
+            type="text"
+            value={availability}
+            onChange={(e) => setAvailability(e.target.value)}
+            className={inputClass}
+            placeholder="e.g. Saturday all day, Sunday morning"
+          />
+        </div>
+      </div>
+
+      <SectionHeading
+        eyebrow="02"
+        title="Your skills & track"
+        helper="This is the core matching signal — role, skills, and what you want to build decide who you're paired with."
+      />
+      <div className="grid gap-4 sm:grid-cols-2">
         <div>
           <label htmlFor="il-primaryRole" className={labelClass}>
             Primary role
@@ -138,23 +182,6 @@ export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFor
             <option value="Data" />
             <option value="Product" />
           </datalist>
-        </div>
-        <div>
-          <label htmlFor="il-experienceLevel" className={labelClass}>
-            Experience level
-          </label>
-          <select
-            id="il-experienceLevel"
-            value={experienceLevel}
-            onChange={(e) =>
-              setExperienceLevel(e.target.value as MemberProfile["experienceLevel"])
-            }
-            className={inputClass}
-          >
-            <option value="BEGINNER">Beginner</option>
-            <option value="INTERMEDIATE">Intermediate</option>
-            <option value="ADVANCED">Advanced</option>
-          </select>
         </div>
         <div>
           <label htmlFor="il-secondaryRoles" className={labelClass}>
@@ -195,19 +222,28 @@ export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFor
             placeholder="e.g. agriculture, health, fintech"
           />
         </div>
-        <div>
-          <label htmlFor="il-availability" className={labelClass}>
-            Availability (comma-separated)
+        <div className="sm:col-span-2">
+          <label htmlFor="il-projectIdeas" className={labelClass}>
+            Project ideas (optional)
           </label>
-          <input
-            id="il-availability"
-            type="text"
-            value={availability}
-            onChange={(e) => setAvailability(e.target.value)}
+          <textarea
+            id="il-projectIdeas"
+            rows={3}
+            maxLength={2000}
+            value={projectIdeas}
+            onChange={(e) => setProjectIdeas(e.target.value)}
             className={inputClass}
-            placeholder="e.g. Saturday all day, Sunday morning"
+            placeholder="Anything you'd love to build this weekend"
           />
         </div>
+      </div>
+
+      <SectionHeading
+        eyebrow="03"
+        title="Teammates"
+        helper="Optional. If you already know who you want to build with, tell us — the matcher tries to honor both lists."
+      />
+      <div className="grid gap-4 sm:grid-cols-2">
         <div>
           <label htmlFor="il-preferredTeammates" className={labelClass}>
             Teammates you&apos;d like (their emails, optional)
@@ -235,20 +271,6 @@ export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFor
           <p className="mt-1 text-[10px] font-mono text-text-dim">
             Private — only organizers ever see this.
           </p>
-        </div>
-        <div className="sm:col-span-2">
-          <label htmlFor="il-projectIdeas" className={labelClass}>
-            Project ideas (optional)
-          </label>
-          <textarea
-            id="il-projectIdeas"
-            rows={3}
-            maxLength={2000}
-            value={projectIdeas}
-            onChange={(e) => setProjectIdeas(e.target.value)}
-            className={inputClass}
-            placeholder="Anything you'd love to build this weekend"
-          />
         </div>
       </div>
 
@@ -332,5 +354,28 @@ export function MatchProfileForm({ profile, onSaved, onCancel }: MatchProfileFor
         )}
       </div>
     </form>
+  );
+}
+
+/** Numbered section divider inside the matching-profile form. */
+function SectionHeading({
+  eyebrow,
+  title,
+  helper,
+}: {
+  eyebrow: string;
+  title: string;
+  helper?: string;
+}) {
+  return (
+    <div className="mt-6 mb-3 border-t border-border-default/60 pt-5">
+      <h3 className="flex items-baseline gap-2 font-mono text-xs font-bold uppercase tracking-wider text-text-primary">
+        <span className="text-green-primary">{eyebrow}</span>
+        {title}
+      </h3>
+      {helper && (
+        <p className="mt-1 text-[11px] text-text-dim leading-relaxed">{helper}</p>
+      )}
+    </div>
   );
 }

--- a/src/app/dashboard/impact-lab/TeamReveal.tsx
+++ b/src/app/dashboard/impact-lab/TeamReveal.tsx
@@ -1,28 +1,62 @@
 "use client";
 
-import { Lightbulb, Mail, Users } from "lucide-react";
+import { useState } from "react";
+import { motion, useReducedMotion } from "framer-motion";
+import { Check, Copy, Lightbulb, Mail, PartyPopper, Users } from "lucide-react";
 import type { TeamRevealView } from "@/lib/impact-lab/member";
 
 /**
  * The finalized team, as qualities rather than numbers — the API already
  * strips scores; this view shows teammates, roles, strengths, and direction.
+ * This is the hero moment of the hackathon dashboard, so it carries a
+ * one-time entrance animation (skipped entirely under prefers-reduced-motion).
  */
 export function TeamReveal({ team }: { team: TeamRevealView }) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const container = {
+    hidden: {},
+    show: {
+      transition: { staggerChildren: prefersReducedMotion ? 0 : 0.08 },
+    },
+  };
+  const item = prefersReducedMotion
+    ? { hidden: { opacity: 1 }, show: { opacity: 1 } }
+    : {
+        hidden: { opacity: 0, y: 12 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" as const } },
+      };
+
   return (
-    <div className="space-y-6">
-      <section
-        className="rounded-lg border border-green-primary/30 bg-bg-secondary p-6"
+    <motion.div
+      className="space-y-6"
+      variants={container}
+      initial="hidden"
+      animate="show"
+    >
+      <motion.section
+        variants={item}
+        className="relative overflow-hidden rounded-lg border border-green-primary/30 bg-bg-secondary p-6"
         aria-label="Your team"
       >
-        <div className="flex flex-wrap items-start gap-4">
+        {!prefersReducedMotion && (
+          <motion.div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 bg-gradient-to-br from-green-primary/10 via-transparent to-transparent"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.8 }}
+          />
+        )}
+        <div className="relative flex flex-wrap items-start gap-4">
           <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded border border-green-primary/30 bg-green-primary/10">
-            <Users className="h-6 w-6 text-green-primary" />
+            <PartyPopper className="h-6 w-6 text-green-primary" />
           </div>
           <div className="flex-1 min-w-0">
             <p className="font-mono text-[11px] uppercase tracking-wider text-green-primary mb-1">
               {"// ./your-team"}
             </p>
-            <h2 className="font-mono text-2xl font-bold text-text-primary">
+            <h2 className="font-mono text-2xl font-bold text-text-primary sm:text-3xl">
               {team.teamName}
             </h2>
             <p className="mt-1 text-sm text-text-secondary">
@@ -30,9 +64,9 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
             </p>
           </div>
         </div>
-      </section>
+      </motion.section>
 
-      <section aria-label="Teammates">
+      <motion.section variants={item} aria-label="Teammates">
         <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
           {"// ./teammates"}
         </h3>
@@ -62,13 +96,7 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
               )}
               <span className="ml-auto">
                 {member.email ? (
-                  <a
-                    href={`mailto:${member.email}`}
-                    className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text-secondary hover:text-green-primary transition-colors"
-                  >
-                    <Mail className="h-3 w-3" />
-                    {member.email}
-                  </a>
+                  <EmailAction email={member.email} />
                 ) : !member.isSelf ? (
                   <span className="font-mono text-[11px] text-text-dim">
                     contact private
@@ -81,10 +109,10 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
         <p className="mt-2 font-mono text-[10px] text-text-dim">
           Emails appear only for teammates who chose to share their contact.
         </p>
-      </section>
+      </motion.section>
 
       {team.strengths.length > 0 && (
-        <section aria-label="Team strengths">
+        <motion.section variants={item} aria-label="Team strengths">
           <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
             {"// ./strengths"}
           </h3>
@@ -101,11 +129,11 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
               </li>
             ))}
           </ul>
-        </section>
+        </motion.section>
       )}
 
       {team.projectDirection && (
-        <section aria-label="Suggested project direction">
+        <motion.section variants={item} aria-label="Suggested project direction">
           <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
             {"// ./suggested-direction"}
           </h3>
@@ -115,8 +143,72 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
               {team.projectDirection}
             </p>
           </div>
-        </section>
+        </motion.section>
       )}
-    </div>
+
+      <motion.section variants={item} aria-label="First 30 minutes">
+        <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
+          <Users className="h-3.5 w-3.5 text-green-primary" />
+          {"// ./first-30-minutes"}
+        </h3>
+        <ol className="space-y-2.5 rounded-lg border border-border-default bg-bg-secondary p-5 text-sm text-text-secondary">
+          <li className="flex items-start gap-2.5">
+            <span className="mt-0.5 font-mono text-xs text-green-primary">1.</span>
+            <span>Find your teammates in the room — say hi, sit together.</span>
+          </li>
+          <li className="flex items-start gap-2.5">
+            <span className="mt-0.5 font-mono text-xs text-green-primary">2.</span>
+            <span>
+              Agree on your track&apos;s problem — pick one angle from the
+              suggested direction above and commit to it.
+            </span>
+          </li>
+          <li className="flex items-start gap-2.5">
+            <span className="mt-0.5 font-mono text-xs text-green-primary">3.</span>
+            <span>Set up a group chat so you can coordinate for the rest of the build.</span>
+          </li>
+        </ol>
+      </motion.section>
+    </motion.div>
+  );
+}
+
+/** Mailto link + copy-to-clipboard affordance for a teammate's email. */
+function EmailAction({ email }: { email: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(email);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API can be unavailable (permissions, insecure context) —
+      // the mailto link next to this button still works either way.
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <a
+        href={`mailto:${email}`}
+        className="inline-flex items-center gap-1.5 font-mono text-[11px] text-text-secondary hover:text-green-primary transition-colors"
+      >
+        <Mail className="h-3 w-3" />
+        {email}
+      </a>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={copied ? "Email copied" : `Copy ${email} to clipboard`}
+        className="rounded p-1 text-text-dim transition-colors hover:text-green-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-green-primary/60"
+      >
+        {copied ? (
+          <Check className="h-3 w-3 text-green-primary" />
+        ) : (
+          <Copy className="h-3 w-3" />
+        )}
+      </button>
+    </span>
   );
 }

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -1,12 +1,15 @@
 "use client"
 
-import { useMemo, useState } from "react"
-import { Loader2, Play, Sparkles, Save } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { ChevronRight, Loader2, Play, RotateCcw, Sparkles, Save } from "lucide-react"
 import { apiSend } from "./api"
 import type { DirectoryParticipant, MatchResponse, TeamExplanation } from "./types"
 // Import path is the constants module directly (not the "@/lib/matching" barrel)
 // so the client bundle gets only the constant objects, not the engine code.
 import { DEFAULT_SETTINGS as ENGINE_DEFAULTS } from "@/lib/matching/constants"
+// Types are erased at compile time, so importing from the types module (rather
+// than the constants module) never pulls engine code into the client bundle.
+import type { MatchWeightKey, MatchWeights } from "@/lib/matching/types"
 
 interface MatchingTabProps {
   cohort: string
@@ -18,12 +21,19 @@ const DEFAULT_SETTINGS = {
   desiredTeamSize: ENGINE_DEFAULTS.desiredTeamSize,
   minTeamSize: ENGINE_DEFAULTS.minTeamSize,
   maxTeamSize: ENGINE_DEFAULTS.maxTeamSize,
+  numberOfTeams: ENGINE_DEFAULTS.numberOfTeams,
   requireBuilder: ENGINE_DEFAULTS.requireBuilder,
   requirePresenter: ENGINE_DEFAULTS.requirePresenter,
   preventBeginnerOnlyTeams: ENGINE_DEFAULTS.preventBeginnerOnlyTeams,
   distributeAdvancedParticipants: ENGINE_DEFAULTS.distributeAdvancedParticipants,
   allowUnassignedParticipants: ENGINE_DEFAULTS.allowUnassignedParticipants,
+  keepPreferredTogether: ENGINE_DEFAULTS.keepPreferredTogether,
+  weights: ENGINE_DEFAULTS.weights,
 }
+
+type MatchTabSettings = typeof DEFAULT_SETTINGS
+
+const STORAGE_KEY = "cck-impact-lab-match-settings"
 
 const DIMENSION_LABEL: Record<string, string> = {
   roleCoverage: "Role coverage",
@@ -34,8 +44,32 @@ const DIMENSION_LABEL: Record<string, string> = {
   participantPreferences: "Preferences",
 }
 
+const WEIGHT_META: { key: MatchWeightKey; label: string; description: string }[] = [
+  { key: "roleCoverage", label: "Role coverage", description: "All five roles covered on each team" },
+  { key: "skillBalance", label: "Skill balance", description: "Complementary, non-overlapping skills" },
+  { key: "experienceBalance", label: "Experience balance", description: "Mix of levels + at least one experienced member" },
+  { key: "interestAlignment", label: "Interest alignment", description: "Shared track — teams build one problem per track" },
+  { key: "availabilityOverlap", label: "Availability overlap", description: "Members share committed time slots" },
+  { key: "participantPreferences", label: "Participant preferences", description: "Requested teammates end up together" },
+]
+
+/**
+ * Merges a stored settings object over the current defaults so old localStorage
+ * payloads that predate a new field (e.g. keepPreferredTogether, weights) still
+ * hydrate cleanly instead of leaving that field undefined.
+ */
+function mergeStoredSettings(stored: Partial<MatchTabSettings>): MatchTabSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...stored,
+    weights: { ...DEFAULT_SETTINGS.weights, ...(stored.weights ?? {}) },
+  }
+}
+
 export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
-  const [settings, setSettings] = useState(DEFAULT_SETTINGS)
+  const [settings, setSettings] = useState<MatchTabSettings>(DEFAULT_SETTINGS)
+  const [hydrated, setHydrated] = useState(false)
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   const [data, setData] = useState<MatchResponse | null>(null)
   const [explanations, setExplanations] = useState<TeamExplanation[] | null>(null)
   const [generating, setGenerating] = useState(false)
@@ -43,6 +77,25 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
   const [saving, setSaving] = useState(false)
   const [runName, setRunName] = useState("")
   const [error, setError] = useState<string | null>(null)
+
+  // localStorage is read after mount — reading it during render would make the
+  // server and client HTML disagree and trigger a hydration error.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        setSettings(mergeStoredSettings(JSON.parse(raw) as Partial<MatchTabSettings>))
+      }
+    } catch {
+      // Malformed or foreign localStorage payload — fall back to defaults.
+    }
+    setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  }, [settings, hydrated])
 
   const directory = useMemo(() => {
     const map = new Map<string, DirectoryParticipant>()
@@ -112,7 +165,72 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
           <Toggle label="No beginner-only teams" checked={settings.preventBeginnerOnlyTeams} onChange={(v) => setSettings({ ...settings, preventBeginnerOnlyTeams: v })} />
           <Toggle label="Distribute advanced" checked={settings.distributeAdvancedParticipants} onChange={(v) => setSettings({ ...settings, distributeAdvancedParticipants: v })} />
           <Toggle label="Allow unassigned" checked={settings.allowUnassignedParticipants} onChange={(v) => setSettings({ ...settings, allowUnassignedParticipants: v })} />
+          <Toggle
+            label="Keep declared teammates together"
+            checked={settings.keepPreferredTogether}
+            onChange={(v) => setSettings({ ...settings, keepPreferredTogether: v })}
+            helper="People who named each other on the Luma form are placed as one unit"
+          />
         </div>
+
+        <div className="pt-1 border-t border-[#1e1e1e]">
+          <button
+            type="button"
+            onClick={() => setAdvancedOpen((prev) => !prev)}
+            aria-expanded={advancedOpen}
+            aria-controls="matching-advanced-settings"
+            className="flex items-center gap-1.5 pt-2 text-[10px] font-mono text-[#888] uppercase tracking-wider hover:text-[#e0e0e0]"
+          >
+            <ChevronRight className={`w-3 h-3 transition-transform ${advancedOpen ? "rotate-90" : ""}`} />
+            Advanced settings
+          </button>
+
+          {advancedOpen && (
+            <div id="matching-advanced-settings" className="pt-3 space-y-4">
+              <div className="flex items-end justify-between gap-3">
+                <div className="w-40">
+                  <label htmlFor="number-of-teams" className="block text-[10px] font-mono text-[#555] mb-1 uppercase">
+                    Number of teams
+                  </label>
+                  <input
+                    id="number-of-teams"
+                    type="number"
+                    min={1}
+                    value={settings.numberOfTeams ?? ""}
+                    placeholder="Auto"
+                    onChange={(e) => {
+                      const raw = e.target.value
+                      setSettings({ ...settings, numberOfTeams: raw === "" ? null : Number(raw) })
+                    }}
+                    className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0]"
+                  />
+                  <p className="text-[10px] font-mono text-[#555] mt-1">Leave blank to compute from team size</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSettings(DEFAULT_SETTINGS)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-[#161616] hover:bg-[#1e1e1e] border border-[#2a2a2a] rounded text-[11px] font-mono text-[#888]"
+                >
+                  <RotateCcw className="w-3 h-3" /> Reset to defaults
+                </button>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3">
+                {WEIGHT_META.map(({ key, label, description }) => (
+                  <WeightSlider
+                    key={key}
+                    id={`weight-${key}`}
+                    label={label}
+                    description={description}
+                    value={settings.weights[key]}
+                    onChange={(v) => setSettings({ ...settings, weights: { ...settings.weights, [key]: v } as MatchWeights })}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
         <div className="flex items-center gap-2 pt-1">
           <button onClick={generate} disabled={generating} className="flex items-center gap-1.5 px-4 py-2 bg-[#00ff41]/10 hover:bg-[#00ff41]/20 border border-[#00ff41]/30 rounded text-[11px] font-mono font-semibold text-[#00ff41] disabled:opacity-40">
             {generating ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Play className="w-3.5 h-3.5" />} Generate teams
@@ -221,11 +339,53 @@ function Num({ label, value, onChange }: { label: string; value: number; onChang
   )
 }
 
-function Toggle({ label, checked, onChange }: { label: string; checked: boolean; onChange: (v: boolean) => void }) {
+function Toggle({ label, checked, onChange, helper }: { label: string; checked: boolean; onChange: (v: boolean) => void; helper?: string }) {
   return (
-    <label className="flex items-center gap-2 text-[11px] font-mono text-[#888] cursor-pointer">
-      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="accent-[#00ff41]" />
-      {label}
+    <label className="flex flex-col gap-0.5 max-w-[220px]">
+      <span className="flex items-center gap-2 text-[11px] font-mono text-[#888] cursor-pointer">
+        <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} className="accent-[#00ff41]" />
+        {label}
+      </span>
+      {helper && <span className="text-[10px] font-mono text-[#555] pl-5">{helper}</span>}
     </label>
+  )
+}
+
+function WeightSlider({
+  id,
+  label,
+  description,
+  value,
+  onChange,
+}: {
+  id: string
+  label: string
+  description: string
+  value: number
+  onChange: (v: number) => void
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label htmlFor={id} className="text-[10px] font-mono text-[#555] uppercase">{label}</label>
+        <span className="text-[10px] font-mono text-[#888]">{value.toFixed(1)}</span>
+      </div>
+      <input
+        id={id}
+        type="range"
+        min={0}
+        max={5}
+        step={0.1}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={5}
+        aria-valuenow={value}
+        aria-valuetext={value.toFixed(1)}
+        className="w-full accent-[#00ff41]"
+      />
+      <p className="text-[10px] font-mono text-[#555]">{description}</p>
+    </div>
   )
 }

--- a/src/components/admin/impact-lab/ParticipantsTab.tsx
+++ b/src/components/admin/impact-lab/ParticipantsTab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import { useCallback, useEffect, useRef, useState } from "react"
-import { Loader2, Plus, Trash2, Upload, Download } from "lucide-react"
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { Loader2, Plus, Trash2, Upload, Download, Pencil, Search, Save, X } from "lucide-react"
 import { apiGet, apiSend } from "./api"
 import { isLumaExport, mapLumaRows } from "@/lib/impact-lab/luma"
 import type { ParticipantRow } from "./types"
@@ -13,6 +13,9 @@ const LEVEL_COLOR: Record<string, string> = {
   INTERMEDIATE: "#00d4ff",
   ADVANCED: "#00ff41",
 }
+
+const TRACK_COLOR = "#ffb000"
+const TEAMMATES_COLOR = "#00d4ff"
 
 /** Quote-aware CSV parser — good enough for Luma / Google Form exports. */
 function parseCsv(text: string): string[][] {
@@ -57,6 +60,41 @@ const EMPTY_FORM = {
   consentToShareContact: false,
 }
 
+/** Editable subset of a participant, mirrored as comma/semicolon-joined strings for text inputs. */
+interface EditFormState {
+  fullName: string
+  email: string
+  phone: string
+  institution: string
+  experienceLevel: (typeof EXPERIENCE)[number]
+  primaryRole: string
+  technicalSkills: string
+  interests: string
+  availability: string
+  preferredTeammates: string
+  projectIdeas: string
+  consentToMatch: boolean
+  consentToShareContact: boolean
+}
+
+function toEditForm(p: ParticipantRow): EditFormState {
+  return {
+    fullName: p.fullName,
+    email: p.email,
+    phone: p.phone ?? "",
+    institution: p.institution ?? "",
+    experienceLevel: p.experienceLevel,
+    primaryRole: p.primaryRole,
+    technicalSkills: p.technicalSkills.join(", "),
+    interests: p.interests.join(", "),
+    availability: p.availability.join(", "),
+    preferredTeammates: p.preferredTeammates.join(", "),
+    projectIdeas: p.projectIdeas ?? "",
+    consentToMatch: p.consentToMatch,
+    consentToShareContact: p.consentToShareContact,
+  }
+}
+
 export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
   const [participants, setParticipants] = useState<ParticipantRow[]>([])
   const [loading, setLoading] = useState(true)
@@ -65,6 +103,9 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
   const [showForm, setShowForm] = useState(false)
   const [form, setForm] = useState(EMPTY_FORM)
   const [importMsg, setImportMsg] = useState<string | null>(null)
+  const [search, setSearch] = useState("")
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editForm, setEditForm] = useState<EditFormState | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const load = useCallback(async () => {
@@ -112,9 +153,50 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
     setBusy(true)
     try {
       await apiSend(`/api/admin/impact-lab/participants/${id}`, "DELETE")
+      if (editingId === id) { setEditingId(null); setEditForm(null) }
       await load()
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to delete")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function startEdit(p: ParticipantRow) {
+    setError(null)
+    setEditingId(p.id)
+    setEditForm(toEditForm(p))
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+    setEditForm(null)
+  }
+
+  async function saveEdit() {
+    if (!editingId || !editForm) return
+    setBusy(true)
+    setError(null)
+    try {
+      const updated = await apiSend<ParticipantRow>(`/api/admin/impact-lab/participants/${editingId}`, "PATCH", {
+        fullName: editForm.fullName,
+        email: editForm.email,
+        phone: editForm.phone || null,
+        institution: editForm.institution || null,
+        experienceLevel: editForm.experienceLevel,
+        primaryRole: editForm.primaryRole,
+        technicalSkills: splitMulti(editForm.technicalSkills),
+        interests: splitMulti(editForm.interests),
+        availability: splitMulti(editForm.availability),
+        preferredTeammates: splitMulti(editForm.preferredTeammates),
+        projectIdeas: editForm.projectIdeas || null,
+        consentToMatch: editForm.consentToMatch,
+        consentToShareContact: editForm.consentToShareContact,
+      })
+      setParticipants((prev) => prev.map((row) => (row.id === updated.id ? updated : row)))
+      cancelEdit()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to update")
     } finally {
       setBusy(false)
     }
@@ -201,13 +283,36 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
 
   const consenting = participants.filter((p) => p.consentToMatch).length
 
+  const filteredParticipants = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return participants
+    return participants.filter((p) =>
+      p.fullName.toLowerCase().includes(q) ||
+      p.email.toLowerCase().includes(q) ||
+      (p.institution ?? "").toLowerCase().includes(q) ||
+      p.interests.some((i) => i.toLowerCase().includes(q))
+    )
+  }, [participants, search])
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-xs font-mono text-[#555]">
           {participants.length} participants · {consenting} consenting
         </p>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative">
+            <Search className="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-[#444] pointer-events-none" />
+            <label htmlFor="participant-search" className="sr-only">Search participants</label>
+            <input
+              id="participant-search"
+              type="search"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search name, email, institution, track…"
+              className="pl-7 pr-2 py-1.5 w-56 bg-[#111] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#e0e0e0] placeholder:text-[#444] focus:outline-none focus:border-[#00ff41]/40"
+            />
+          </div>
           <button
             onClick={() => setShowForm((s) => !s)}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-[#00ff41]/10 hover:bg-[#00ff41]/20 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] transition-all"
@@ -280,37 +385,130 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
           <div className="p-8 text-center"><Loader2 className="w-5 h-5 animate-spin text-[#333] mx-auto" /></div>
         ) : participants.length === 0 ? (
           <div className="p-8 text-center text-sm font-mono text-[#555]">No participants yet — add or import.</div>
+        ) : filteredParticipants.length === 0 ? (
+          <div className="p-8 text-center text-sm font-mono text-[#555]">No participants match &quot;{search}&quot;.</div>
         ) : (
-          <table className="w-full">
-            <thead>
-              <tr className="border-b border-[#1e1e1e]">
-                {["Name", "Role", "Level", "Skills", "Consent", ""].map((h) => (
-                  <th key={h} className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">{h}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-[#141414]">
-              {participants.map((p) => (
-                <tr key={p.id} className="hover:bg-[#111]">
-                  <td className="px-4 py-3">
-                    <div className="text-sm font-mono text-[#e0e0e0]">{p.fullName}</div>
-                    <div className="text-[11px] font-mono text-[#444]">{p.email}</div>
-                  </td>
-                  <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{p.primaryRole}</td>
-                  <td className="px-4 py-3">
-                    <span className="text-[10px] font-mono px-2 py-0.5 rounded border" style={{ color: LEVEL_COLOR[p.experienceLevel], borderColor: `${LEVEL_COLOR[p.experienceLevel]}40` }}>{p.experienceLevel}</span>
-                  </td>
-                  <td className="px-4 py-3 text-[11px] font-mono text-[#666] max-w-xs truncate">{p.technicalSkills.join(", ")}</td>
-                  <td className="px-4 py-3 text-[11px] font-mono">
-                    <span className={p.consentToMatch ? "text-[#00ff41]" : "text-[#ff3333]"}>{p.consentToMatch ? "yes" : "no"}</span>
-                  </td>
-                  <td className="px-4 py-3 text-right">
-                    <button onClick={() => remove(p.id)} disabled={busy} className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>
-                  </td>
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#1e1e1e]">
+                  {["Name", "Role", "Level", "Track", "Skills", "Teammates", "Consent", ""].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">{h}</th>
+                  ))}
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody className="divide-y divide-[#141414]">
+                {filteredParticipants.map((p) => (
+                  <Fragment key={p.id}>
+                    <tr className="hover:bg-[#111]">
+                      <td className="px-4 py-3">
+                        <div className="text-sm font-mono text-[#e0e0e0]">{p.fullName}</div>
+                        <div className="text-[11px] font-mono text-[#444]">{p.email}</div>
+                      </td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{p.primaryRole}</td>
+                      <td className="px-4 py-3">
+                        <span className="text-[10px] font-mono px-2 py-0.5 rounded border" style={{ color: LEVEL_COLOR[p.experienceLevel], borderColor: `${LEVEL_COLOR[p.experienceLevel]}40` }}>{p.experienceLevel}</span>
+                      </td>
+                      <td className="px-4 py-3">
+                        {p.interests[0] ? (
+                          <span className="text-[10px] font-mono px-2 py-0.5 rounded border" style={{ color: TRACK_COLOR, borderColor: `${TRACK_COLOR}40` }}>{p.interests[0]}</span>
+                        ) : (
+                          <span className="text-[11px] font-mono text-[#333]">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#666] max-w-xs truncate">{p.technicalSkills.join(", ")}</td>
+                      <td className="px-4 py-3">
+                        {p.preferredTeammates.length > 0 ? (
+                          <span className="text-[10px] font-mono px-2 py-0.5 rounded border" style={{ color: TEAMMATES_COLOR, borderColor: `${TEAMMATES_COLOR}40` }}>+{p.preferredTeammates.length} teammates</span>
+                        ) : (
+                          <span className="text-[11px] font-mono text-[#333]">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-[11px] font-mono">
+                        <div className="flex flex-col gap-0.5">
+                          <span className={p.consentToMatch ? "text-[#00ff41]" : "text-[#ff3333]"}>{p.consentToMatch ? "yes" : "no"}</span>
+                          {!p.consentToMatch && (
+                            <span className="text-[9px] font-mono text-[#ff3333]/60 italic">excluded from matching</span>
+                          )}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex items-center justify-end gap-2.5">
+                          <button
+                            onClick={() => (editingId === p.id ? cancelEdit() : startEdit(p))}
+                            disabled={busy}
+                            aria-label={editingId === p.id ? `Cancel editing ${p.fullName}` : `Edit ${p.fullName}`}
+                            aria-expanded={editingId === p.id}
+                            className="text-[#00d4ff]/70 hover:text-[#00d4ff] disabled:opacity-40"
+                          >
+                            <Pencil className="w-3.5 h-3.5" />
+                          </button>
+                          <button
+                            onClick={() => remove(p.id)}
+                            disabled={busy}
+                            aria-label={`Delete ${p.fullName}`}
+                            className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"
+                          >
+                            <Trash2 className="w-3.5 h-3.5" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                    {editingId === p.id && editForm && (
+                      <tr className="bg-[#0a0a0a]">
+                        <td colSpan={8} className="px-4 py-4">
+                          <div className="grid grid-cols-2 gap-3">
+                            <Input label="Full name" value={editForm.fullName} onChange={(v) => setEditForm({ ...editForm, fullName: v })} />
+                            <Input label="Email" value={editForm.email} onChange={(v) => setEditForm({ ...editForm, email: v })} />
+                            <Input label="Phone" value={editForm.phone} onChange={(v) => setEditForm({ ...editForm, phone: v })} />
+                            <Input label="Institution" value={editForm.institution} onChange={(v) => setEditForm({ ...editForm, institution: v })} />
+                            <Input label="Primary role" value={editForm.primaryRole} onChange={(v) => setEditForm({ ...editForm, primaryRole: v })} />
+                            <div>
+                              <label className="block text-[10px] font-mono text-[#555] mb-1 uppercase">Experience</label>
+                              <select
+                                value={editForm.experienceLevel}
+                                onChange={(e) => setEditForm({ ...editForm, experienceLevel: e.target.value as (typeof EXPERIENCE)[number] })}
+                                className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0]"
+                              >
+                                {EXPERIENCE.map((l) => <option key={l} value={l}>{l}</option>)}
+                              </select>
+                            </div>
+                            <Input label="Skills (; or ,)" value={editForm.technicalSkills} onChange={(v) => setEditForm({ ...editForm, technicalSkills: v })} />
+                            <Input label="Interests (; or ,)" value={editForm.interests} onChange={(v) => setEditForm({ ...editForm, interests: v })} />
+                            <Input label="Availability (; or ,)" value={editForm.availability} onChange={(v) => setEditForm({ ...editForm, availability: v })} />
+                            <Input label="Preferred teammates (emails)" value={editForm.preferredTeammates} onChange={(v) => setEditForm({ ...editForm, preferredTeammates: v })} />
+                            <div className="col-span-2">
+                              <Textarea label="Project ideas" value={editForm.projectIdeas} onChange={(v) => setEditForm({ ...editForm, projectIdeas: v })} />
+                            </div>
+                            <div className="col-span-2 flex items-center gap-4 flex-wrap">
+                              <Check label="Consent to match" checked={editForm.consentToMatch} onChange={(v) => setEditForm({ ...editForm, consentToMatch: v })} />
+                              <Check label="Consent to share contact" checked={editForm.consentToShareContact} onChange={(v) => setEditForm({ ...editForm, consentToShareContact: v })} />
+                              <div className="ml-auto flex items-center gap-2">
+                                <button
+                                  onClick={cancelEdit}
+                                  disabled={busy}
+                                  className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888] disabled:opacity-40"
+                                >
+                                  <X className="w-3 h-3" /> Cancel
+                                </button>
+                                <button
+                                  onClick={saveEdit}
+                                  disabled={busy || !editForm.fullName || !editForm.email || !editForm.primaryRole}
+                                  className="flex items-center gap-1.5 px-3 py-1.5 bg-[#00ff41]/10 hover:bg-[#00ff41]/20 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] disabled:opacity-40"
+                                >
+                                  {busy ? <Loader2 className="w-3 h-3 animate-spin" /> : <Save className="w-3 h-3" />} Save
+                                </button>
+                              </div>
+                            </div>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </div>
@@ -322,6 +520,20 @@ function Input({ label, value, onChange }: { label: string; value: string; onCha
     <div>
       <label className="block text-[10px] font-mono text-[#555] mb-1 uppercase">{label}</label>
       <input value={value} onChange={(e) => onChange(e.target.value)} className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0]" />
+    </div>
+  )
+}
+
+function Textarea({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <label className="block text-[10px] font-mono text-[#555] mb-1 uppercase">{label}</label>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        className="w-full bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-xs font-mono text-[#e0e0e0] resize-y"
+      />
     </div>
   )
 }

--- a/src/components/admin/impact-lab/RunDetail.tsx
+++ b/src/components/admin/impact-lab/RunDetail.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Loader2 } from "lucide-react"
+import { apiGet } from "./api"
+import type { MatchResult } from "./types"
+
+/** The subset of GET /runs/[id]'s response this view renders. */
+interface RunDetailData {
+  id: string
+  result: MatchResult
+}
+
+/** Minimal shape needed to resolve a member id to a display name. */
+interface DirectoryEntry {
+  fullName: string
+}
+
+const DIMENSION_LABEL: Record<string, string> = {
+  roleCoverage: "Role coverage",
+  skillBalance: "Skill diversity",
+  experienceBalance: "Experience balance",
+  interestAlignment: "Shared interests",
+  availabilityOverlap: "Availability",
+  participantPreferences: "Preferences",
+}
+
+interface RunDetailProps {
+  runId: string
+  /** Participant directory (id → name) for the run's cohort, loaded by the parent tab. */
+  directory: Map<string, DirectoryEntry>
+}
+
+/** Expanded-row detail for a saved matching run: teams, members, scores, warnings. */
+export function RunDetail({ runId, directory }: RunDetailProps) {
+  const [detail, setDetail] = useState<RunDetailData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    apiGet<RunDetailData>(`/api/admin/impact-lab/runs/${runId}`)
+      .then((data) => { if (!cancelled) setDetail(data) })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load run detail") })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [runId])
+
+  if (loading) {
+    return (
+      <div className="p-6 text-center bg-[#0a0a0a] border-t border-[#1e1e1e]">
+        <Loader2 className="w-4 h-4 animate-spin text-[#333] mx-auto" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="p-3 bg-[#0a0a0a] border-t border-[#1e1e1e] text-[11px] font-mono text-[#ff3333]">
+        {error}
+      </div>
+    )
+  }
+
+  if (!detail) return null
+
+  const { result } = detail
+
+  return (
+    <div className="p-4 space-y-3 bg-[#0a0a0a] border-t border-[#1e1e1e]">
+      {result.warnings.length > 0 && (
+        <div className="p-2 bg-[#ffb000]/5 border border-[#ffb000]/20 rounded text-[11px] font-mono text-[#ffb000] space-y-0.5">
+          {result.warnings.map((w, i) => <div key={i}>⚠ {w}</div>)}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        {result.teams.map((team) => (
+          <div key={team.id} className="p-3 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg space-y-2">
+            <div className="flex items-center justify-between">
+              <div className="text-xs font-mono text-[#e0e0e0]">
+                {team.name}
+                {team.locked && <span className="ml-2 text-[10px] text-[#ffb000]">[locked]</span>}
+              </div>
+              <div className="text-xs font-mono font-bold text-[#00ff41]">
+                {team.score.total}<span className="text-[#444]">/100</span>
+              </div>
+            </div>
+
+            <div className="space-y-1">
+              {team.memberIds.map((id) => (
+                <div key={id} className="text-[11px] font-mono text-[#aaa]">
+                  {directory.get(id)?.fullName ?? id}
+                </div>
+              ))}
+            </div>
+
+            <div className="space-y-1 pt-1">
+              {team.score.dimensions.map((d) => (
+                <div key={d.key} className="flex items-center gap-2">
+                  <span className="text-[10px] font-mono text-[#555] w-28 flex-shrink-0">{DIMENSION_LABEL[d.key] ?? d.key}</span>
+                  <div className="flex-1 h-1.5 bg-[#161616] rounded overflow-hidden">
+                    <div className="h-full bg-[#00ff41]/60" style={{ width: `${Math.round(d.raw * 100)}%` }} />
+                  </div>
+                  <span className="text-[10px] font-mono text-[#666] w-8 text-right">{Math.round(d.raw * 100)}%</span>
+                </div>
+              ))}
+            </div>
+
+            {team.score.penalties.length > 0 && (
+              <div className="text-[10px] font-mono text-[#ff3333]/80 space-y-0.5">
+                {team.score.penalties.map((p, i) => <div key={i}>−{p.points} {p.reason}</div>)}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {result.unassignedIds.length > 0 && (
+        <div className="p-2 bg-[#0d0d0d] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888]">
+          <span className="text-[#555]">Unassigned:</span>{" "}
+          {result.unassignedIds.map((id) => directory.get(id)?.fullName ?? id).join(", ")}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/RunsTab.tsx
+++ b/src/components/admin/impact-lab/RunsTab.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
-import { Loader2, Trash2, Download, CheckCircle2 } from "lucide-react"
+import { Fragment, useCallback, useEffect, useState } from "react"
+import { Loader2, Trash2, Download, CheckCircle2, ChevronRight, ChevronDown, Pencil, Save, X } from "lucide-react"
 import { apiGet, apiSend } from "./api"
-import type { RunSummary } from "./types"
+import { RunDetail } from "./RunDetail"
+import type { ParticipantRow, RunSummary } from "./types"
 
 interface RunsTabProps {
   cohort: string
@@ -15,6 +16,15 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
   const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const [directory, setDirectory] = useState<Map<string, ParticipantRow> | null>(null)
+  const [directoryLoading, setDirectoryLoading] = useState(false)
+
+  const [editingNameId, setEditingNameId] = useState<string | null>(null)
+  const [nameDraft, setNameDraft] = useState("")
+  const [editingNotesId, setEditingNotesId] = useState<string | null>(null)
+  const [notesDraft, setNotesDraft] = useState("")
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -29,6 +39,25 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
   }, [cohort])
 
   useEffect(() => { void load() }, [load, refreshKey])
+  // Reset the participant directory and any open rows when the cohort changes —
+  // ids from one cohort's directory must never resolve names for another's.
+  useEffect(() => { setDirectory(null); setExpanded(new Set()) }, [cohort])
+
+  function toggleExpand(id: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+    if (!directory && !directoryLoading) {
+      setDirectoryLoading(true)
+      apiGet<ParticipantRow[]>(`/api/admin/impact-lab/participants?cohort=${cohort}`)
+        .then((rows) => setDirectory(new Map(rows.map((p) => [p.id, p]))))
+        .catch((e) => setError(e instanceof Error ? e.message : "Failed to load participants"))
+        .finally(() => setDirectoryLoading(false))
+    }
+  }
 
   async function markFinal(id: string) {
     setBusy(true)
@@ -55,6 +84,36 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
     }
   }
 
+  async function saveName(id: string) {
+    const name = nameDraft.trim()
+    if (!name) return
+    setBusy(true)
+    setError(null)
+    try {
+      await apiSend(`/api/admin/impact-lab/runs/${id}`, "PATCH", { name })
+      setEditingNameId(null)
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to rename")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function saveNotes(id: string) {
+    setBusy(true)
+    setError(null)
+    try {
+      await apiSend(`/api/admin/impact-lab/runs/${id}`, "PATCH", { notes: notesDraft.trim() || null })
+      setEditingNotesId(null)
+      await load()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save notes")
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="space-y-4">
       {error && <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>}
@@ -73,33 +132,106 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
               </tr>
             </thead>
             <tbody className="divide-y divide-[#141414]">
-              {runs.map((run) => (
-                <tr key={run.id} className="hover:bg-[#111]">
-                  <td className="px-4 py-3">
-                    <div className="text-sm font-mono text-[#e0e0e0]">{run.name}</div>
-                    {run.notes && <div className="text-[11px] font-mono text-[#444]">{run.notes}</div>}
-                  </td>
-                  <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.teamCount}</td>
-                  <td className="px-4 py-3 text-[11px] font-mono text-[#00ff41]">{run.averageScore}</td>
-                  <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.unassignedCount}</td>
-                  <td className="px-4 py-3">
-                    {run.isFinal ? (
-                      <span className="text-[10px] font-mono px-2 py-0.5 rounded bg-[#00ff41]/10 border border-[#00ff41]/30 text-[#00ff41]">FINAL</span>
-                    ) : (
-                      <span className="text-[10px] font-mono text-[#555]">draft</span>
+              {runs.map((run) => {
+                const isExpanded = expanded.has(run.id)
+                return (
+                  <Fragment key={run.id}>
+                    <tr className="hover:bg-[#111]">
+                      <td className="px-4 py-3">
+                        <div className="flex items-start gap-2">
+                          <button
+                            onClick={() => toggleExpand(run.id)}
+                            aria-expanded={isExpanded}
+                            aria-label={isExpanded ? `Collapse ${run.name}` : `Expand ${run.name}`}
+                            className="mt-0.5 text-[#555] hover:text-[#888] flex-shrink-0"
+                          >
+                            {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+                          </button>
+                          <div className="min-w-0 flex-1">
+                            {editingNameId === run.id ? (
+                              <div className="flex items-center gap-1">
+                                <input
+                                  aria-label={`Rename ${run.name}`}
+                                  value={nameDraft}
+                                  onChange={(e) => setNameDraft(e.target.value)}
+                                  className="bg-[#111] border border-[#1e1e1e] rounded px-1.5 py-0.5 text-sm font-mono text-[#e0e0e0] w-40"
+                                />
+                                <button onClick={() => saveName(run.id)} disabled={busy || !nameDraft.trim()} title="Save name" aria-label="Save name" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40">
+                                  <Save className="w-3.5 h-3.5" />
+                                </button>
+                                <button onClick={() => setEditingNameId(null)} title="Cancel" aria-label="Cancel rename" className="text-[#555] hover:text-[#888]">
+                                  <X className="w-3.5 h-3.5" />
+                                </button>
+                              </div>
+                            ) : (
+                              <div className="flex items-center gap-1.5">
+                                <span className="text-sm font-mono text-[#e0e0e0]">{run.name}</span>
+                                <button
+                                  onClick={() => { setEditingNameId(run.id); setNameDraft(run.name) }}
+                                  title="Rename"
+                                  aria-label={`Rename ${run.name}`}
+                                  className="text-[#555] hover:text-[#888]"
+                                >
+                                  <Pencil className="w-3 h-3" />
+                                </button>
+                              </div>
+                            )}
+
+                            {editingNotesId === run.id ? (
+                              <div className="mt-1 space-y-1">
+                                <textarea
+                                  aria-label={`Notes for ${run.name}`}
+                                  value={notesDraft}
+                                  onChange={(e) => setNotesDraft(e.target.value)}
+                                  rows={2}
+                                  className="w-full bg-[#111] border border-[#1e1e1e] rounded px-1.5 py-1 text-[11px] font-mono text-[#e0e0e0]"
+                                />
+                                <div className="flex items-center gap-2">
+                                  <button onClick={() => saveNotes(run.id)} disabled={busy} className="text-[10px] font-mono text-[#00ff41] hover:underline disabled:opacity-40">Save notes</button>
+                                  <button onClick={() => setEditingNotesId(null)} className="text-[10px] font-mono text-[#555] hover:underline">Cancel</button>
+                                </div>
+                              </div>
+                            ) : (
+                              <button
+                                onClick={() => { setEditingNotesId(run.id); setNotesDraft(run.notes ?? "") }}
+                                className="mt-0.5 block text-[11px] font-mono text-[#444] hover:text-[#666] text-left"
+                              >
+                                {run.notes || "+ add notes"}
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.teamCount}</td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#00ff41]">{run.averageScore}</td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.unassignedCount}</td>
+                      <td className="px-4 py-3">
+                        {run.isFinal ? (
+                          <span className="text-[10px] font-mono px-2 py-0.5 rounded bg-[#00ff41]/10 border border-[#00ff41]/30 text-[#00ff41]">FINAL</span>
+                        ) : (
+                          <span className="text-[10px] font-mono text-[#555]">draft</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-end gap-2">
+                          {!run.isFinal && (
+                            <button onClick={() => markFinal(run.id)} disabled={busy} title="Mark final" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40"><CheckCircle2 className="w-3.5 h-3.5" /></button>
+                          )}
+                          <a href={`/api/admin/impact-lab/runs/${run.id}/export`} title="Export teams CSV" className="text-[#00d4ff]/70 hover:text-[#00d4ff]"><Download className="w-3.5 h-3.5" /></a>
+                          <button onClick={() => remove(run.id)} disabled={busy} title="Delete" className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>
+                        </div>
+                      </td>
+                    </tr>
+                    {isExpanded && (
+                      <tr>
+                        <td colSpan={6} className="p-0">
+                          <RunDetail runId={run.id} directory={directory ?? new Map()} />
+                        </td>
+                      </tr>
                     )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center justify-end gap-2">
-                      {!run.isFinal && (
-                        <button onClick={() => markFinal(run.id)} disabled={busy} title="Mark final" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40"><CheckCircle2 className="w-3.5 h-3.5" /></button>
-                      )}
-                      <a href={`/api/admin/impact-lab/runs/${run.id}/export`} title="Export teams CSV" className="text-[#00d4ff]/70 hover:text-[#00d4ff]"><Download className="w-3.5 h-3.5" /></a>
-                      <button onClick={() => remove(run.id)} disabled={busy} title="Delete" className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
+                  </Fragment>
+                )
+              })}
             </tbody>
           </table>
         )}

--- a/src/lib/impact-lab/luma.ts
+++ b/src/lib/impact-lab/luma.ts
@@ -22,13 +22,11 @@ const QUESTION_PREFIXES = {
   track: "your track - each carries one fixed problem",
   trackSecond: "second choice, if your first track fills up",
   demoSlice: "what will exist and work by",
-  teamStatus: "teams are 3-5 people",
   teammates: "if you have team-mates",
   fullNight: "can you commit to the full night",
 } as const
 
 const EMAIL_PATTERN = /[\w.+-]+@[\w-]+\.[\w.-]+/g
-const FULL_TEAM_PREFIX = "i have a full team"
 
 // participant-schema.ts limits — kept in sync manually (the zod schema is the
 // source of truth; these only pre-clamp so rows survive validation).
@@ -104,7 +102,6 @@ export function mapLumaRows(headers: string[], rows: string[][]): LumaImportResu
       continue
     }
 
-    const teamStatus = get(q.teamStatus).toLowerCase()
     const interests = [get(q.track), get(q.trackSecond)]
       .map((v) => clamp(v, MAX_TOKEN))
       .filter(Boolean)
@@ -123,11 +120,13 @@ export function mapLumaRows(headers: string[], rows: string[][]): LumaImportResu
       projectIdeas: clamp(get(q.demoSlice), MAX_IDEAS) || null,
       preferredTeammates: (get(q.teammates).match(EMAIL_PATTERN) ?? []).slice(0, MAX_TOKENS),
       blockedTeammates: [],
-      // Pre-formed full teams are placed manually by organisers (locked
-      // teams), so the matcher must not move them; everyone else approved
-      // registered for a team-formation event and is matchable.
-      consentToMatch: !teamStatus.startsWith(FULL_TEAM_PREFIX),
-      consentToShareContact: false,
+      // Organiser decision (2026-07-24): everyone approved registered for a
+      // team-formation event, so everyone is matchable and teammates may see
+      // each other's contact details. Pre-formed teams stay together via
+      // their declared teammate emails (the engine's keep-together groups),
+      // not by exclusion. Individuals can still opt out from their profile.
+      consentToMatch: true,
+      consentToShareContact: true,
     })
   }
 

--- a/src/lib/impact-lab/settings.ts
+++ b/src/lib/impact-lab/settings.ts
@@ -34,6 +34,7 @@ export const settingsSchema = z
     requirePresenter: z.boolean(),
     preventBeginnerOnlyTeams: z.boolean(),
     distributeAdvancedParticipants: z.boolean(),
+    keepPreferredTogether: z.boolean(),
     lockedTeams: z.array(lockedTeamSchema),
     weights: weightsSchema,
   })

--- a/src/lib/matching/algorithm.ts
+++ b/src/lib/matching/algorithm.ts
@@ -9,11 +9,13 @@
  *   1. partition by consent          (constraints)
  *   2. normalize                     (normalization)
  *   3. resolve locked teams          (constraints)
+ *      + resolve declared-teammate together-groups (groups)
  *   4. size the run — how many teams
- *   5. seed each team with a scarce / high-impact role
+ *   5. place together-groups as units, then seed each still-empty team with a
+ *      scarce / high-impact role
  *   6. distribute advanced participants round-robin
  *   7. greedy fill by marginal contribution
- *   8. (optimization pass — wired in optimization.ts)
+ *   8. (optimization pass — wired in optimization.ts; never splits a group)
  *   9. assemble scored teams + warnings
  */
 
@@ -29,6 +31,7 @@ import {
   partitionByConsent,
   resolveLockedTeams,
 } from "./constraints"
+import { resolveTogetherGroups, type TogetherGroups } from "./groups"
 import { normalizeParticipants } from "./normalization"
 import { scoreTeam, scoreTeamTotal, type ScoringContext } from "./scoring"
 import type {
@@ -226,6 +229,55 @@ function chooseFillTeam(
   return best
 }
 
+// ─── Step 5.5: place declared-teammate groups as units ───────────────────────
+
+/**
+ * Place a whole together-group onto one team. Candidates are non-locked teams
+ * with room for the entire group and no block conflict against any current
+ * member; among them, highest summed marginal contribution wins (ties toward
+ * the smaller team, then index). Returns false only when every team has a
+ * block conflict with the group — the caller then leaves the group unassigned
+ * rather than break a block, which is inviolable.
+ */
+function placeGroup(
+  group: NormalizedParticipant[],
+  teams: WorkingTeam[],
+  byId: Map<string, NormalizedParticipant>,
+  context: ScoringContext
+): boolean {
+  const settings = context.settings
+  const blockFree = teams.filter(
+    (t) =>
+      !t.locked &&
+      group.every((g) => !hasBlockConflict(g, membersOf(t, byId)))
+  )
+  if (blockFree.length === 0) return false
+  const withRoom = blockFree.filter(
+    (t) => t.memberIds.length + group.length <= settings.maxTeamSize
+  )
+  const pickFrom = withRoom.length > 0 ? withRoom : blockFree
+
+  let best: WorkingTeam | null = null
+  let bestScore = -Infinity
+  for (const team of pickFrom) {
+    const members = membersOf(team, byId)
+    const score =
+      scoreTeamTotal([...members, ...group], context) -
+      scoreTeamTotal(members, context) -
+      SIZE_BALANCE_PENALTY_PER_MEMBER * members.length
+    if (
+      best === null ||
+      score > bestScore ||
+      (score === bestScore && team.memberIds.length < best.memberIds.length)
+    ) {
+      best = team
+      bestScore = score
+    }
+  }
+  best!.memberIds.push(...group.map((g) => g.id))
+  return true
+}
+
 // ─── Step 6: distribute advanced participants ────────────────────────────────
 
 function advancedCount(
@@ -360,6 +412,12 @@ export function assign(
 
   const pool = normalized.filter((p) => !lockedIds.has(p.id))
 
+  // Step 3.5: resolve declared-teammate groups — hard keep-together units.
+  const together: TogetherGroups = settings.keepPreferredTogether
+    ? resolveTogetherGroups(pool, settings)
+    : { groups: [], groupedIds: new Set<string>(), warnings: [] }
+  context.pinnedTogetherIds = together.groupedIds
+
   // Step 4: size the run.
   const count = targetTeamCount(pool.length, settings)
   const generated: WorkingTeam[] = Array.from({ length: count }, () => ({
@@ -368,17 +426,44 @@ export function assign(
   }))
   const teams: WorkingTeam[] = [...lockedWorking, ...generated]
 
-  // Step 5: seed one scarce/high-impact-role participant per generated team.
-  const seeded = new Set<string>()
-  if (count > 0) {
-    const order = seedOrder(pool, countPrimaryRoles(pool))
-    for (let i = 0; i < count && i < order.length; i++) {
-      generated[i].memberIds.push(order[i].id)
-      seeded.add(order[i].id)
+  // Step 5: place together-groups first (as whole units), then seed one
+  // scarce/high-impact-role participant into each team still empty. Groups go
+  // first so they claim empty teams before seeding scatters individuals.
+  const placed = new Set<string>()
+  const groupWarnings = [...together.warnings]
+  const unassignedIds: string[] = []
+  for (const group of together.groups) {
+    if (placeGroup(group, generated, byId, context)) {
+      for (const member of group) placed.add(member.id)
+    } else {
+      // Every team block-conflicts with this group — blocks are inviolable,
+      // so the group sits out rather than being forced next to a blocker.
+      groupWarnings.push(
+        `Could not place the declared team of ${group.map((g) => g.fullName).join(", ")} — a blocked pair stands in the way on every team.`
+      )
+      for (const member of group) {
+        unassignedIds.push(member.id)
+        placed.add(member.id)
+      }
+    }
+  }
+  if (together.groups.length > 0) {
+    groupWarnings.push(
+      `${together.groups.length} declared teammate group(s) kept together.`
+    )
+  }
+
+  const unseededPool = pool.filter((p) => !placed.has(p.id))
+  const emptyTeams = generated.filter((t) => t.memberIds.length === 0)
+  if (emptyTeams.length > 0) {
+    const order = seedOrder(unseededPool, countPrimaryRoles(unseededPool))
+    for (let i = 0; i < emptyTeams.length && i < order.length; i++) {
+      emptyTeams[i].memberIds.push(order[i].id)
+      placed.add(order[i].id)
     }
   }
 
-  let remaining = pool.filter((p) => !seeded.has(p.id))
+  let remaining = unseededPool.filter((p) => !placed.has(p.id))
 
   // Step 6: distribute advanced participants first (if enabled).
   if (settings.distributeAdvancedParticipants) {
@@ -391,7 +476,6 @@ export function assign(
   }
 
   // Step 7: greedy fill by marginal contribution (id order = deterministic).
-  const unassignedIds: string[] = []
   for (const candidate of remaining) {
     const team = chooseFillTeam(candidate, teams, byId, context)
     if (team) team.memberIds.push(candidate.id)
@@ -409,7 +493,7 @@ export function assign(
       assembled,
       unassignedIds,
       excludedIds,
-      lockedWarnings,
+      [...lockedWarnings, ...groupWarnings],
       settings
     ),
     averageScore: averageScore(assembled),

--- a/src/lib/matching/constants.ts
+++ b/src/lib/matching/constants.ts
@@ -86,6 +86,22 @@ export const ROLE_SYNONYMS: Readonly<Record<string, CanonicalRole>> = {
   "project manager": "product",
   strategist: "product",
   business: "product",
+
+  // Occupational answers seen in the real Luma export ("What is your role?"
+  // was answered with job titles, not hackathon roles). Conservative mappings
+  // only — pure "student"/"intern" answers carry no role signal and stay
+  // unmapped on purpose.
+  founder: "product",
+  ceo: "product",
+  cto: "builder",
+  "computer science": "builder",
+  "data science": "data",
+  "web developer": "builder",
+  architect: "builder",
+  architecture: "builder",
+  devops: "builder",
+  engineering: "builder",
+  "software engineering": "builder",
 }
 
 // ─── Experience ──────────────────────────────────────────────────────────────

--- a/src/lib/matching/constants.ts
+++ b/src/lib/matching/constants.ts
@@ -107,7 +107,10 @@ export const DEFAULT_WEIGHTS: MatchWeights = {
   roleCoverage: 2,
   skillBalance: 1.5,
   experienceBalance: 1.4,
-  interestAlignment: 1,
+  // Interests carry the participants' track choices, and each track is one
+  // fixed problem — a team that doesn't share a track can't share a project.
+  // Weighted at the top alongside role coverage for that reason.
+  interestAlignment: 2.5,
   availabilityOverlap: 1,
   participantPreferences: 0.8,
 }
@@ -126,6 +129,7 @@ export const DEFAULT_SETTINGS: MatchSettings = {
   requirePresenter: true,
   preventBeginnerOnlyTeams: true,
   distributeAdvancedParticipants: true,
+  keepPreferredTogether: true,
   lockedTeams: [],
   weights: DEFAULT_WEIGHTS,
 }

--- a/src/lib/matching/groups.ts
+++ b/src/lib/matching/groups.ts
@@ -1,0 +1,108 @@
+/**
+ * Impact Lab matching engine — declared-teammate groups.
+ *
+ * Participants who named each other (or were named) as preferred teammates form
+ * "together groups": units the algorithm places onto one team as a whole, so a
+ * declared team is guaranteed to stay together rather than merely nudged by a
+ * placement bonus. Edges are directed-or-reverse (one person filling the form
+ * for their whole team is the common case), resolved with a union-find over the
+ * unlocked pool only — emails that aren't in the pool (not approved, not
+ * registered, or already organiser-pinned) simply don't create an edge.
+ *
+ * Two rules keep groups sane:
+ *   1. Blocks beat preferences — an edge between two participants who block
+ *      each other is never created.
+ *   2. A group larger than maxTeamSize can't fit on one team, so it is split
+ *      deterministically (id order) into maxTeamSize-sized chunks, with a
+ *      warning so organisers can re-pin by hand if the split is wrong.
+ */
+
+import type { MatchSettings, NormalizedParticipant } from "./types"
+import { participantsConflict } from "./constraints"
+
+export interface TogetherGroups {
+  /** Groups of 2+ participants that must share a team, deterministic order. */
+  groups: NormalizedParticipant[][]
+  /** Every id belonging to any group — excluded from individual placement. */
+  groupedIds: Set<string>
+  warnings: string[]
+}
+
+/** Union-find with path compression; keyed by participant id. */
+function findRoot(parent: Map<string, string>, id: string): string {
+  let root = id
+  while (parent.get(root) !== root) root = parent.get(root)!
+  while (parent.get(id) !== root) {
+    const next = parent.get(id)!
+    parent.set(id, root)
+    id = next
+  }
+  return root
+}
+
+/**
+ * Resolve declared-teammate groups from the pool's preferredTeammates. Only
+ * emails resolving to someone in the pool create edges; blocked pairs never
+ * link. Returns groups of 2+ (singletons are just individuals), split to fit
+ * maxTeamSize.
+ */
+export function resolveTogetherGroups(
+  pool: NormalizedParticipant[],
+  settings: MatchSettings
+): TogetherGroups {
+  const byEmail = new Map(pool.map((p) => [p.email, p]))
+  const parent = new Map(pool.map((p) => [p.id, p.id]))
+
+  for (const p of pool) {
+    for (const email of p.preferredTeammates) {
+      const other = byEmail.get(email)
+      if (!other || other.id === p.id) continue
+      if (participantsConflict(p, other)) continue // blocks beat preferences
+      const rootA = findRoot(parent, p.id)
+      const rootB = findRoot(parent, other.id)
+      if (rootA !== rootB) {
+        // Deterministic union: smaller root id wins.
+        if (rootA < rootB) parent.set(rootB, rootA)
+        else parent.set(rootA, rootB)
+      }
+    }
+  }
+
+  const byRoot = new Map<string, NormalizedParticipant[]>()
+  for (const p of pool) {
+    const root = findRoot(parent, p.id)
+    const members = byRoot.get(root)
+    if (members) members.push(p)
+    else byRoot.set(root, [p])
+  }
+
+  const warnings: string[] = []
+  const groups: NormalizedParticipant[][] = []
+
+  // Deterministic order: largest group first, then by smallest member id —
+  // big groups get first pick of empty teams, and ties never reshuffle.
+  const raw = [...byRoot.values()]
+    .filter((members) => members.length >= 2)
+    .map((members) => [...members].sort((a, b) => (a.id < b.id ? -1 : 1)))
+    .sort((a, b) => b.length - a.length || (a[0].id < b[0].id ? -1 : 1))
+
+  for (const members of raw) {
+    if (members.length <= settings.maxTeamSize) {
+      groups.push(members)
+      continue
+    }
+    // A preference chain linked more people than fit on one team. Split in id
+    // order into max-sized chunks — organisers see the warning and can re-pin.
+    const names = members.map((m) => m.fullName).join(", ")
+    warnings.push(
+      `A declared-teammate chain of ${members.length} (${names}) exceeds the max team size of ${settings.maxTeamSize} and was split — review and pin manually if the split is wrong.`
+    )
+    for (let i = 0; i < members.length; i += settings.maxTeamSize) {
+      const chunk = members.slice(i, i + settings.maxTeamSize)
+      if (chunk.length >= 2) groups.push(chunk)
+    }
+  }
+
+  const groupedIds = new Set(groups.flat().map((p) => p.id))
+  return { groups, groupedIds, warnings }
+}

--- a/src/lib/matching/normalization.ts
+++ b/src/lib/matching/normalization.ts
@@ -24,14 +24,33 @@ export function normalizeEmail(value: string): string {
   return value.toLowerCase().trim().replace(/\s/g, "")
 }
 
+/** Synonym keys longest-first, so "data scientist" wins over "data". */
+const SYNONYM_KEYS_BY_LENGTH = Object.keys(ROLE_SYNONYMS).sort(
+  (a, b) => b.length - a.length || (a < b ? -1 : 1)
+)
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
 /**
  * Map a raw role string to a canonical role, or null if it maps to nothing
- * known. Unmapped roles are dropped rather than guessed — see 02-engine-design.
+ * known. Exact synonym lookup first; when that misses, real-world free text
+ * ("Lead Machine Learning Engineer, Student") is scanned for synonym keys as
+ * whole words, longest key first. Word boundaries prevent short keys like "ai"
+ * or "ml" matching inside other words. Still conservative: text containing no
+ * known role word maps to nothing — see 02-engine-design.
  */
 export function canonicalizeRole(raw: string): CanonicalRole | null {
   const token = normalizeToken(raw)
   if (!token) return null
-  return ROLE_SYNONYMS[token] ?? null
+  const exact = ROLE_SYNONYMS[token]
+  if (exact) return exact
+  for (const key of SYNONYM_KEYS_BY_LENGTH) {
+    const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(key)}([^a-z0-9]|$)`)
+    if (pattern.test(token)) return ROLE_SYNONYMS[key]
+  }
+  return null
 }
 
 /**

--- a/src/lib/matching/optimization.ts
+++ b/src/lib/matching/optimization.ts
@@ -56,10 +56,15 @@ export function optimizeAssignment(
   for (let pass = 0; pass < MAX_SWAP_PASSES; pass++) {
     let improved = false
 
+    const pinned = context.pinnedTogetherIds
     for (let i = 0; i < editable.length; i++) {
       for (let j = i + 1; j < editable.length; j++) {
         for (let ai = 0; ai < editable[i].ids.length; ai++) {
+          // A member of a kept-together group never swaps — moving one member
+          // alone would split the group.
+          if (pinned?.has(editable[i].ids[ai])) continue
           for (let bj = 0; bj < editable[j].ids.length; bj++) {
+            if (pinned?.has(editable[j].ids[bj])) continue
             const idsI = editable[i].ids.map((id, idx) =>
               idx === ai ? editable[j].ids[bj] : id
             )

--- a/src/lib/matching/scoring.ts
+++ b/src/lib/matching/scoring.ts
@@ -36,6 +36,12 @@ import type {
 export interface ScoringContext {
   settings: MatchSettings
   eligibleEmails: Set<string>
+  /**
+   * Ids belonging to a declared-teammate together-group (set by the algorithm
+   * when keepPreferredTogether is on). Scoring ignores it; the optimizer reads
+   * it so a swap never splits a kept-together group.
+   */
+  pinnedTogetherIds?: Set<string>
 }
 
 // ─── Small numeric helpers ───────────────────────────────────────────────────

--- a/src/lib/matching/types.ts
+++ b/src/lib/matching/types.ts
@@ -101,6 +101,13 @@ export interface MatchSettings {
   requirePresenter: boolean
   preventBeginnerOnlyTeams: boolean
   distributeAdvancedParticipants: boolean
+  /**
+   * Treat declared preferred-teammate connections as a hard keep-together
+   * constraint: connected participants are placed onto one team as a unit
+   * (blocks still win; chains larger than maxTeamSize are split with a
+   * warning). When false, preferences fall back to the soft placement bonus.
+   */
+  keepPreferredTogether: boolean
   lockedTeams: LockedTeam[]
   weights: MatchWeights
 }


### PR DESCRIPTION
## Why

Impact Lab / AI Mashinani runs **25–26 July** (tomorrow). Peter's calls for the event:
consent must not gate matching or contact sharing, people who declared teammates on the
Luma form MUST land on one team, the Luma registration questions must drive the matching,
and every dashboard in the flow gets elevated.

## Engine (`src/lib/matching`)

- **New hard constraint — `keepPreferredTogether` (default on):** declared-teammate
  connections resolve via union-find into together-groups (`groups.ts`), placed onto teams
  as whole units before seeding; the swap optimizer never splits one. One-way declarations
  count (one member fills the Luma form for the whole team). Blocks beat preferences: a
  blocked edge never links, and a group with no block-free team goes unassigned with a
  warning. Chains longer than maxTeamSize split deterministically with a warning. Flag off
  → old soft +6 bonus.
- **Free-text role canonicalization:** the Luma "What is your role?" answers are job
  titles/sentences — only **7/120** mapped with exact lookup. `canonicalizeRole` now scans
  for synonym keys as whole words (longest first, word-bounded so `ai`/`ml` never match
  inside words) plus conservative occupational synonyms → **43/120** mapped.
- **`interestAlignment` weight 1 → 2.5:** interests carry the track choice and each track
  is one fixed problem — track alignment now ranks with role coverage.
- **Luma import consent-off:** every approved guest imports with `consentToMatch` AND
  `consentToShareContact` true (organiser decision 2026-07-24; per-profile opt-out
  remains). The old full-team-declarer exclusion is gone — pre-formed teams stay together
  via together-groups. *(Prod data for the current 120 was already flipped to match.)*

**Real-cohort dry run (actual 2026-07-23 export):** 30 teams (10×3, 10×4, 10×5),
0 unassigned, all 14 declared groups intact, **25/25 teammate wishes fully satisfied**,
avg team score 47 → **61**, teams under 40: 7 → 1.

## Admin (`src/components/admin/impact-lab`)

- **Matching tab:** keep-together toggle + collapsed Advanced section — number-of-teams
  override, six weight sliders with descriptions, reset-to-defaults; settings persist in
  localStorage and feed generate/explain/save identically.
- **Participants tab:** inline row editing (all fields + both consents) via the previously
  uncalled PATCH route, instant search, track badge, +N-teammates chip,
  excluded-from-matching marker.
- **Runs tab:** rows expand into a full run detail (teams, member names, score bars,
  penalties, warnings) via the previously uncalled GET /runs/[id]; inline rename + notes.
  Member names resolve from the cohort directory — the PII participantsSnapshot stays
  server-only.

## Member dashboard (`src/app/dashboard/impact-lab`)

Guided 3-section profile form, waiting state with what-happens-next + bring-list, and the
team reveal rebuilt as the hero moment: staggered entrance (fully skipped under
prefers-reduced-motion), mailto + copy-email per teammate (contact sharing is now on),
suggested direction, and a first-30-minutes nudge. Numeric scores remain hidden — nothing
new fetched or exposed.

## Docs + verification

`docs/impact-lab/` updated across 7 files to mirror all of the above.
`verify:matching` grew from 21 → **29 assertions** (keep-together pair/trio, blocks beat
preferences, chain splitting, soft-mode determinism, free-text role mapping) — all pass.
`tsc --noEmit` clean, `next build` clean, eslint clean on touched dashboard files.

## Event run-book (after merge + deploy)

1. Admin → Impact Lab → Matching → **Generate** (all 120 now included) → **Save run**
2. Runs tab → review detail → **Mark final** — only then do members see their team
3. Announce: participants must sign up with their **Luma email** + verify it to see the reveal

@Spidey-Acer