### PR TITLE
fix(impact-lab): make Save actually work + two-step participant email (signup, then reveal)

### DIFF
--- a/src/app/api/admin/impact-lab/notify/route.ts
+++ b/src/app/api/admin/impact-lab/notify/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { rateLimit } from "@/lib/rate-limit"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import {
+  impactLabAccountEmail,
+  impactLabRevealEmail,
+  sendEmailBatch,
+  type BatchEmailItem,
+} from "@/lib/email"
+
+// A full-cohort blast is ~125 emails = 2 Resend batch calls; give the function
+// room for slow API responses.
+export const maxDuration = 60
+
+const notifySchema = z.object({
+  cohort: z.string().max(60).optional(),
+  type: z.enum(["onboarding", "reveal"]),
+})
+
+function firstNameOf(fullName: string): string {
+  return fullName.trim().split(/\s+/)[0] || "there"
+}
+
+/**
+ * Email blast to Impact Lab participants. "onboarding" tells every participant
+ * in the cohort how to create the account that unlocks their reveal; "reveal"
+ * tells everyone assigned in the cohort's FINAL run that their team is ready.
+ * Emails carry at most the team name — teammates, contacts, and the writeup
+ * stay behind the verified dashboard.
+ */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "create")
+  if (!check.authorized) return check.response
+
+  // Cohort-sized email blasts must not be spammable by a double-click storm.
+  const limit = await rateLimit(request, {
+    maxRequests: 4,
+    windowInSeconds: 600,
+    identifier: () => `impact-lab-notify:${check.user.id}`,
+  })
+  if (!limit.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many notification blasts. Wait a few minutes." },
+      { status: 429, headers: limit.headers }
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: "Invalid request body" }, { status: 400 })
+  }
+
+  const parsed = notifySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json({ success: false, error: "Validation failed" }, { status: 400 })
+  }
+
+  const cohort = safeCohort(parsed.data.cohort)
+  let items: BatchEmailItem[]
+
+  if (parsed.data.type === "onboarding") {
+    const participants = await prisma.impactLabParticipant.findMany({
+      where: { cohort },
+      select: { email: true, fullName: true },
+    })
+    items = participants.map((p) =>
+      impactLabAccountEmail({ to: p.email, firstName: firstNameOf(p.fullName) })
+    )
+  } else {
+    const run = await prisma.impactLabMatchRun.findFirst({
+      where: { cohort, isFinal: true },
+      orderBy: { createdAt: "desc" },
+      select: { id: true, result: true },
+    })
+    if (!run) {
+      return NextResponse.json(
+        { success: false, error: "No final run — mark a run as final before announcing teams." },
+        { status: 409 }
+      )
+    }
+    const teams = extractFrozenTeams(run.result)
+    if (!teams) {
+      return NextResponse.json(
+        { success: false, error: "The final run's result is malformed." },
+        { status: 409 }
+      )
+    }
+
+    const teamNameById = new Map<string, string>()
+    for (const team of teams) {
+      for (const id of team.memberIds) teamNameById.set(id, team.name)
+    }
+    const assigned = await prisma.impactLabParticipant.findMany({
+      where: { cohort, id: { in: [...teamNameById.keys()] } },
+      select: { id: true, email: true, fullName: true },
+    })
+    items = assigned.map((p) =>
+      impactLabRevealEmail({
+        to: p.email,
+        firstName: firstNameOf(p.fullName),
+        teamName: teamNameById.get(p.id) ?? "your team",
+      })
+    )
+  }
+
+  const { sent, failed } = await sendEmailBatch(items)
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "CREATE",
+    entity: "ImpactLabParticipant",
+    entityId: `notify:${parsed.data.type}:${cohort}`,
+    changes: { type: parsed.data.type, recipients: items.length, sent, failed },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({
+    success: true,
+    data: { sent, failed, recipients: items.length },
+  })
+}

--- a/src/app/api/admin/impact-lab/notify/route.ts
+++ b/src/app/api/admin/impact-lab/notify/route.ts
@@ -21,7 +21,24 @@ export const maxDuration = 60
 const notifySchema = z.object({
   cohort: z.string().max(60).optional(),
   type: z.enum(["onboarding", "reveal"]),
+  /**
+   * Which half of the cohort to send to. Daily provider quotas can be smaller
+   * than the cohort, so a blast can be split across a quota reset. The split is
+   * deterministic (email-sorted, first half then the rest), so the two halves
+   * never overlap and together cover everyone.
+   */
+  group: z.enum(["all", "first", "second"]).default("all"),
 })
