### PR TITLE
feat(volunteer): revamp — 6 new roles incl. event support, modern selects, city routing, a11y

### DIFF
--- a/prisma/migrations/20260724160000_volunteer_roles_expansion/migration.sql
+++ b/prisma/migrations/20260724160000_volunteer_roles_expansion/migration.sql
@@ -1,0 +1,10 @@
+-- Six new volunteer roles (event-day help was the loudest gap) and an optional
+-- city/chapter so admins can route applications to Nairobi vs Mombasa.
+ALTER TYPE "VolunteerRole" ADD VALUE 'EVENT_SUPPORT';
+ALTER TYPE "VolunteerRole" ADD VALUE 'MENTOR';
+ALTER TYPE "VolunteerRole" ADD VALUE 'DESIGNER';
+ALTER TYPE "VolunteerRole" ADD VALUE 'PHOTOGRAPHER';
+ALTER TYPE "VolunteerRole" ADD VALUE 'TECH_SUPPORT';
+ALTER TYPE "VolunteerRole" ADD VALUE 'PARTNERSHIPS';
+
+ALTER TABLE "volunteer_applications" ADD COLUMN "city" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -463,6 +463,12 @@ enum VolunteerRole {
   COMMUNITY_MANAGER
   CONTENT_CREATOR
   EVENT_COORDINATOR
+  EVENT_SUPPORT
+  MENTOR
+  DESIGNER
+  PHOTOGRAPHER
+  TECH_SUPPORT
+  PARTNERSHIPS
 }
 
 model VolunteerApplication {
@@ -472,6 +478,9 @@ model VolunteerApplication {
   email        String
   phone        String?
   role         VolunteerRole
+  /// Chapter the volunteer can show up for (Nairobi / Mombasa / Remote) —
+  /// lets admins route applications; optional for older rows.
+  city         String?
   experience   String            @db.Text
   availability String
   motivation   String            @db.Text

--- a/src/app/admin/volunteers/page.tsx
+++ b/src/app/admin/volunteers/page.tsx
@@ -4,22 +4,12 @@ import { StatusBadge } from "@/components/admin/StatusBadge"
 import Link from "next/link"
 import { formatDate } from "@/lib/utils"
 import { ChevronRight, HandHeart } from "lucide-react"
+import {
+  VOLUNTEER_ROLE_LABELS as ROLE_LABELS,
+  VOLUNTEER_ROLE_COLORS as ROLE_COLORS,
+} from "@/lib/volunteer-roles"
 
 export const dynamic = "force-dynamic"
-
-const ROLE_LABELS: Record<string, string> = {
-  SOCIAL_MEDIA_MANAGER: "Social Media",
-  COMMUNITY_MANAGER: "Community Mgr",
-  CONTENT_CREATOR: "Content Creator",
-  EVENT_COORDINATOR: "Event Coordinator",
-}
-
-const ROLE_COLORS: Record<string, string> = {
-  SOCIAL_MEDIA_MANAGER: "#5865F2",
-  COMMUNITY_MANAGER: "#25D366",
-  CONTENT_CREATOR: "#ffb000",
-  EVENT_COORDINATOR: "#00d4ff",
-}
 
 export default async function VolunteersPage() {
   const applications = await prisma.volunteerApplication.findMany({

--- a/src/app/api/volunteer/apply/route.ts
+++ b/src/app/api/volunteer/apply/route.ts
@@ -8,18 +8,36 @@ import { sendVolunteerApplicationNotification } from "@/lib/email"
 import { VolunteerRole } from "@/generated/prisma/client"
 import { getSessionUserId } from "@/lib/auth-helpers"
 
+/**
+ * Profile links arrive as people actually type them ("github.com/name") — add
+ * the https:// scheme when it's missing, then validate as a URL. Empty strings
+ * count as absent so an untouched optional field never fails validation.
+ */
+const lenientUrl = z
+  .string()
+  .max(300)
+  .optional()
+  .transform((v) => {
+    const trimmed = v?.trim()
+    if (!trimmed) return undefined
+    return /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`
+  })
+  .pipe(z.string().url().optional())
+  .transform((v) => (v ? zodSanitizeUrl(v) : undefined))
+
 const volunteerSchema = z.object({
   name: z.string().min(2).max(100).transform(zodSanitizeString),
   email: z.string().email().transform(zodSanitizeEmail),
   phone: z.string().max(20).optional().transform(v => v ? zodSanitizeString(v) : undefined),
   role: z.nativeEnum(VolunteerRole),
+  city: z.string().max(60).optional().transform(v => v ? zodSanitizeString(v) : undefined),
   experience: z.string().min(20).max(2000).transform(zodSanitizeMultilineText(2000)),
   availability: z.string().min(2).max(200).transform(zodSanitizeString),
   motivation: z.string().min(20).max(2000).transform(zodSanitizeMultilineText(2000)),
-  linkedIn: z.string().url().optional().transform(v => v ? zodSanitizeUrl(v) : undefined),
-  github: z.string().url().optional().transform(v => v ? zodSanitizeUrl(v) : undefined),
-  twitter: z.string().url().optional().transform(v => v ? zodSanitizeUrl(v) : undefined),
-  portfolio: z.string().url().optional().transform(v => v ? zodSanitizeUrl(v) : undefined),
+  linkedIn: lenientUrl,
+  github: lenientUrl,
+  twitter: lenientUrl,
+  portfolio: lenientUrl,
 })
 
 export async function POST(request: NextRequest) {
@@ -66,6 +84,7 @@ export async function POST(request: NextRequest) {
         email: data.email,
         phone: data.phone,
         role: data.role,
+        city: data.city,
         experience: data.experience,
         availability: data.availability,
         motivation: data.motivation,

--- a/src/components/karibu/KaribuSelect.tsx
+++ b/src/components/karibu/KaribuSelect.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * KaribuSelect — accessible custom dropdown (APG "select-only" listbox
+ * pattern) styled to match the Karibu warm-light input idiom. Use in place
+ * of a native <select> when the visual language needs more control (e.g.
+ * the volunteer city picker).
+ *
+ * Keyboard: Enter/Space/ArrowUp/ArrowDown open the popover; once open,
+ * ArrowUp/ArrowDown move the active option, Enter/Space selects it,
+ * Escape or Tab closes without changing the selection. Focus never leaves
+ * the trigger button, so it's always where it should be on close.
+ */
+
+import { useEffect, useId, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+export interface KaribuSelectOption {
+  value: string;
+  label: string;
+}
+
+interface KaribuSelectProps {
+  id: string;
+  label?: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: readonly KaribuSelectOption[];
+  placeholder?: string;
+  error?: string;
+}
+
+const triggerCls = (hasError: boolean) =>
+  `flex w-full items-center justify-between gap-2 rounded-lg border ${
+    hasError ? "border-red-500/60" : "border-sand-2"
+  } bg-paper px-3 py-2.5 text-left font-inter text-sm text-ink transition-colors focus:border-clay focus:outline-none focus:ring-2 focus:ring-clay/20`;
+
+export function KaribuSelect({
+  id,
+  label,
+  value,
+  onChange,
+  options,
+  placeholder = "Select...",
+  error,
+}: KaribuSelectProps) {
+  const [open, setOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLUListElement>(null);
+  const listboxId = useId();
+  const errorId = `${id}-error`;
+
+  const selected = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", onPointerDown);
+    return () => document.removeEventListener("mousedown", onPointerDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || activeIndex < 0) return;
+    const el = listRef.current?.children[activeIndex] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+  }, [open, activeIndex]);
+
+  function openList() {
+    const idx = options.findIndex((o) => o.value === value);
+    setActiveIndex(idx >= 0 ? idx : 0);
+    setOpen(true);
+  }
+
+  function selectAndClose(optValue: string) {
+    onChange(optValue);
+    setOpen(false);
+    buttonRef.current?.focus();
+  }
+
+  function handleButtonKeyDown(e: React.KeyboardEvent<HTMLButtonElement>) {
+    if (!open) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openList();
+      }
+      return;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setActiveIndex((i) => Math.min(i + 1, options.length - 1));
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setActiveIndex((i) => Math.max(i - 1, 0));
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        if (activeIndex >= 0 && options[activeIndex]) {
+          selectAndClose(options[activeIndex].value);
+        } else {
+          setOpen(false);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setOpen(false);
+        break;
+      case "Tab":
+        setOpen(false);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return (
+    <div ref={rootRef} className="relative">
+      {label && (
+        <label
+          htmlFor={id}
+          className="mb-1.5 block font-inter text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-muted"
+        >
+          {label}
+        </label>
+      )}
+      <button
+        ref={buttonRef}
+        id={id}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        aria-describedby={error ? errorId : undefined}
+        onClick={() => (open ? setOpen(false) : openList())}
+        onKeyDown={handleButtonKeyDown}
+        className={triggerCls(!!error)}
+      >
+        <span className={selected ? "text-ink" : "text-ink-muted/70"}>
+          {selected ? selected.label : placeholder}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className={`h-4 w-4 flex-shrink-0 text-ink-muted transition-transform motion-reduce:transition-none ${
+            open ? "rotate-180" : ""
+          }`}
+        />
+      </button>
+
+      {open && (
+        <ul
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-activedescendant={activeIndex >= 0 ? `${listboxId}-opt-${activeIndex}` : undefined}
+          className="absolute z-20 mt-1 max-h-60 w-full overflow-auto rounded-lg border border-sand-2 bg-paper-card p-1 shadow-lg motion-reduce:transition-none"
+        >
+          {options.map((opt, i) => (
+            <li
+              key={opt.value}
+              id={`${listboxId}-opt-${i}`}
+              role="option"
+              aria-selected={opt.value === value}
+              onMouseEnter={() => setActiveIndex(i)}
+              onClick={() => selectAndClose(opt.value)}
+              className={`cursor-pointer rounded-md px-3 py-2 font-inter text-sm transition-colors ${
+                i === activeIndex ? "bg-clay/10 text-ink" : "text-ink-soft"
+              } ${opt.value === value ? "font-semibold text-clay" : ""}`}
+            >
+              {opt.label}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {error && (
+        <p id={errorId} role="alert" className="mt-1 font-inter text-[11px] text-red-600">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/karibu/KaribuVolunteer.tsx
+++ b/src/components/karibu/KaribuVolunteer.tsx
@@ -7,30 +7,26 @@
  * /api/csrf-token, POST /api/volunteer/apply, field-level errors, success
  * screen) — only the styling differs. The dark version stays until the
  * persona cleanup PR removes it.
+ *
+ * Role source of truth: src/lib/volunteer-roles.ts.
  */
 
-import { useState, useTransition } from "react";
+import { useEffect, useRef, useState, useTransition } from "react";
 import Link from "next/link";
-import { HandHeart, Send, Loader2, CheckCircle, AlertTriangle } from "lucide-react";
+import { Send, Loader2, CheckCircle, AlertTriangle } from "lucide-react";
 import { Reveal } from "@/components/karibu/motion/Reveal";
+import { KaribuSelect } from "@/components/karibu/KaribuSelect";
+import {
+  VOLUNTEER_ROLES,
+  VOLUNTEER_CITIES,
+  VOLUNTEER_AVAILABILITY_OPTIONS,
+} from "@/lib/volunteer-roles";
 
 const WRAP = "mx-auto max-w-[880px] px-6 md:px-10";
 const KICKER = "font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay";
+const GROUP_LABEL = "mb-1.5 font-inter text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-muted";
 
-const VOLUNTEER_ROLES = [
-  { value: "SOCIAL_MEDIA_MANAGER", label: "Social Media Manager", description: "Manage Twitter/X, LinkedIn posting and engagement" },
-  { value: "COMMUNITY_MANAGER", label: "Community Manager", description: "Manage Discord/WhatsApp, welcome members, moderate" },
-  { value: "CONTENT_CREATOR", label: "Content Creator", description: "Write blog posts, create graphics, video content" },
-  { value: "EVENT_COORDINATOR", label: "Event Coordinator", description: "Help organize and run meetups in Nairobi/Mombasa" },
-] as const;
-
-const AVAILABILITY_OPTIONS = [
-  "Weekday evenings",
-  "Weekends only",
-  "Flexible schedule",
-  "A few hours per week",
-  "Full commitment",
-] as const;
+const CITY_OPTIONS = VOLUNTEER_CITIES.map((c) => ({ value: c, label: c }));
 
 const inputCls = (hasError?: string) =>
   `w-full rounded-lg border ${
@@ -38,27 +34,47 @@ const inputCls = (hasError?: string) =>
   } bg-paper px-3 py-2.5 font-inter text-sm text-ink placeholder:text-ink-muted/70 transition-colors focus:border-clay focus:outline-none focus:ring-2 focus:ring-clay/20`;
 
 function Field({
+  id,
   label,
   error,
+  helper,
   children,
 }: {
+  id: string;
   label: string;
   error?: string;
+  helper?: string;
   children: React.ReactNode;
 }) {
   return (
     <div>
-      <label className="mb-1.5 block font-inter text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-muted">
+      <label htmlFor={id} className={GROUP_LABEL}>
         {label}
       </label>
+      {helper && <p className="mb-1.5 font-inter text-[12px] text-ink-soft">{helper}</p>}
       {children}
-      {error && <FieldError msg={error} />}
+      {error && <FieldError id={`${id}-error`} msg={error} />}
     </div>
   );
 }
 
-function FieldError({ msg }: { msg: string }) {
-  return <p className="mt-1 font-inter text-[11px] text-red-600">{msg}</p>;
+function FieldError({ id, msg }: { id?: string; msg: string }) {
+  return (
+    <p id={id} role="alert" className="mt-1 font-inter text-[11px] text-red-600">
+      {msg}
+    </p>
+  );
+}
+
+function CharCount({ value, max }: { value: string; max: number }) {
+  const nearLimit = value.length > max * 0.9;
+  return (
+    <div className="mt-1 flex justify-end">
+      <span className={`font-inter text-[11px] ${nearLimit ? "text-amber-600" : "text-ink-muted"}`}>
+        {value.length} / {max}
+      </span>
+    </div>
+  );
 }
 
 export function KaribuVolunteer() {
@@ -66,23 +82,47 @@ export function KaribuVolunteer() {
   const [success, setSuccess] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const successHeadingRef = useRef<HTMLHeadingElement>(null);
 
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phone, setPhone] = useState("");
+  const [city, setCity] = useState("");
   const [role, setRole] = useState("");
   const [experience, setExperience] = useState("");
-  const [availability, setAvailability] = useState("");
+  const [availabilitySelections, setAvailabilitySelections] = useState<string[]>([]);
   const [motivation, setMotivation] = useState("");
   const [linkedIn, setLinkedIn] = useState("");
   const [github, setGithub] = useState("");
   const [twitter, setTwitter] = useState("");
   const [portfolio, setPortfolio] = useState("");
 
+  useEffect(() => {
+    if (success) successHeadingRef.current?.focus();
+  }, [success]);
+
+  function toggleAvailability(opt: string) {
+    setAvailabilitySelections((prev) =>
+      prev.includes(opt) ? prev.filter((o) => o !== opt) : [...prev, opt]
+    );
+  }
+
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setFieldErrors({});
+
+    const manualErrors: Record<string, string> = {};
+    if (!role) manualErrors.role = "Select a volunteer role";
+    if (availabilitySelections.length === 0) {
+      manualErrors.availability = "Select at least one availability option";
+    }
+
+    if (Object.keys(manualErrors).length > 0) {
+      setFieldErrors(manualErrors);
+      setError("Please fix the errors below");
+      return;
+    }
 
     startTransition(async () => {
       try {
@@ -99,9 +139,10 @@ export function KaribuVolunteer() {
             name,
             email,
             phone: phone || undefined,
+            city: city || undefined,
             role,
             experience,
-            availability,
+            availability: availabilitySelections.join(", "),
             motivation,
             linkedIn: linkedIn || undefined,
             github: github || undefined,
@@ -126,12 +167,18 @@ export function KaribuVolunteer() {
 
   if (success) {
     return (
-      <section className={`${WRAP} py-24`} aria-label="Application submitted">
+      <section className={`${WRAP} py-24`} aria-label="Application submitted" role="status" aria-live="polite">
         <div className="mx-auto max-w-lg rounded-2xl border border-sand bg-paper-card py-10 text-center">
           <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-full bg-clay/10 text-clay">
             <CheckCircle className="h-7 w-7" />
           </div>
-          <h1 className="mb-2 font-newsreader text-[22px] text-ink">Application submitted</h1>
+          <h1
+            ref={successHeadingRef}
+            tabIndex={-1}
+            className="mb-2 font-newsreader text-[22px] text-ink outline-none"
+          >
+            Application submitted
+          </h1>
           <p className="mx-auto mb-6 max-w-md px-4 font-inter text-sm text-ink-soft">
             Thank you for volunteering with Claude Community Kenya. We&apos;ll review
             your application and get back to you soon.
@@ -162,7 +209,7 @@ export function KaribuVolunteer() {
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Volunteer header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Volunteer · Kujitolea</div>
+          <div className={`${KICKER} mb-4`}>Volunteer</div>
           <h1 className="mb-4 max-w-[700px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Give a few hours. <span className="italic text-clay">Grow the community.</span>
           </h1>
@@ -173,59 +220,48 @@ export function KaribuVolunteer() {
         </Reveal>
       </section>
 
-      {/* Available roles */}
-      <section className={`${WRAP} py-5`} aria-label="Available roles">
-        <Reveal className="grid gap-4 sm:grid-cols-2">
-          {VOLUNTEER_ROLES.map((r) => (
-            <div
-              key={r.value}
-              className="rounded-2xl border border-sand bg-paper-card p-5"
-            >
-              <div className="mb-1.5 flex items-center gap-2">
-                <HandHeart className="h-4 w-4 text-clay" />
-                <span className="font-inter text-sm font-semibold text-ink">{r.label}</span>
-              </div>
-              <p className="font-inter text-[13px] leading-[1.5] text-ink-soft">
-                {r.description}
-              </p>
-            </div>
-          ))}
-        </Reveal>
-      </section>
-
       {/* Form */}
       <section className={`${WRAP} py-10`} aria-label="Volunteer application form">
         <Reveal>
           <form onSubmit={handleSubmit} className="space-y-5">
             <div className="rounded-2xl border border-sand bg-paper-card p-6">
               <div className="grid gap-4 sm:grid-cols-2">
-                <Field label="Name *" error={fieldErrors.name}>
+                <Field id="name" label="Name *" error={fieldErrors.name}>
                   <input
+                    id="name"
                     type="text"
                     value={name}
                     onChange={(e) => setName(e.target.value)}
                     required
+                    aria-required="true"
+                    aria-invalid={!!fieldErrors.name}
+                    aria-describedby={fieldErrors.name ? "name-error" : undefined}
                     minLength={2}
                     maxLength={100}
                     placeholder="Your full name"
                     className={inputCls(fieldErrors.name)}
                   />
                 </Field>
-                <Field label="Email *" error={fieldErrors.email}>
+                <Field id="email" label="Email *" error={fieldErrors.email}>
                   <input
+                    id="email"
                     type="email"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
                     required
+                    aria-required="true"
+                    aria-invalid={!!fieldErrors.email}
+                    aria-describedby={fieldErrors.email ? "email-error" : undefined}
                     placeholder="you@example.com"
                     className={inputCls(fieldErrors.email)}
                   />
                 </Field>
               </div>
 
-              <div className="mt-4">
-                <Field label="Phone (optional)">
+              <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                <Field id="phone" label="Phone (optional)">
                   <input
+                    id="phone"
                     type="tel"
                     value={phone}
                     onChange={(e) => setPhone(e.target.value)}
@@ -234,108 +270,195 @@ export function KaribuVolunteer() {
                     className={inputCls()}
                   />
                 </Field>
+                <KaribuSelect
+                  id="city"
+                  label="City (optional)"
+                  value={city}
+                  onChange={setCity}
+                  options={CITY_OPTIONS}
+                  placeholder="Select a city..."
+                  error={fieldErrors.city}
+                />
               </div>
 
-              <div className="mt-4">
-                <Field label="Volunteer role *" error={fieldErrors.role}>
-                  <select
-                    value={role}
-                    onChange={(e) => setRole(e.target.value)}
-                    required
-                    className={inputCls(fieldErrors.role)}
-                  >
-                    <option value="">Select a role...</option>
-                    {VOLUNTEER_ROLES.map((r) => (
-                      <option key={r.value} value={r.value}>{r.label}</option>
-                    ))}
-                  </select>
-                </Field>
+              {/* Role picker */}
+              <div className="mt-5">
+                <div id="role-group-label" className={GROUP_LABEL}>
+                  Volunteer role *
+                </div>
+                <div
+                  role="radiogroup"
+                  aria-labelledby="role-group-label"
+                  aria-required="true"
+                  aria-invalid={!!fieldErrors.role}
+                  aria-describedby={fieldErrors.role ? "role-error" : undefined}
+                  className="grid grid-cols-1 gap-3 sm:grid-cols-2"
+                >
+                  {VOLUNTEER_ROLES.map((r) => {
+                    const checked = role === r.value;
+                    return (
+                      <label
+                        key={r.value}
+                        className={`relative flex cursor-pointer flex-col gap-1 rounded-xl border p-4 pl-5 transition-colors motion-reduce:transition-none ${
+                          checked ? "border-clay bg-clay/5" : "border-sand-2 hover:border-clay/50"
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="role"
+                          value={r.value}
+                          checked={checked}
+                          onChange={() => setRole(r.value)}
+                          className="sr-only"
+                        />
+                        <span
+                          aria-hidden="true"
+                          className="absolute left-2 top-[1.35rem] h-1.5 w-1.5 rounded-full"
+                          style={{
+                            backgroundColor: checked ? r.color : "transparent",
+                            boxShadow: checked ? "none" : `inset 0 0 0 1.5px ${r.color}66`,
+                          }}
+                        />
+                        <span className="font-inter text-sm font-semibold text-ink">{r.label}</span>
+                        <span className="font-inter text-[12px] leading-[1.5] text-ink-soft">
+                          {r.description}
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+                {fieldErrors.role && <FieldError id="role-error" msg={fieldErrors.role} />}
               </div>
 
-              <div className="mt-4">
-                <Field label="Availability *" error={fieldErrors.availability}>
-                  <select
-                    value={availability}
-                    onChange={(e) => setAvailability(e.target.value)}
-                    required
-                    className={inputCls(fieldErrors.availability)}
-                  >
-                    <option value="">Select availability...</option>
-                    {AVAILABILITY_OPTIONS.map((opt) => (
-                      <option key={opt} value={opt}>{opt}</option>
-                    ))}
-                  </select>
-                </Field>
+              {/* Availability */}
+              <div className="mt-5">
+                <div id="availability-group-label" className={GROUP_LABEL}>
+                  Availability *
+                </div>
+                <div
+                  role="group"
+                  aria-labelledby="availability-group-label"
+                  aria-describedby={fieldErrors.availability ? "availability-error" : undefined}
+                  className="flex flex-wrap gap-2"
+                >
+                  {VOLUNTEER_AVAILABILITY_OPTIONS.map((opt) => {
+                    const selected = availabilitySelections.includes(opt);
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        aria-pressed={selected}
+                        onClick={() => toggleAvailability(opt)}
+                        className={`rounded-full border px-3.5 py-1.5 font-inter text-[13px] font-medium transition-colors motion-reduce:transition-none ${
+                          selected
+                            ? "border-clay bg-clay/10 text-clay"
+                            : "border-sand-2 text-ink-soft hover:border-clay/50"
+                        }`}
+                      >
+                        {opt}
+                      </button>
+                    );
+                  })}
+                </div>
+                {fieldErrors.availability && (
+                  <FieldError id="availability-error" msg={fieldErrors.availability} />
+                )}
               </div>
 
-              <div className="mt-4">
-                <Field label="Relevant experience * (min 20 chars)" error={fieldErrors.experience}>
+              <div className="mt-5">
+                <Field
+                  id="experience"
+                  label="Relevant experience * (min 20 chars)"
+                  helper="What have you done that prepares you for this role?"
+                  error={fieldErrors.experience}
+                >
                   <textarea
+                    id="experience"
                     value={experience}
                     onChange={(e) => setExperience(e.target.value)}
                     required
+                    aria-required="true"
+                    aria-invalid={!!fieldErrors.experience}
+                    aria-describedby={fieldErrors.experience ? "experience-error" : undefined}
                     minLength={20}
                     maxLength={2000}
                     rows={4}
-                    placeholder="Tell us about your experience relevant to this role..."
+                    placeholder="Tell us what you've done that's relevant..."
                     className={`${inputCls(fieldErrors.experience)} resize-none`}
                   />
+                  <CharCount value={experience} max={2000} />
                 </Field>
               </div>
 
               <div className="mt-4">
-                <Field label="Why do you want to volunteer? * (min 20 chars)" error={fieldErrors.motivation}>
+                <Field
+                  id="motivation"
+                  label="Why volunteer? * (min 20 chars)"
+                  helper="What do you want to get out of it, and why CCK?"
+                  error={fieldErrors.motivation}
+                >
                   <textarea
+                    id="motivation"
                     value={motivation}
                     onChange={(e) => setMotivation(e.target.value)}
                     required
+                    aria-required="true"
+                    aria-invalid={!!fieldErrors.motivation}
+                    aria-describedby={fieldErrors.motivation ? "motivation-error" : undefined}
                     minLength={20}
                     maxLength={2000}
                     rows={3}
                     placeholder="What excites you about contributing to Claude Community Kenya?"
                     className={`${inputCls(fieldErrors.motivation)} resize-none`}
                   />
+                  <CharCount value={motivation} max={2000} />
                 </Field>
               </div>
 
               <div className="mt-5">
-                <div className="mb-3 font-inter text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-muted">
-                  Social links (optional)
-                </div>
+                <div className={`${GROUP_LABEL} mb-3`}>Links (optional)</div>
                 <div className="grid gap-3 sm:grid-cols-2">
-                  <Field label="LinkedIn">
+                  <Field id="linkedIn" label="LinkedIn">
                     <input
-                      type="url"
+                      id="linkedIn"
+                      type="text"
+                      inputMode="url"
                       value={linkedIn}
                       onChange={(e) => setLinkedIn(e.target.value)}
-                      placeholder="https://linkedin.com/in/..."
+                      placeholder="linkedin.com/in/yourname"
                       className={inputCls()}
                     />
                   </Field>
-                  <Field label="GitHub">
+                  <Field id="github" label="GitHub">
                     <input
-                      type="url"
+                      id="github"
+                      type="text"
+                      inputMode="url"
                       value={github}
                       onChange={(e) => setGithub(e.target.value)}
-                      placeholder="https://github.com/..."
+                      placeholder="github.com/yourname"
                       className={inputCls()}
                     />
                   </Field>
-                  <Field label="Twitter / X">
+                  <Field id="twitter" label="Twitter / X">
                     <input
-                      type="url"
+                      id="twitter"
+                      type="text"
+                      inputMode="url"
                       value={twitter}
                       onChange={(e) => setTwitter(e.target.value)}
-                      placeholder="https://twitter.com/..."
+                      placeholder="x.com/yourname"
                       className={inputCls()}
                     />
                   </Field>
-                  <Field label="Portfolio">
+                  <Field id="portfolio" label="Portfolio">
                     <input
-                      type="url"
+                      id="portfolio"
+                      type="text"
+                      inputMode="url"
                       value={portfolio}
                       onChange={(e) => setPortfolio(e.target.value)}
-                      placeholder="https://..."
+                      placeholder="yoursite.com"
                       className={inputCls()}
                     />
                   </Field>
@@ -344,7 +467,10 @@ export function KaribuVolunteer() {
             </div>
 
             {error && (
-              <div className="flex items-start gap-2.5 rounded-lg border border-red-500/30 bg-red-500/10 p-4 font-inter text-sm text-red-700">
+              <div
+                role="alert"
+                className="flex items-start gap-2.5 rounded-lg border border-red-500/30 bg-red-500/10 p-4 font-inter text-sm text-red-700"
+              >
                 <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
                 {error}
               </div>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -4,6 +4,7 @@
  */
 
 import { Resend } from "resend"
+import { VOLUNTEER_ROLE_LABELS as SHARED_VOLUNTEER_ROLE_LABELS } from "@/lib/volunteer-roles"
 
 // Lazy initialization — avoids build-time error when env var is not set
 let _resend: Resend | null = null
@@ -283,12 +284,7 @@ export async function sendJoinApplicationNotification(data: {
   return adminSent
 }
 
-const VOLUNTEER_ROLE_LABELS: Record<string, string> = {
-  SOCIAL_MEDIA_MANAGER: "Social Media Manager",
-  COMMUNITY_MANAGER: "Community Manager",
-  CONTENT_CREATOR: "Content Creator",
-  EVENT_COORDINATOR: "Event Coordinator",
-}
+const VOLUNTEER_ROLE_LABELS: Record<string, string> = SHARED_VOLUNTEER_ROLE_LABELS
 
 export async function sendVolunteerApplicationNotification(data: {
   name: string

--- a/src/lib/volunteer-roles.ts
+++ b/src/lib/volunteer-roles.ts
@@ -1,0 +1,103 @@
+/**
+ * Volunteer roles — the single source of truth.
+ *
+ * The role list previously lived in four places (form, email templates, admin
+ * page, Prisma enum) with labels already drifting between them. Every surface
+ * now derives from this module; the Prisma enum stays the storage contract and
+ * is checked against this list by the type below.
+ */
+
+import type { VolunteerRole } from "@/generated/prisma/enums"
+
+export interface VolunteerRoleMeta {
+  value: VolunteerRole
+  label: string
+  /** One-line pitch shown on the role card in the volunteer form. */
+  description: string
+  /** Badge color used in the admin list. */
+  color: string
+}
+
+export const VOLUNTEER_ROLES: readonly VolunteerRoleMeta[] = [
+  {
+    value: "EVENT_SUPPORT",
+    label: "Event Support",
+    description: "Help run events on the day — registration desk, setup, logistics, keeping things moving.",
+    color: "#ff3333",
+  },
+  {
+    value: "EVENT_COORDINATOR",
+    label: "Event Coordinator",
+    description: "Plan and organize meetups end to end in Nairobi and Mombasa.",
+    color: "#00d4ff",
+  },
+  {
+    value: "MENTOR",
+    label: "Mentor / Facilitator",
+    description: "Guide beginners at workshops, study groups, and hackathons.",
+    color: "#00ff41",
+  },
+  {
+    value: "TECH_SUPPORT",
+    label: "Technical Support",
+    description: "Venue AV, livestreams, demo setups, and tech triage during events.",
+    color: "#a78bfa",
+  },
+  {
+    value: "SOCIAL_MEDIA_MANAGER",
+    label: "Social Media Manager",
+    description: "Manage Twitter/X and LinkedIn posting and engagement.",
+    color: "#5865F2",
+  },
+  {
+    value: "COMMUNITY_MANAGER",
+    label: "Community Manager",
+    description: "Manage Discord and WhatsApp, welcome members, moderate.",
+    color: "#25D366",
+  },
+  {
+    value: "CONTENT_CREATOR",
+    label: "Content Creator",
+    description: "Write blog posts, create graphics and video content.",
+    color: "#ffb000",
+  },
+  {
+    value: "DESIGNER",
+    label: "Designer",
+    description: "Posters, slides, social visuals, and brand assets for events and campaigns.",
+    color: "#f472b6",
+  },
+  {
+    value: "PHOTOGRAPHER",
+    label: "Photography & Video",
+    description: "Capture events and edit highlights for recaps and social media.",
+    color: "#fb923c",
+  },
+  {
+    value: "PARTNERSHIPS",
+    label: "Partnerships",
+    description: "Help find venues, sponsors, and community partners.",
+    color: "#38bdf8",
+  },
+] as const
+
+/** value → label, for email templates and anywhere a bare label is needed. */
+export const VOLUNTEER_ROLE_LABELS: Record<VolunteerRole, string> = Object.fromEntries(
+  VOLUNTEER_ROLES.map((r) => [r.value, r.label])
+) as Record<VolunteerRole, string>
+
+/** value → badge color, for the admin list. */
+export const VOLUNTEER_ROLE_COLORS: Record<VolunteerRole, string> = Object.fromEntries(
+  VOLUNTEER_ROLES.map((r) => [r.value, r.color])
+) as Record<VolunteerRole, string>
+
+/** Chapters a volunteer can show up for; stored as a plain string. */
+export const VOLUNTEER_CITIES = ["Nairobi", "Mombasa", "Remote / Online"] as const
+
+export const VOLUNTEER_AVAILABILITY_OPTIONS = [
+  "Weekday evenings",
+  "Weekends",
+  "Event days",
+  "A few hours per week",
+  "Flexible",
+] as const


### PR DESCRIPTION
## The critique (what was wrong)

- **Role UX did the same job twice**: four display-only description cards, then a bare native dropdown re-asking the same question with descriptions stripped.
- **Every field had a real a11y bug**: labels not associated with inputs (no htmlFor/id) — screen readers announced nothing, label clicks did nothing; errors never announced.
- **Roles duplicated in 4 places** (form, email templates, admin page, DB enum) with labels already drifted ("Community Manager" vs "Community Mgr").
- Only 4 roles — no way to say "I just want to help at events". No city, so admins can't route Nairobi vs Mombasa. Single-choice availability. URL fields rejected `github.com/name`. Swahili "Kujitolea" in the kicker against the standing plain-English rule.

## The rebuild

- **10 roles** (enum migration `20260724160000`): adds **Event Support** (event-day help — the ask), Mentor/Facilitator, Designer, Photography & Video, Technical Support, Partnerships.
- **Role picker = one radiogroup of clickable cards** (label + description + per-role color accent, sr-only native radios). No more card/dropdown duplication.
- **`KaribuSelect`** — new reusable accessible listbox dropdown (APG select-only pattern, full keyboard support, no deps) → powers the new optional **city** picker (Nairobi / Mombasa / Remote; new nullable `city` column, shown to admins for routing).
- **Availability = multi-select chips**, joined into the API's existing string field.
- **`src/lib/volunteer-roles.ts` is the single source of truth** (value/label/description/color) — form, email templates, and admin list all derive from it.
- **API**: accepts `city`; profile links normalized server-side (`github.com/name` → `https://github.com/name`).
- Full a11y sweep (htmlFor/id, aria-required/invalid/describedby, role=alert, focused success heading), character counters, English-only copy.

## Merge order + migration

Merge **#54 → #55 → this**, in that order (keeps migration history linear). After this merges, ping me (or run `npx prisma migrate deploy` against prod from main) — the enum migration is **not yet applied to prod**; it's additive and safe, and the new roles only appear on the form after this deploys anyway.

Gates: tsc clean, eslint clean on both files, `next build` compiled.

@Spidey-Acer