### PR TITLE
HOTFIX: activation emails never sent — await transactional sends; explain-route 504

### DIFF
--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -11,8 +11,11 @@ import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
 
-// The Claude call can take several seconds — give it room past the default.
-export const maxDuration = 30
+// One Claude call explains EVERY team in a single structured response — at
+// real cohort size (30 teams) that runs well past 30s and the platform kills
+// the function before even the deterministic fallback can return (observed:
+// 504 at exactly 30s in prod, 2026-07-24).
+export const maxDuration = 120
 
 /**
  * Explain a match with Claude. The result is recomputed server-side from the

--- a/src/app/api/forgot-password/route.ts
+++ b/src/app/api/forgot-password/route.ts
@@ -63,16 +63,18 @@ export async function POST(request: NextRequest) {
   const baseUrl = process.env.NEXTAUTH_URL || "https://www.claudekenya.org"
   const resetUrl = `${baseUrl}/reset-password?token=${token}`
 
-  // Don't await — the user shouldn't have to wait on Resend, and we always
-  // return the generic message regardless of email send success.
-  sendPasswordResetEmail({
+  // Awaited on purpose: a fire-and-forget promise dies when the serverless
+  // function freezes after the response, so the email silently never leaves.
+  // The response stays generic either way — account enumeration gets no signal.
+  const sent = await sendPasswordResetEmail({
     to: user.email,
     firstName: user.firstName,
     resetUrl,
     expiresInMinutes: TOKEN_TTL_MINUTES,
-  }).catch((err) => {
-    console.error("[forgot-password] sendPasswordResetEmail failed:", err)
   })
+  if (!sent) {
+    console.error(`[forgot-password] reset email not sent for user ${user.id}`)
+  }
 
   return genericResponse
 }

--- a/src/app/api/resend-verification/route.ts
+++ b/src/app/api/resend-verification/route.ts
@@ -45,14 +45,22 @@ export async function POST(request: NextRequest) {
   const baseUrl = process.env.NEXTAUTH_URL || "https://www.claudekenya.org"
   const verifyUrl = `${baseUrl}/verify-email?token=${token}`
 
-  sendEmailVerificationEmail({
+  // Awaited on purpose: a fire-and-forget send dies when the serverless
+  // function freezes after the response. The user explicitly asked for this
+  // email, so a failed send is reported honestly instead of claiming success.
+  const sent = await sendEmailVerificationEmail({
     to: user.email,
     firstName: user.firstName,
     verifyUrl,
     expiresInHours: VERIFICATION_TTL_HOURS,
-  }).catch((err) => {
-    console.error("[resend-verification] send failed:", err)
   })
+  if (!sent) {
+    console.error(`[resend-verification] send failed for user ${user.id}`)
+    return NextResponse.json(
+      { success: false, error: "Could not send the email right now. Please try again shortly." },
+      { status: 502 }
+    )
+  }
 
   return NextResponse.json({
     success: true,

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -85,16 +85,19 @@ export async function POST(request: NextRequest) {
   const baseUrl = process.env.NEXTAUTH_URL || "https://www.claudekenya.org"
   const verifyUrl = `${baseUrl}/verify-email?token=${verificationToken}`
 
-  // Fire-and-forget: signup should not fail if email delivery hiccups.
-  // The user can request a resend from the dashboard.
-  sendEmailVerificationEmail({
+  // Awaited on purpose: on serverless, returning the response freezes the
+  // function and kills an in-flight fire-and-forget send — the email silently
+  // never leaves. Signup still succeeds if delivery fails (sendEmail catches
+  // internally); the user can resend from the dashboard.
+  const sent = await sendEmailVerificationEmail({
     to: created.email,
     firstName: created.firstName,
     verifyUrl,
     expiresInHours: VERIFICATION_TTL_HOURS,
-  }).catch((err) => {
-    console.error("[signup] sendEmailVerificationEmail failed:", err)
   })
+  if (!sent) {
+    console.error(`[signup] verification email not sent for user ${created.id}`)
+  }
 
   return NextResponse.json({
     success: true,


### PR DESCRIPTION
## Symptom

A member signed up today and never received the activation email. Nothing in the logs.

## Root cause

`signup`, `resend-verification` and `forgot-password` all sent their email **fire-and-forget** and returned the response immediately. On Vercel serverless, the function freezes the moment the response goes out — the in-flight Resend request is killed, the email silently never leaves, and the `.catch` never fires because the promise is abandoned, not rejected. So: no email AND no log line.

## Fix

- All three routes now `await` the send (sendEmail already catches internally, so routes never throw on delivery failure).
- **signup**: still succeeds if delivery fails — logged with user id; the user can resend from the dashboard.
- **resend-verification**: now returns an honest 502 ("Could not send the email right now") instead of claiming success when the send fails.
- **forgot-password**: response stays generic either way — account enumeration still gets no signal.

## Also in this PR

`POST /api/admin/impact-lab/explain` 504'd in prod today at exactly 30s: one Claude call explains **all** teams in a single structured response, and at real cohort size (30 teams) that outruns `maxDuration = 30` — the platform kills the function before even the deterministic fallback can return. Bumped to 120.

## Event impact (25–26 Jul)

Without this, participants cannot verify their accounts → cannot see their team reveal, and "Explain with Claude" fails on the full cohort. Merge before the reveal.

Gates: `tsc --noEmit` clean, `next build` compiled successfully.

## After merging

1. Confirm the production deployment actually fires for the merge commit (the #50 merge webhook was dropped once).
2. Have the affected member log in → dashboard → resend verification (their account exists; only the email died).

@Spidey-Acer