+
+function selectGroup<T extends { to: string }>(
+  items: T[],
+  group: "all" | "first" | "second"
+): T[] {
+  if (group === "all") return items
+  const sorted = [...items].sort((a, b) => (a.to < b.to ? -1 : a.to > b.to ? 1 : 0))
+  const half = Math.ceil(sorted.length / 2)
+  return group === "first" ? sorted.slice(0, half) : sorted.slice(half)
+}
 
 function firstNameOf(fullName: string): string {
   return fullName.trim().split(/\s+/)[0] || "there"
@@ -114,7 +131,8 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const { sent, failed } = await sendEmailBatch(items)
+  const selected = selectGroup(items, parsed.data.group)
+  const { sent, failed } = await sendEmailBatch(selected)
 
   await logAudit({
     userId: check.user.id,
@@ -123,12 +141,24 @@ export async function POST(request: NextRequest) {
     action: "CREATE",
     entity: "ImpactLabParticipant",
     entityId: `notify:${parsed.data.type}:${cohort}`,
-    changes: { type: parsed.data.type, recipients: items.length, sent, failed },
+    changes: {
+      type: parsed.data.type,
+      group: parsed.data.group,
+      recipients: selected.length,
+      sent,
+      failed,
+    },
     ...getRequestMetadata(request),
   })
 
   return NextResponse.json({
     success: true,
-    data: { sent, failed, recipients: items.length },
+    data: {
+      sent,
+      failed,
+      recipients: selected.length,
+      group: parsed.data.group,
+      cohortSize: items.length,
+    },
   })
 }

--- a/src/app/api/admin/impact-lab/runs/[id]/route.ts
+++ b/src/app/api/admin/impact-lab/runs/[id]/route.ts
@@ -36,10 +36,24 @@ export async function GET(
   return NextResponse.json({ success: true, data: run })
 }
 
+const explanationSchema = z.object({
+  teamId: z.string().max(40),
+  summary: z.string().max(4000),
+  strengths: z.array(z.string().max(1000)).max(20),
+  weaknesses: z.array(z.string().max(1000)).max(20),
+  suggestedProjectDirection: z.string().max(2000).optional(),
+  suggestedInternalRoles: z.record(z.string().max(40), z.string().max(200)).optional(),
+  warnings: z.array(z.string().max(1000)).max(20),
+  source: z.enum(["deterministic", "ai"]),
+})
+
 const updateSchema = z.object({
   name: z.string().min(1).max(120).optional(),
   notes: z.string().max(1000).nullable().optional(),
   isFinal: z.boolean().optional(),
+  // Lets the Matching tab attach explanations to a run it auto-saved before
+  // Claude had finished writing them. Filtered to the run's own teams.
+  explanations: z.array(explanationSchema).max(200).optional(),
 })
 
 /**
@@ -79,6 +93,17 @@ export async function PATCH(
 
   const { name, notes, isFinal } = validation.data
 
+  // Explanations may only describe teams that exist in this run's frozen result.
+  let explanationsUpdate: Record<string, unknown> | undefined
+  if (validation.data.explanations) {
+    const teams = (existing.result as { teams?: { id?: string }[] } | null)?.teams ?? []
+    const teamIds = new Set(teams.map((t) => t.id))
+    const kept = validation.data.explanations.filter((e) => teamIds.has(e.teamId))
+    if (kept.length > 0) {
+      explanationsUpdate = { explanations: JSON.parse(JSON.stringify(kept)) }
+    }
+  }
+
   if (isFinal === true) {
     // Approving a final run requires the `approve` permission, not just `edit`.
     const approveCheck = await checkApiPermission("impact-lab", "approve")
@@ -96,6 +121,7 @@ export async function PATCH(
             isFinal: true,
             ...(name !== undefined ? { name } : {}),
             ...(notes !== undefined ? { notes } : {}),
+            ...explanationsUpdate,
           },
         }),
       ])
@@ -117,6 +143,7 @@ export async function PATCH(
         ...(name !== undefined ? { name } : {}),
         ...(notes !== undefined ? { notes } : {}),
         ...(isFinal === false ? { isFinal: false } : {}),
+        ...explanationsUpdate,
       },
     })
   }

--- a/src/app/api/admin/impact-lab/runs/route.ts
+++ b/src/app/api/admin/impact-lab/runs/route.ts
@@ -21,19 +21,92 @@ const explanationSchema = z.object({
   source: z.enum(["deterministic", "ai"]),
 })
 
+// The reviewed result as displayed by the Matching tab — a structural mirror of
+// the engine's MatchResult, validated field by field before it may be frozen.
+const dimensionSchema = z.object({
+  key: z.string().max(40),
+  raw: z.number(),
+  weight: z.number(),
+  weighted: z.number(),
+})
+const scoreSchema = z.object({
+  total: z.number().min(0).max(100),
+  dimensions: z.array(dimensionSchema).max(10),
+  penalties: z.array(z.object({ reason: z.string().max(300), points: z.number() })).max(10),
+  penaltyTotal: z.number(),
+})
+const teamSchema = z.object({
+  id: z.string().max(40),
+  name: z.string().max(120),
+  memberIds: z.array(z.string().max(40)).min(1).max(20),
+  locked: z.boolean(),
+  score: scoreSchema,
+})
+const resultSchema = z.object({
+  teams: z.array(teamSchema).max(200),
+  unassignedIds: z.array(z.string().max(40)).max(1000),
+  warnings: z.array(z.string().max(600)).max(200),
+  averageScore: z.number(),
+  settingsUsed: z.unknown(),
+})
+
 const saveSchema = z.object({
   cohort: z.string().max(60).optional(),
   name: z.string().min(1).max(120),
   notes: z.string().max(1000).optional(),
   settings: z.unknown().optional(),
-  // Signature of the result the organiser reviewed. If the recomputed result
-  // differs (a participant was edited since Generate), we refuse to save.
+  // The result the organiser reviewed on screen. When present it is frozen
+  // as-is (after structural + constraint validation) — participants editing
+  // their profiles between Generate and Save can no longer block the save.
+  result: resultSchema.optional(),
+  // Legacy fallback only (no `result` in the payload): signature of the
+  // reviewed result; the server recomputes and refuses on mismatch.
   expectedSignature: z.string().max(64).optional(),
   // The explanations the organiser reviewed (Claude or deterministic). Stored
   // with the run so the member reveal shows the same wording; optional because
   // an organiser may save without ever clicking Explain.
   explanations: z.array(explanationSchema).max(200).optional(),
 })
+
+/**
+ * Constraint checks on a client-submitted result: every referenced participant
+ * must exist in the cohort, nobody may be assigned twice, and no team may pair
+ * participants who blocked each other. Returns an error string or null.
+ */
+function validateReviewedResult(
+  result: z.infer<typeof resultSchema>,
+  rowsById: Map<string, { email: string; blockedTeammates: string[] }>
+): string | null {
+  const seen = new Set<string>()
+  for (const team of result.teams) {
+    for (const id of team.memberIds) {
+      if (!rowsById.has(id)) {
+        return "The reviewed teams reference a participant who no longer exists. Regenerate and try again."
+      }
+      if (seen.has(id)) {
+        return "The reviewed teams assign a participant to two teams. Regenerate and try again."
+      }
+      seen.add(id)
+    }
+    const members = team.memberIds.map((id) => rowsById.get(id)!)
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        if (
+          members[i].blockedTeammates.includes(members[j].email) ||
+          members[j].blockedTeammates.includes(members[i].email)
+        ) {
+          return "The reviewed teams place a blocked pair together. Regenerate and try again."
+        }
+      }
+    }
+  }
+  for (const id of result.unassignedIds) {
+    if (seen.has(id)) {
+      return "A participant is both assigned and unassigned. Regenerate and try again."
+    }
+  }
+  return null
+}
 
 export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "view")
