### PR TITLE
feat(impact-lab): save Claude's explanations with the run + participant-facing voice

### DIFF
--- a/prisma/migrations/20260724150000_match_run_explanations/migration.sql
+++ b/prisma/migrations/20260724150000_match_run_explanations/migration.sql
@@ -1,0 +1,3 @@
+-- Persist the reviewed team explanations (Claude or deterministic) with the
+-- frozen run. Nullable: legacy runs fall back to deterministic explanations.
+ALTER TABLE "impact_lab_match_runs" ADD COLUMN "explanations" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -688,6 +688,10 @@ model ImpactLabMatchRun {
   settings             Json
   result               Json
   participantsSnapshot Json
+  /// TeamExplanation[] captured at save time (Claude or deterministic) so the
+  /// reviewed wording survives the save — the member reveal and run detail read
+  /// this instead of recomputing. Null on legacy runs → deterministic fallback.
+  explanations         Json?
   createdById          String?
   createdBy            User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdAt            DateTime @default(now())

--- a/src/app/api/admin/impact-lab/runs/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/runs/[id]/route.ts
@@ -26,6 +26,7 @@ export async function GET(
       isFinal: true,
       settings: true,
       result: true,
+      explanations: true,
       createdById: true,
       createdAt: true,
     },

--- a/src/app/api/admin/impact-lab/runs/route.ts
+++ b/src/app/api/admin/impact-lab/runs/route.ts
@@ -10,6 +10,17 @@ import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
 
+const explanationSchema = z.object({
+  teamId: z.string().max(40),
+  summary: z.string().max(4000),
+  strengths: z.array(z.string().max(1000)).max(20),
+  weaknesses: z.array(z.string().max(1000)).max(20),
+  suggestedProjectDirection: z.string().max(2000).optional(),
+  suggestedInternalRoles: z.record(z.string().max(40), z.string().max(200)).optional(),
+  warnings: z.array(z.string().max(1000)).max(20),
+  source: z.enum(["deterministic", "ai"]),
+})
+
 const saveSchema = z.object({
   cohort: z.string().max(60).optional(),
   name: z.string().min(1).max(120),
@@ -18,6 +29,10 @@ const saveSchema = z.object({
   // Signature of the result the organiser reviewed. If the recomputed result
   // differs (a participant was edited since Generate), we refuse to save.
   expectedSignature: z.string().max(64).optional(),
+  // The explanations the organiser reviewed (Claude or deterministic). Stored
+  // with the run so the member reveal shows the same wording; optional because
+  // an organiser may save without ever clicking Explain.
+  explanations: z.array(explanationSchema).max(200).optional(),
 })
 
 export async function GET(request: NextRequest) {
@@ -114,6 +129,13 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  // Only keep explanations that describe teams actually in the recomputed
+  // result — a stale teamId (from a different generate) must not be frozen.
+  const resultTeamIds = new Set(result.teams.map((t) => t.id))
+  const explanations = (validation.data.explanations ?? []).filter((e) =>
+    resultTeamIds.has(e.teamId)
+  )
+
   // JSON.parse(JSON.stringify(...)) yields plain JSON values for Prisma's Json columns.
   const run = await prisma.impactLabMatchRun.create({
     data: {
@@ -123,6 +145,7 @@ export async function POST(request: NextRequest) {
       settings: JSON.parse(JSON.stringify(settings)),
       result: JSON.parse(JSON.stringify(result)),
       participantsSnapshot: JSON.parse(JSON.stringify(mapped)),
+      explanations: explanations.length > 0 ? explanations : undefined,
       createdById: check.user.id || null,
     },
   })

--- a/src/app/api/impact-lab/team/route.ts
+++ b/src/app/api/impact-lab/team/route.ts
@@ -12,7 +12,29 @@ import {
   normalizeParticipants,
   type MatchParticipant,
   type NormalizedParticipant,
+  type TeamExplanation,
 } from "@/lib/matching"
+
+/**
+ * Loose guard over the run's stored `explanations` JSON: returns the entry for
+ * the given team when it looks like a TeamExplanation, else null (legacy runs
+ * or drifted JSON degrade to the deterministic explanation, never throw).
+ */
+function storedExplanationFor(
+  explanations: unknown,
+  teamId: string
+): TeamExplanation | null {
+  if (!Array.isArray(explanations)) return null
+  const entry = explanations.find(
+    (e) => typeof e === "object" && e !== null && (e as { teamId?: unknown }).teamId === teamId
+  )
+  if (!entry) return null
+  const candidate = entry as Partial<TeamExplanation>
+  if (typeof candidate.summary !== "string" || !Array.isArray(candidate.strengths)) {
+    return null
+  }
+  return candidate as TeamExplanation
+}
 
 /**
  * Members see strengths as qualities, never numbers — strip the "(NN%)"
@@ -67,10 +89,14 @@ export async function GET() {
     normalizeParticipants(snapshot).map((p) => [p.id, p])
   )
 
+  // Prefer the explanation frozen with the run (usually Claude's, reviewed by
+  // the organiser) — recompute deterministically only for legacy runs saved
+  // without one.
   const members = team.memberIds
     .map((id) => normalizedById.get(id))
     .filter((p): p is NormalizedParticipant => p !== undefined)
-  const explanation = explainTeam(team, members)
+  const explanation =
+    storedExplanationFor(run.explanations, team.id) ?? explainTeam(team, members)
 
   const live = await prisma.impactLabParticipant.findMany({
     where: { cohort: DEFAULT_COHORT, id: { in: team.memberIds } },
@@ -95,6 +121,7 @@ export async function GET() {
   const teamView: TeamRevealView = {
     teamName: team.name,
     members: memberViews,
+    summary: explanation.summary || null,
     strengths: withoutPercentages(explanation.strengths),
     projectDirection: explanation.suggestedProjectDirection ?? null,
   }

--- a/src/app/dashboard/impact-lab/TeamReveal.tsx
+++ b/src/app/dashboard/impact-lab/TeamReveal.tsx
@@ -111,6 +111,17 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
         </p>
       </motion.section>
 
+      {team.summary && (
+        <motion.section variants={item} aria-label="Why this team">
+          <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
+            {"// ./why-this-team"}
+          </h3>
+          <blockquote className="rounded-lg border border-green-primary/20 bg-green-primary/5 p-5 text-sm leading-relaxed text-text-secondary">
+            {team.summary}
+          </blockquote>
+        </motion.section>
+      )}
+
       {team.strengths.length > 0 && (
         <motion.section variants={item} aria-label="Team strengths">
           <h3 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -140,7 +140,9 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     setSaving(true)
     setError(null)
     try {
-      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings, expectedSignature: data?.signature })
+      // Explanations ride along so the reviewed wording (usually Claude's) is
+      // frozen with the run — the member reveal shows exactly what was saved.
+      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings, expectedSignature: data?.signature, explanations: explanations ?? undefined })
       setRunName("")
       onSaved()
     } catch (e) {

--- a/src/components/admin/impact-lab/RunDetail.tsx
+++ b/src/components/admin/impact-lab/RunDetail.tsx
@@ -9,6 +9,8 @@ import type { MatchResult } from "./types"
 interface RunDetailData {
   id: string
   result: MatchResult
+  /** Explanations frozen at save time (usually Claude's); null on legacy runs. */
+  explanations: { teamId: string; summary: string; source: "deterministic" | "ai" }[] | null
 }
 
 /** Minimal shape needed to resolve a member id to a display name. */
@@ -67,6 +69,9 @@ export function RunDetail({ runId, directory }: RunDetailProps) {
   if (!detail) return null
 
   const { result } = detail
+  const summaryByTeam = new Map(
+    (detail.explanations ?? []).map((e) => [e.teamId, e])
+  )
 
   return (
     <div className="p-4 space-y-3 bg-[#0a0a0a] border-t border-[#1e1e1e]">
@@ -96,6 +101,15 @@ export function RunDetail({ runId, directory }: RunDetailProps) {
                 </div>
               ))}
             </div>
+
+            {summaryByTeam.has(team.id) && (
+              <p className="text-[11px] leading-relaxed text-[#8a8a8a] border-l-2 border-[#00ff41]/30 pl-2">
+                {summaryByTeam.get(team.id)!.summary}
+                {summaryByTeam.get(team.id)!.source === "ai" && (
+                  <span className="ml-1.5 text-[9px] font-mono uppercase text-[#00ff41]/60">claude</span>
+                )}
+              </p>
+            )}
 
             <div className="space-y-1 pt-1">
               {team.score.dimensions.map((d) => (

--- a/src/lib/impact-lab/member.ts
+++ b/src/lib/impact-lab/member.ts
@@ -105,6 +105,8 @@ export interface TeamMemberView {
 export interface TeamRevealView {
   teamName: string
   members: TeamMemberView[]
+  /** The saved (usually Claude-written) team writeup, addressed to the team. */
+  summary: string | null
   strengths: string[]
   projectDirection: string | null
 }

--- a/src/lib/matching/ai-explanations.ts
+++ b/src/lib/matching/ai-explanations.ts
@@ -32,11 +32,25 @@ const MODEL = "claude-sonnet-5"
 const anthropic = createAnthropic()
 
 const SYSTEM_INSTRUCTION =
-  "Teams were already assigned by a deterministic algorithm. Your job is to " +
-  "explain the assignments so organisers understand each team's strengths and " +
-  "gaps. Never propose changing team membership. Only reference the participants " +
-  "supplied for each team. Suggested internal roles must use the given " +
-  "participant ids and only participants already on that team."
+  "Teams for an overnight hackathon in Nairobi (Impact Lab: AI Mashinani) were " +
+  "already assigned by a deterministic algorithm. Your job is to explain each " +
+  "team — and your words are shown BOTH to organisers and to the team members " +
+  "themselves at the moment their team is revealed, so write for the " +
+  "participants first.\n\n" +
+  "For the summary: 2–4 sentences addressed to the team ('You have…', 'Your " +
+  "team combines…'). Be specific and thoughtful, never generic — name the " +
+  "actual complementary skills, say WHY this particular combination can ship " +
+  "something real by morning, and point at what the mix of experience levels " +
+  "means for how they should work (who can unblock, who brings fresh eyes). " +
+  "Make it energising and concrete; a participant reading it should feel the " +
+  "team was put together on purpose and know how to start.\n\n" +
+  "Strengths: specific, evidence-based (tie each to real skills or roles on " +
+  "the team). Weaknesses: honest but constructive — phrase each as something " +
+  "the team can plan around tonight, not a verdict. Suggested internal roles: " +
+  "give each member a concrete job that plays to what they listed.\n\n" +
+  "Hard rules: never propose changing team membership. Only reference the " +
+  "participants supplied for each team. Suggested internal roles must use the " +
+  "given participant ids and only participants already on that team."
 
 const aiTeamSchema = z.object({
   teamId: z.string(),

--- a/src/lib/matching/ai-explanations.ts
+++ b/src/lib/matching/ai-explanations.ts
@@ -52,6 +52,15 @@ const aiTeamSchema = z.object({
 
 const aiResponseSchema = z.object({ teams: z.array(aiTeamSchema) })
 
+/**
+ * Teams per Claude call. One call covering a full cohort hits the model's
+ * output-token ceiling — observed in prod (2026-07-24, 30 teams): finishReason
+ * "length", truncated "{}" output, schema validation failure, silent
+ * deterministic fallback. Small batches answer well within the ceiling and run
+ * in parallel, so wall-clock stays near a single small call.
+ */
+const TEAMS_PER_CALL = 6
+
 /** The slim, privacy-safe view of a participant sent to the model. */
 interface AiParticipantView {
   id: string
@@ -126,16 +135,43 @@ export async function explainWithAi(
   }
 
   try {
-    const { object } = await generateObject({
-      model: anthropic(MODEL),
-      schema: aiResponseSchema,
-      system: SYSTEM_INSTRUCTION,
-      prompt:
-        "Explain each team below. Return one entry per team.\n\n" +
-        JSON.stringify(buildPayload(result, byId), null, 2),
-    })
+    const payload = buildPayload(result, byId)
+    const batches: (typeof payload)[] = []
+    for (let i = 0; i < payload.length; i += TEAMS_PER_CALL) {
+      batches.push(payload.slice(i, i + TEAMS_PER_CALL))
+    }
 
-    const aiByTeam = new Map(object.teams.map((t) => [t.teamId, t]))
+    // Batches run in parallel and fail independently: a failed batch only
+    // sends ITS teams to the deterministic fallback, never the whole run.
+    const settled = await Promise.allSettled(
+      batches.map((batch) =>
+        generateObject({
+          model: anthropic(MODEL),
+          schema: aiResponseSchema,
+          system: SYSTEM_INSTRUCTION,
+          prompt:
+            "Explain each team below. Return one entry per team.\n\n" +
+            JSON.stringify(batch, null, 2),
+        })
+      )
+    )
+
+    const aiByTeam = new Map<string, z.infer<typeof aiTeamSchema>>()
+    let failedBatches = 0
+    for (const outcome of settled) {
+      if (outcome.status === "fulfilled") {
+        for (const team of outcome.value.object.teams) aiByTeam.set(team.teamId, team)
+      } else {
+        failedBatches++
+        console.error("[impact-lab] AI explanation batch failed:", outcome.reason)
+      }
+    }
+    if (failedBatches === settled.length) {
+      return allFallback(
+        "AI explanations failed; showing deterministic summaries instead."
+      )
+    }
+
     const warnings: string[] = []
     let usedFallback = false
 


### PR DESCRIPTION
## Why

Two of Peter's asks: saved runs must keep the Claude explanations, and the explanations should be thoughtful and engaging for the hackathon participants who see them at the reveal.

Today, saving throws Claude's work away — the save route never stores explanations, and the member team route **recomputes deterministic ones** from the snapshot. Participants would never have seen Claude's writeup no matter what the organiser reviewed in the admin.

## What

- **`ImpactLabMatchRun.explanations Json?`** (migration `20260724150000`, **already applied to prod** — additive/nullable, safe ahead of deploy). The Save-run payload now carries the reviewed explanations, zod-validated server-side and filtered to teams present in the recomputed result.
- **Member reveal prefers the frozen explanation** over recomputing, behind a loose shape guard — legacy runs and drifted JSON degrade to deterministic, never throw. `TeamRevealView` gains `summary`; the reveal renders it as a **"why this team"** block before strengths.
- **Run detail** shows each team's saved summary with a `claude` source tag.
- **Prompt rewritten for the real audience**: summaries are addressed to the team ("You have…"), name the actual complementary skills, say why this mix can ship something real by morning, and phrase weaknesses as things to plan around tonight — energising and concrete, not generic.

## Depends on

**Merge #54 first** (batched explanations — this branch builds on it; merging this PR also brings that commit if #54 is closed instead).

## Flow after deploy

Generate → **Explain with Claude** → review → **Save run** → **Mark final**. The reveal now shows participants exactly the words the organiser reviewed.

Gates: tsc clean, verify:matching 29/29, `next build` compiled, prod migration applied.

@Spidey-Acer