### PR TITLE
HOTFIX: Claude team explanations truncated at full cohort — batch the calls

### DIFF
--- a/src/lib/matching/ai-explanations.ts
+++ b/src/lib/matching/ai-explanations.ts
@@ -52,6 +52,15 @@ const aiTeamSchema = z.object({
 
 const aiResponseSchema = z.object({ teams: z.array(aiTeamSchema) })
 
+/**
+ * Teams per Claude call. One call covering a full cohort hits the model's
+ * output-token ceiling — observed in prod (2026-07-24, 30 teams): finishReason
+ * "length", truncated "{}" output, schema validation failure, silent
+ * deterministic fallback. Small batches answer well within the ceiling and run
+ * in parallel, so wall-clock stays near a single small call.
+ */
+const TEAMS_PER_CALL = 6
+
 /** The slim, privacy-safe view of a participant sent to the model. */
 interface AiParticipantView {
   id: string
@@ -126,16 +135,43 @@ export async function explainWithAi(
   }
 
   try {
-    const { object } = await generateObject({
-      model: anthropic(MODEL),
-      schema: aiResponseSchema,
-      system: SYSTEM_INSTRUCTION,
-      prompt:
-        "Explain each team below. Return one entry per team.\n\n" +
-        JSON.stringify(buildPayload(result, byId), null, 2),
-    })
+    const payload = buildPayload(result, byId)
+    const batches: (typeof payload)[] = []
+    for (let i = 0; i < payload.length; i += TEAMS_PER_CALL) {
+      batches.push(payload.slice(i, i + TEAMS_PER_CALL))
+    }
 
-    const aiByTeam = new Map(object.teams.map((t) => [t.teamId, t]))
+    // Batches run in parallel and fail independently: a failed batch only
+    // sends ITS teams to the deterministic fallback, never the whole run.
+    const settled = await Promise.allSettled(
+      batches.map((batch) =>
+        generateObject({
+          model: anthropic(MODEL),
+          schema: aiResponseSchema,
+          system: SYSTEM_INSTRUCTION,
+          prompt:
+            "Explain each team below. Return one entry per team.\n\n" +
+            JSON.stringify(batch, null, 2),
+        })
+      )
+    )
+
+    const aiByTeam = new Map<string, z.infer<typeof aiTeamSchema>>()
+    let failedBatches = 0
+    for (const outcome of settled) {
+      if (outcome.status === "fulfilled") {
+        for (const team of outcome.value.object.teams) aiByTeam.set(team.teamId, team)
+      } else {
+        failedBatches++
+        console.error("[impact-lab] AI explanation batch failed:", outcome.reason)
+      }
+    }
+    if (failedBatches === settled.length) {
+      return allFallback(
+        "AI explanations failed; showing deterministic summaries instead."
+      )
+    }
+
     const warnings: string[] = []
     let usedFallback = false
 


### PR DESCRIPTION
## Symptom

"Explain with Claude" returns generic summaries, not AI ones — while the site chatbot works fine, so the API key was never the problem.

## Root cause (from prod logs, 13:06 UTC)

`AI_NoObjectGeneratedError` … `finishReason: 'length'`, output `'{}'`. One `generateObject` call was asked to explain **all 30 teams in a single structured response** and hit the model's output-token ceiling. The truncated JSON fails schema validation and the route silently degrades to deterministic fallback — by design, which is why it looked like "Claude is not working" with a 200 response.

(PR #53's maxDuration bump fixed the 504; this fixes the truncation that was hiding behind it.)

## Fix

Teams are sent to Claude in **batches of 6, in parallel** (`Promise.allSettled`), results merged. A failed batch sends only its own teams to the deterministic fallback instead of nuking the whole run; if every batch fails, behavior is unchanged from before. All existing safety properties intact (privacy-safe payload, role-suggestion validation, engine warnings merged).

## Proof

Ran the fix end-to-end against the **real 120-person cohort** with a live key:

```
teams: 30
explained in 39.2s — ai: 30, deterministic fallback: 0
usedFallback: false
ALL TEAMS EXPLAINED BY CLAUDE
```

Well inside the route's 120s budget. `tsc --noEmit` + `next build` clean.

## After merging

Confirm the production deployment fires, then hit **Explain with Claude** again in the Matching tab — every team should now carry an AI summary, strengths/weaknesses, and suggested internal roles.

@Spidey-Acer