@@ -113,20 +186,36 @@ export async function POST(request: NextRequest) {
 
   const participants = await prisma.impactLabParticipant.findMany({ where: { cohort } })
   const mapped = participants.map(toMatchParticipant)
-  const result = runMatching(mapped, settings)
 
-  // Refuse to freeze a run that differs from what the organiser reviewed.
-  if (
-    validation.data.expectedSignature &&
-    resultSignature(result) !== validation.data.expectedSignature
-  ) {
-    return NextResponse.json(
-      {
-        success: false,
-        error: "Participants changed since these teams were generated. Regenerate before saving.",
-      },
-      { status: 409 }
+  let result: MatchResult
+  if (validation.data.result) {
+    // Freeze exactly what the organiser reviewed. Recomputing here used to
+    // 409 whenever ANY participant edited their profile between Generate and
+    // Save — with a live cohort editing constantly, that dead-ended every
+    // save. Constraint validation replaces bit-exact recompute.
+    const rowsById = new Map(
+      participants.map((p) => [p.id, { email: p.email, blockedTeammates: p.blockedTeammates }])
     )
+    const constraintError = validateReviewedResult(validation.data.result, rowsById)
+    if (constraintError) {
+      return NextResponse.json({ success: false, error: constraintError }, { status: 409 })
+    }
+    result = validation.data.result as MatchResult
+  } else {
+    // Legacy path (older clients): recompute and refuse on signature drift.
+    result = runMatching(mapped, settings)
+    if (
+      validation.data.expectedSignature &&
+      resultSignature(result) !== validation.data.expectedSignature
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Participants changed since these teams were generated. Regenerate before saving.",
+        },
+        { status: 409 }
+      )
+    }
   }
 
   // Only keep explanations that describe teams actually in the recomputed

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -140,9 +140,10 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     setSaving(true)
     setError(null)
     try {
-      // Explanations ride along so the reviewed wording (usually Claude's) is
-      // frozen with the run — the member reveal shows exactly what was saved.
-      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings, expectedSignature: data?.signature, explanations: explanations ?? undefined })
+      // The reviewed result and its explanations ride along so the run
+      // freezes exactly what's on screen — profile edits by participants
+      // between Generate and Save can no longer block the save with a 409.
+      await apiSend("/api/admin/impact-lab/runs", "POST", { cohort, name: runName.trim(), settings, result: data?.result, expectedSignature: data?.signature, explanations: explanations ?? undefined })
       setRunName("")
       onSaved()
     } catch (e) {

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -77,6 +77,9 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
   const [saving, setSaving] = useState(false)
   const [runName, setRunName] = useState("")
   const [error, setError] = useState<string | null>(null)
+  /** Run created automatically at generate time; explanations get patched onto it. */
+  const [autoSavedRunId, setAutoSavedRunId] = useState<string | null>(null)
+  const [autoSaveNote, setAutoSaveNote] = useState<string | null>(null)
 
   // localStorage is read after mount — reading it during render would make the
   // server and client HTML disagree and trigger a hydration error.
@@ -113,8 +116,32 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     setGenerating(true)
     setError(null)
     setExplanations(null)
+    setAutoSavedRunId(null)
+    setAutoSaveNote(null)
     try {
-      setData(await apiSend<MatchResponse>("/api/admin/impact-lab/match", "POST", { cohort, settings }))
+      const res = await apiSend<MatchResponse>("/api/admin/impact-lab/match", "POST", { cohort, settings })
+      setData(res)
+
+      // Auto-save immediately: a generated result that only lives in this tab
+      // is one refresh away from being lost, and the reveal needs a SAVED run.
+      // Named by clock time so successive runs stay tellable apart; rename or
+      // delete from the Runs tab.
+      try {
+        const stamp = new Date().toLocaleString("en-KE", { dateStyle: "short", timeStyle: "short" })
+        const run = await apiSend<{ id: string }>("/api/admin/impact-lab/runs", "POST", {
+          cohort,
+          name: `Auto-save · ${stamp}`,
+          settings,
+          result: res.result,
+        })
+        setAutoSavedRunId(run.id)
+        setAutoSaveNote("Saved automatically — find it in the Runs tab.")
+        onSaved()
+      } catch (saveError) {
+        setAutoSaveNote(
+          `Generated, but auto-save failed: ${saveError instanceof Error ? saveError.message : "unknown error"}. Save manually below.`
+        )
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to generate")
     } finally {
@@ -128,6 +155,20 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     try {
       const res = await apiSend<{ explanations: TeamExplanation[] }>("/api/admin/impact-lab/explain", "POST", { cohort, settings, expectedSignature: data?.signature })
       setExplanations(res.explanations)
+
+      // Attach the writeups to the run auto-saved at generate time, so what
+      // participants see on the reveal matches what's on screen here.
+      if (autoSavedRunId) {
+        try {
+          await apiSend(`/api/admin/impact-lab/runs/${autoSavedRunId}`, "PATCH", {
+            explanations: res.explanations,
+          })
+          setAutoSaveNote("Saved automatically, explanations attached — see the Runs tab.")
+          onSaved()
+        } catch {
+          setAutoSaveNote("Explanations ready, but attaching them to the auto-saved run failed. Save manually below.")
+        }
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to explain")
     } finally {
@@ -247,6 +288,19 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
       </div>
 
       {error && <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>}
+
+      {autoSaveNote && (
+        <div
+          role="status"
+          className={`p-2 border rounded text-[11px] font-mono ${
+            autoSavedRunId
+              ? "bg-[#00ff41]/5 border-[#00ff41]/30 text-[#00ff41]"
+              : "bg-[#ffb000]/5 border-[#ffb000]/30 text-[#ffb000]"
+          }`}
+        >
+          {autoSaveNote}
+        </div>
+      )}
 
       {data && (
         <>

--- a/src/components/admin/impact-lab/ParticipantsTab.tsx
+++ b/src/components/admin/impact-lab/ParticipantsTab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Loader2, Plus, Trash2, Upload, Download, Pencil, Search, Save, X } from "lucide-react"
+import { Loader2, Plus, Trash2, Upload, Download, Pencil, Search, Save, X, Mail } from "lucide-react"
 import { apiGet, apiSend } from "./api"
 import { isLumaExport, mapLumaRows } from "@/lib/impact-lab/luma"
 import type { ParticipantRow } from "./types"
@@ -106,6 +106,8 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
   const [search, setSearch] = useState("")
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editForm, setEditForm] = useState<EditFormState | null>(null)
+  const [notifying, setNotifying] = useState(false)
+  const [notifyResult, setNotifyResult] = useState<{ sent: number; failed: number; recipients: number } | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const load = useCallback(async () => {
@@ -199,6 +201,25 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
       setError(e instanceof Error ? e.message : "Failed to update")
     } finally {
       setBusy(false)
+    }
+  }
+
+  async function sendOnboardingEmails() {
+    if (!window.confirm(`Email account-setup instructions to all ${participants.length} participants? This sends real email.`)) return
+    setNotifying(true)
+    setError(null)
+    setNotifyResult(null)
+    try {
+      const result = await apiSend<{ sent: number; failed: number; recipients: number }>(
+        "/api/admin/impact-lab/notify",
+        "POST",
+        { type: "onboarding" }
+      )
+      setNotifyResult(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to send emails")
+    } finally {
+      setNotifying(false)
     }
   }
 
@@ -331,6 +352,14 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
           >
             <Download className="w-3 h-3" /> Export
           </a>
+          <button
+            onClick={sendOnboardingEmails}
+            disabled={notifying || participants.length === 0}
+            aria-label="Email signup instructions to all participants"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888] transition-all disabled:opacity-40"
+          >
+            {notifying ? <Loader2 className="w-3 h-3 animate-spin" /> : <Mail className="w-3 h-3" />} Email signup instructions
+          </button>
           <input ref={fileRef} type="file" accept=".csv" onChange={onFile} className="hidden" />
         </div>
       </div>
@@ -342,6 +371,17 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
       </p>
       {importMsg && (
         <div className="p-2 bg-[#00d4ff]/10 border border-[#00d4ff]/30 rounded text-[11px] font-mono text-[#00d4ff]">{importMsg}</div>
+      )}
+      {notifyResult && (
+        <div role="status" className="p-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] flex items-center justify-between gap-2">
+          <span>
+            Sent {notifyResult.sent} of {notifyResult.recipients} emails
+            {notifyResult.failed > 0 && <span className="text-[#ff3333]">, {notifyResult.failed} failed</span>}
+          </span>
+          <button onClick={() => setNotifyResult(null)} aria-label="Dismiss notification status" className="text-[#00ff41]/60 hover:text-[#00ff41]">
+            <X className="w-3 h-3" />
+          </button>
+        </div>
       )}
       {error && (
         <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>

--- a/src/components/admin/impact-lab/ParticipantsTab.tsx
+++ b/src/components/admin/impact-lab/ParticipantsTab.tsx
@@ -17,6 +17,18 @@ const LEVEL_COLOR: Record<string, string> = {
 const TRACK_COLOR = "#ffb000"
 const TEAMMATES_COLOR = "#00d4ff"
 
+/** Which slice of the cohort a notify blast targets — see /api/admin/impact-lab/notify. */
+type EmailGroup = "all" | "first" | "second"
+const GROUP_LABEL: Record<EmailGroup, string> = { all: "All", first: "1st half", second: "2nd half" }
+
+interface NotifyResult {
+  sent: number
+  failed: number
+  recipients: number
+  group: EmailGroup
+  cohortSize: number
+}
+
 /** Quote-aware CSV parser — good enough for Luma / Google Form exports. */
 function parseCsv(text: string): string[][] {
   const rows: string[][] = []
@@ -106,8 +118,8 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
   const [search, setSearch] = useState("")
   const [editingId, setEditingId] = useState<string | null>(null)
   const [editForm, setEditForm] = useState<EditFormState | null>(null)
-  const [notifying, setNotifying] = useState(false)
-  const [notifyResult, setNotifyResult] = useState<{ sent: number; failed: number; recipients: number } | null>(null)
+  const [notifying, setNotifying] = useState<EmailGroup | null>(null)
+  const [notifyResult, setNotifyResult] = useState<NotifyResult | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
 
   const load = useCallback(async () => {
@@ -204,22 +216,31 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
     }
   }
 
-  async function sendOnboardingEmails() {
-    if (!window.confirm(`Email account-setup instructions to all ${participants.length} participants? This sends real email.`)) return
-    setNotifying(true)
+  async function sendOnboardingEmails(group: EmailGroup) {
+    const n = participants.length
+    const firstHalf = Math.ceil(n / 2)
+    const secondHalf = n - firstHalf
+    const confirmText =
+      group === "all"
+        ? `Email account-setup instructions to all ${n} participants? This sends real email.`
+        : group === "first"
+        ? `Email account-setup instructions to the first half (~${firstHalf} of ${n} participants)? This sends real email.`
+        : `Email account-setup instructions to the second half (~${secondHalf} of ${n} participants)? This sends real email.`
+    if (!window.confirm(confirmText)) return
+    setNotifying(group)
     setError(null)
     setNotifyResult(null)
     try {
-      const result = await apiSend<{ sent: number; failed: number; recipients: number }>(
+      const result = await apiSend<NotifyResult>(
         "/api/admin/impact-lab/notify",
         "POST",
-        { type: "onboarding" }
+        { type: "onboarding", group }
       )
       setNotifyResult(result)
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to send emails")
     } finally {
-      setNotifying(false)
+      setNotifying(null)
     }
   }
 
@@ -352,14 +373,32 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
           >
             <Download className="w-3 h-3" /> Export
           </a>
-          <button
-            onClick={sendOnboardingEmails}
-            disabled={notifying || participants.length === 0}
-            aria-label="Email signup instructions to all participants"
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border border-[#1e1e1e] rounded text-[11px] font-mono text-[#888] transition-all disabled:opacity-40"
-          >
-            {notifying ? <Loader2 className="w-3 h-3 animate-spin" /> : <Mail className="w-3 h-3" />} Email signup instructions
-          </button>
+          <div className="flex items-center rounded border border-[#1e1e1e] overflow-hidden">
+            <button
+              onClick={() => sendOnboardingEmails("all")}
+              disabled={notifying !== null || participants.length === 0}
+              aria-label="Email signup instructions to all participants"
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border-r border-[#1e1e1e] text-[11px] font-mono text-[#888] transition-all disabled:opacity-40"
+            >
+              {notifying === "all" ? <Loader2 className="w-3 h-3 animate-spin" /> : <Mail className="w-3 h-3" />} Email signup instructions
+            </button>
+            <button
+              onClick={() => sendOnboardingEmails("first")}
+              disabled={notifying !== null || participants.length === 0}
+              aria-label="Email signup instructions to the first half"
+              className="px-2.5 py-1.5 bg-[#1a1a1a] hover:bg-[#222] border-r border-[#1e1e1e] text-[10px] font-mono text-[#888] transition-all disabled:opacity-40"
+            >
+              {notifying === "first" ? <Loader2 className="w-3 h-3 animate-spin mx-auto" /> : "1st half"}
+            </button>
+            <button
+              onClick={() => sendOnboardingEmails("second")}
+              disabled={notifying !== null || participants.length === 0}
+              aria-label="Email signup instructions to the second half"
+              className="px-2.5 py-1.5 bg-[#1a1a1a] hover:bg-[#222] text-[10px] font-mono text-[#888] transition-all disabled:opacity-40"
+            >
+              {notifying === "second" ? <Loader2 className="w-3 h-3 animate-spin mx-auto" /> : "2nd half"}
+            </button>
+          </div>
           <input ref={fileRef} type="file" accept=".csv" onChange={onFile} className="hidden" />
         </div>
       </div>
@@ -375,7 +414,7 @@ export function ParticipantsTab({ cohort }: ParticipantsTabProps) {
       {notifyResult && (
         <div role="status" className="p-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] flex items-center justify-between gap-2">
           <span>
-            Sent {notifyResult.sent} of {notifyResult.recipients} emails
+            {GROUP_LABEL[notifyResult.group]}: sent {notifyResult.sent} of {notifyResult.recipients} emails
             {notifyResult.failed > 0 && <span className="text-[#ff3333]">, {notifyResult.failed} failed</span>}
           </span>
           <button onClick={() => setNotifyResult(null)} aria-label="Dismiss notification status" className="text-[#00ff41]/60 hover:text-[#00ff41]">

--- a/src/components/admin/impact-lab/RunsTab.tsx
+++ b/src/components/admin/impact-lab/RunsTab.tsx
@@ -11,6 +11,18 @@ interface RunsTabProps {
   refreshKey: number
 }
 
+/** Which slice of the cohort a notify blast targets — see /api/admin/impact-lab/notify. */
+type EmailGroup = "all" | "first" | "second"
+const GROUP_LABEL: Record<EmailGroup, string> = { all: "All", first: "1st half", second: "2nd half" }
+
+interface NotifyResult {
+  sent: number
+  failed: number
+  recipients: number
+  group: EmailGroup
+  cohortSize: number
+}
+
 export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
   const [runs, setRuns] = useState<RunSummary[]>([])
   const [loading, setLoading] = useState(true)
@@ -27,7 +39,8 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
   const [notesDraft, setNotesDraft] = useState("")
 
   const [notifyingRunId, setNotifyingRunId] = useState<string | null>(null)
-  const [notifyResult, setNotifyResult] = useState<{ sent: number; failed: number; recipients: number } | null>(null)
+  const [notifyingGroup, setNotifyingGroup] = useState<EmailGroup | null>(null)
+  const [notifyResult, setNotifyResult] = useState<NotifyResult | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -117,22 +130,28 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
     }
   }
 
-  async function emailReveal(run: RunSummary) {
-    if (!window.confirm("Email every matched participant that their team is ready? This sends real email.")) return
+  async function emailReveal(run: RunSummary, group: EmailGroup) {
+    const confirmText =
+      group === "all"
+        ? "Email every matched participant that their team is ready? This sends real email."
+        : `Email the ${group === "first" ? "first" : "second"} half of matched participants that their team is ready? This sends real email.`
+    if (!window.confirm(confirmText)) return
     setNotifyingRunId(run.id)
+    setNotifyingGroup(group)
     setError(null)
     setNotifyResult(null)
     try {
-      const result = await apiSend<{ sent: number; failed: number; recipients: number }>(
+      const result = await apiSend<NotifyResult>(
         "/api/admin/impact-lab/notify",
         "POST",
-        { type: "reveal" }
+        { type: "reveal", group }
       )
       setNotifyResult(result)
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to send emails")
     } finally {
       setNotifyingRunId(null)
+      setNotifyingGroup(null)
     }
   }
 
@@ -142,7 +161,7 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
       {notifyResult && (
         <div role="status" className="p-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] flex items-center justify-between gap-2">
           <span>
-            Sent {notifyResult.sent} of {notifyResult.recipients} emails
+            {GROUP_LABEL[notifyResult.group]}: sent {notifyResult.sent} of {notifyResult.recipients} emails
             {notifyResult.failed > 0 && <span className="text-[#ff3333]">, {notifyResult.failed} failed</span>}
           </span>
           <button onClick={() => setNotifyResult(null)} aria-label="Dismiss notification status" className="text-[#00ff41]/60 hover:text-[#00ff41]">
@@ -251,15 +270,33 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
                             <button onClick={() => markFinal(run.id)} disabled={busy} title="Mark final" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40"><CheckCircle2 className="w-3.5 h-3.5" /></button>
                           )}
                           {run.isFinal && (
-                            <button
-                              onClick={() => emailReveal(run)}
-                              disabled={busy || notifyingRunId !== null}
-                              title="Email team reveal"
-                              aria-label={`Email team reveal for ${run.name}`}
-                              className="text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
-                            >
-                              {notifyingRunId === run.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
-                            </button>
+                            <div className="flex items-center gap-1.5">
+                              <button
+                                onClick={() => emailReveal(run, "all")}
+                                disabled={busy || notifyingRunId !== null}
+                                title="Email team reveal to all"
+                                aria-label={`Email team reveal to all matched participants for ${run.name}`}
+                                className="text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
+                              >
+                                {notifyingRunId === run.id && notifyingGroup === "all" ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+                              </button>
+                              <button
+                                onClick={() => emailReveal(run, "first")}
+                                disabled={busy || notifyingRunId !== null}
+                                aria-label={`Email team reveal to the first half for ${run.name}`}
+                                className="text-[10px] font-mono text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
+                              >
+                                {notifyingRunId === run.id && notifyingGroup === "first" ? <Loader2 className="w-3 h-3 animate-spin" /> : "1st half"}
+                              </button>
+                              <button
+                                onClick={() => emailReveal(run, "second")}
+                                disabled={busy || notifyingRunId !== null}
+                                aria-label={`Email team reveal to the second half for ${run.name}`}
+                                className="text-[10px] font-mono text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
+                              >
+                                {notifyingRunId === run.id && notifyingGroup === "second" ? <Loader2 className="w-3 h-3 animate-spin" /> : "2nd half"}
+                              </button>
+                            </div>
                           )}
                           <a href={`/api/admin/impact-lab/runs/${run.id}/export`} title="Export teams CSV" className="text-[#00d4ff]/70 hover:text-[#00d4ff]"><Download className="w-3.5 h-3.5" /></a>
                           <button onClick={() => remove(run.id)} disabled={busy} title="Delete" className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>

--- a/src/components/admin/impact-lab/RunsTab.tsx
+++ b/src/components/admin/impact-lab/RunsTab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Fragment, useCallback, useEffect, useState } from "react"
-import { Loader2, Trash2, Download, CheckCircle2, ChevronRight, ChevronDown, Pencil, Save, X } from "lucide-react"
+import { Loader2, Trash2, Download, CheckCircle2, ChevronRight, ChevronDown, Pencil, Save, X, Send } from "lucide-react"
 import { apiGet, apiSend } from "./api"
 import { RunDetail } from "./RunDetail"
 import type { ParticipantRow, RunSummary } from "./types"
@@ -25,6 +25,9 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
   const [nameDraft, setNameDraft] = useState("")
   const [editingNotesId, setEditingNotesId] = useState<string | null>(null)
   const [notesDraft, setNotesDraft] = useState("")
+
+  const [notifyingRunId, setNotifyingRunId] = useState<string | null>(null)
+  const [notifyResult, setNotifyResult] = useState<{ sent: number; failed: number; recipients: number } | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -114,9 +117,39 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
     }
   }
 
+  async function emailReveal(run: RunSummary) {
+    if (!window.confirm("Email every matched participant that their team is ready? This sends real email.")) return
+    setNotifyingRunId(run.id)
+    setError(null)
+    setNotifyResult(null)
+    try {
+      const result = await apiSend<{ sent: number; failed: number; recipients: number }>(
+        "/api/admin/impact-lab/notify",
+        "POST",
+        { type: "reveal" }
+      )
+      setNotifyResult(result)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to send emails")
+    } finally {
+      setNotifyingRunId(null)
+    }
+  }
+
   return (
     <div className="space-y-4">
       {error && <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>}
+      {notifyResult && (
+        <div role="status" className="p-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] flex items-center justify-between gap-2">
+          <span>
+            Sent {notifyResult.sent} of {notifyResult.recipients} emails
+            {notifyResult.failed > 0 && <span className="text-[#ff3333]">, {notifyResult.failed} failed</span>}
+          </span>
+          <button onClick={() => setNotifyResult(null)} aria-label="Dismiss notification status" className="text-[#00ff41]/60 hover:text-[#00ff41]">
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
       <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
         {loading ? (
           <div className="p-8 text-center"><Loader2 className="w-5 h-5 animate-spin text-[#333] mx-auto" /></div>
@@ -216,6 +249,17 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
                         <div className="flex items-center justify-end gap-2">
                           {!run.isFinal && (
                             <button onClick={() => markFinal(run.id)} disabled={busy} title="Mark final" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40"><CheckCircle2 className="w-3.5 h-3.5" /></button>
+                          )}
+                          {run.isFinal && (
+                            <button
+                              onClick={() => emailReveal(run)}
+                              disabled={busy || notifyingRunId !== null}
+                              title="Email team reveal"
+                              aria-label={`Email team reveal for ${run.name}`}
+                              className="text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
+                            >
+                              {notifyingRunId === run.id ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+                            </button>
                           )}
                           <a href={`/api/admin/impact-lab/runs/${run.id}/export`} title="Export teams CSV" className="text-[#00d4ff]/70 hover:text-[#00d4ff]"><Download className="w-3.5 h-3.5" /></a>
                           <button onClick={() => remove(run.id)} disabled={busy} title="Delete" className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -76,6 +76,62 @@ export async function sendEmail({
   }
 }
 
+// ─── Batch sending ───────────────────────────────────────────────────────────
+
+export interface BatchEmailItem {
+  to: string
+  subject: string
+  html: string
+}
+
+/**
+ * Send many emails via Resend's batch API (100 per call — the API's own
+ * ceiling). Failures are counted per chunk: if a chunk's call throws, all its
+ * items count as failed; a successful call counts all its items as sent.
+ * Without an API key, logs a mock line per item and reports everything failed.
+ */
+export async function sendEmailBatch(
+  items: BatchEmailItem[]
+): Promise<{ sent: number; failed: number }> {
+  if (items.length === 0) return { sent: 0, failed: 0 }
+
+  if (!process.env.RESEND_API_KEY) {
+    console.warn("[EMAIL] RESEND_API_KEY not configured, batch not sent")
+    for (const item of items) {
+      console.log(`[EMAIL MOCK] To: ${item.to} | Subject: ${item.subject}`)
+    }
+    return { sent: 0, failed: items.length }
+  }
+
+  const from = `${EMAIL_FROM_NAME} <${EMAIL_FROM}>`
+  let sent = 0
+  let failed = 0
+  for (let i = 0; i < items.length; i += 100) {
+    const chunk = items.slice(i, i + 100)
+    try {
+      const { error } = await getResend().batch.send(
+        chunk.map((item) => ({
+          from,
+          to: [item.to],
+          subject: item.subject,
+          html: item.html,
+          text: stripHtml(item.html),
+        }))
+      )
+      if (error) {
+        console.error("[EMAIL] Batch chunk rejected:", error)
+        failed += chunk.length
+      } else {
+        sent += chunk.length
+      }
+    } catch (err) {
+      console.error("[EMAIL] Batch chunk failed:", err)
+      failed += chunk.length
+    }
+  }
+  return { sent, failed }
+}
+
 // ─── CCK-specific email templates ───────────────────────────────────────────
 
 export async function sendSpeakerApplicationNotification(data: {
@@ -376,6 +432,62 @@ export async function sendPasswordResetEmail(data: {
     subject: "Reset your CCK password",
     html,
   })
+}
+
+/**
+ * Impact Lab: account-setup instructions, sent to every approved participant
+ * before matching goes live. The recipient's own address is spelled out because
+ * signing up with a DIFFERENT email is the one mistake that locks them out of
+ * their team reveal.
+ */
+export function impactLabAccountEmail(data: {
+  to: string
+  firstName: string
+}): BatchEmailItem {
+  const html = `
+    <div style="font-family:monospace;background:#0a0a0a;color:#e0e0e0;padding:24px;border-radius:8px;border:1px solid #00ff41;">
+      <h2 style="color:#00ff41;">Impact Lab: your team drops tonight</h2>
+      <p>Hi ${esc(data.firstName)},</p>
+      <p>You're approved for <strong>Impact Lab: AI Mashinani</strong> (25&ndash;26 July). Teams are being matched tonight — here's how to see yours the moment it lands:</p>
+      <ol style="line-height:1.8;">
+        <li><a href="${APP_URL}/signup" style="color:#00ff41;">Create your account</a> using <strong>this exact email address</strong> (${esc(data.to)}) — it's how we match you to your registration.</li>
+        <li>Verify your email (the link arrives right after signup).</li>
+        <li>Open <a href="${APP_URL}/dashboard/impact-lab" style="color:#00ff41;">your Impact Lab dashboard</a> and check your matching profile — your Luma answers are pre-filled and editable.</li>
+      </ol>
+      <p>Already set up? You're done — your team will appear on that same page.</p>
+      <p style="margin:24px 0;">
+        <a href="${APP_URL}/signup" style="display:inline-block;background:#00ff41;color:#0a0a0a;padding:12px 24px;text-decoration:none;border-radius:4px;font-weight:bold;">Create my account →</a>
+      </p>
+      <p style="color:#8a8a8a;font-size:12px;">Claude Community Kenya · ${APP_URL}</p>
+    </div>
+  `
+  return { to: data.to, subject: "Impact Lab: set up your account — teams drop tonight", html }
+}
+
+/**
+ * Impact Lab: the team-is-ready announcement. Deliberately contains only the
+ * team name — teammates, contacts, and the writeup live behind the verified
+ * dashboard, never in email.
+ */
+export function impactLabRevealEmail(data: {
+  to: string
+  firstName: string
+  teamName: string
+}): BatchEmailItem {
+  const html = `
+    <div style="font-family:monospace;background:#0a0a0a;color:#e0e0e0;padding:24px;border-radius:8px;border:1px solid #00ff41;">
+      <h2 style="color:#00ff41;">Your Impact Lab team is ready</h2>
+      <p>Hi ${esc(data.firstName)},</p>
+      <p>Matching is done — you're on <strong>${esc(data.teamName)}</strong>.</p>
+      <p>Your teammates, their contacts, and why this team was put together are waiting on your dashboard:</p>
+      <p style="margin:24px 0;">
+        <a href="${APP_URL}/dashboard/impact-lab" style="display:inline-block;background:#00ff41;color:#0a0a0a;padding:12px 24px;text-decoration:none;border-radius:4px;font-weight:bold;">Meet ${esc(data.teamName)} →</a>
+      </p>
+      <p style="color:#8a8a8a;font-size:12px;">No account yet? <a href="${APP_URL}/signup" style="color:#00ff41;">Sign up</a> with this exact email address (${esc(data.to)}), verify it, and your team unlocks on the dashboard.</p>
+      <p style="color:#8a8a8a;font-size:12px;">See you at the venue. Claude Community Kenya · ${APP_URL}</p>
+    </div>
+  `
+  return { to: data.to, subject: `Impact Lab: you're on ${data.teamName}`, html }
 }
 
 export async function sendApplicationReviewEmail(data: {

--- a/src/lib/matching/ai-explanations.ts
+++ b/src/lib/matching/ai-explanations.ts
@@ -67,13 +67,21 @@ const aiTeamSchema = z.object({
 const aiResponseSchema = z.object({ teams: z.array(aiTeamSchema) })
 
 /**
- * Teams per Claude call. One call covering a full cohort hits the model's
- * output-token ceiling — observed in prod (2026-07-24, 30 teams): finishReason
- * "length", truncated "{}" output, schema validation failure, silent
- * deterministic fallback. Small batches answer well within the ceiling and run
- * in parallel, so wall-clock stays near a single small call.
+ * Teams per Claude call. Batching exists because one call covering a full
+ * cohort truncates (finishReason "length" → "{}" → schema failure → silent
+ * deterministic fallback). Prod on 2026-07-24 showed 6 was still too many once
+ * the prompt asked for participant-facing prose: five of six batches truncated
+ * and only the trailing 2-team batch survived. Three keeps each response well
+ * inside the budget below; batches run in parallel so wall-clock barely moves.
  */
-const TEAMS_PER_CALL = 6
+const TEAMS_PER_CALL = 3
+
+/**
+ * Explicit output budget per call. Without it the SDK uses a modest provider
+ * default that a few rich team writeups blow straight through — the exact
+ * cause of the truncation above.
+ */
+const MAX_OUTPUT_TOKENS = 16_000
 
 /** The slim, privacy-safe view of a participant sent to the model. */
 interface AiParticipantView {
@@ -150,37 +158,54 @@ export async function explainWithAi(
 
   try {
     const payload = buildPayload(result, byId)
-    const batches: (typeof payload)[] = []
+    type Batch = typeof payload
+    const batches: Batch[] = []
     for (let i = 0; i < payload.length; i += TEAMS_PER_CALL) {
       batches.push(payload.slice(i, i + TEAMS_PER_CALL))
     }
 
-    // Batches run in parallel and fail independently: a failed batch only
-    // sends ITS teams to the deterministic fallback, never the whole run.
-    const settled = await Promise.allSettled(
-      batches.map((batch) =>
-        generateObject({
-          model: anthropic(MODEL),
-          schema: aiResponseSchema,
-          system: SYSTEM_INSTRUCTION,
-          prompt:
-            "Explain each team below. Return one entry per team.\n\n" +
-            JSON.stringify(batch, null, 2),
-        })
-      )
+    const aiByTeam = new Map<string, z.infer<typeof aiTeamSchema>>()
+
+    const askFor = async (batch: Batch): Promise<void> => {
+      const { object } = await generateObject({
+        model: anthropic(MODEL),
+        schema: aiResponseSchema,
+        system: SYSTEM_INSTRUCTION,
+        maxOutputTokens: MAX_OUTPUT_TOKENS,
+        prompt:
+          "Explain each team below. Return one entry per team.\n\n" +
+          JSON.stringify(batch, null, 2),
+      })
+      for (const team of object.teams) aiByTeam.set(team.teamId, team)
+    }
+
+    // Batches run in parallel and fail independently. A failed multi-team batch
+    // is retried one team at a time — the dominant failure is an over-long
+    // combined response, so a single-team call almost always succeeds where the
+    // group didn't. Only a team that fails alone falls back to deterministic.
+    await Promise.allSettled(
+      batches.map(async (batch) => {
+        try {
+          await askFor(batch)
+        } catch (error) {
+          console.error("[impact-lab] AI explanation batch failed; retrying per team:", error)
+          await Promise.allSettled(
+            batch.map(async (team) => {
+              try {
+                await askFor([team])
+              } catch (retryError) {
+                console.error(
+                  `[impact-lab] AI explanation failed for ${team.teamId}:`,
+                  retryError
+                )
+              }
+            })
+          )
+        }
+      })
     )
 
-    const aiByTeam = new Map<string, z.infer<typeof aiTeamSchema>>()
-    let failedBatches = 0
-    for (const outcome of settled) {
-      if (outcome.status === "fulfilled") {
-        for (const team of outcome.value.object.teams) aiByTeam.set(team.teamId, team)
-      } else {
-        failedBatches++
-        console.error("[impact-lab] AI explanation batch failed:", outcome.reason)
-      }
-    }
-    if (failedBatches === settled.length) {
+    if (aiByTeam.size === 0) {
       return allFallback(
         "AI explanations failed; showing deterministic summaries instead."
       )


### PR DESCRIPTION
## Why Save has never worked

Production has **zero saved runs** despite repeated attempts. Root cause: the save route recomputed the match server-side and returned 409 unless the fresh result was *bit-identical* to what the organiser reviewed. **125 participants edited their profiles in the last six hours** — so every recompute drifted, and every save dead-ended. No saved run → no final run → no member reveal. The whole reveal path was unreachable.

**Fix:** the payload now carries the reviewed result itself. The server validates it structurally (zod) and then against the live cohort:

- every referenced participant exists in the cohort
- nobody is assigned to two teams
- no team contains a blocked pair
- nobody is both assigned and unassigned

Those are the properties that actually matter. Bit-exact recompute never was one. Clients that send no `result` keep the old recompute + signature path.

## Two-step email (the plan)

Deliberately **not** putting team details in email — email is the knock on the door, the dashboard is the room.

1. **"Email signup instructions"** (Participants tab) — every participant gets account-setup steps with **their own address spelled out**, because signing up with a different email is the one mistake that locks them out of their reveal. Send this now.
2. **"Email team reveal"** (Runs tab, only on a **final** run) — everyone assigned gets "you're on **Team X**" + a dashboard link. Returns 409 if no run is final, so teams can't be announced before they're locked. Send at midnight.

Both are buttons you press — not a cron — so you keep control if timing slips. Confirm dialog with live recipient count, per-blast status line (`Sent X of Y`, failures in red), rate-limited 4 per 10 min per user, audit-logged. Uses Resend's batch API (~125 emails = 2 calls).

Emails carry at most the team name; teammates, contacts, and Claude's writeup stay behind the verified dashboard.

## ⚠️ Check before midnight

**Resend free tier caps at 100 emails/day** — this cohort is ~125. Confirm the plan on your Resend dashboard, or the second half of each blast will land in the `failed` count (the status line will tell you honestly).

## Order of operations tonight

1. Merge + confirm deploy
2. Participants tab → **Email signup instructions**
3. Matching tab → Generate → **Explain with Claude** → **Save run** (now works)
4. Runs tab → **Mark final** → **Email team reveal**

Gates: tsc clean, verify:matching 29/29, `next build` compiled.

@Spidey-Acer