### PR TITLE
URGENT: drop signup verification email (blocks participants) + remove reveal email

### DIFF
--- a/src/app/api/admin/impact-lab/notify/route.ts
+++ b/src/app/api/admin/impact-lab/notify/route.ts
@@ -6,13 +6,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { rateLimit } from "@/lib/rate-limit"
 import { safeCohort } from "@/lib/impact-lab/constants"
-import { extractFrozenTeams } from "@/lib/impact-lab/member"
-import {
-  impactLabAccountEmail,
-  impactLabRevealEmail,
-  sendEmailBatch,
-  type BatchEmailItem,
-} from "@/lib/email"
+import { impactLabAccountEmail, sendEmailBatch, type BatchEmailItem } from "@/lib/email"
 
 // A full-cohort blast is ~125 emails = 2 Resend batch calls; give the function
 // room for slow API responses.
@@ -20,7 +14,10 @@ export const maxDuration = 60
 
 const notifySchema = z.object({
   cohort: z.string().max(60).optional(),
-  type: z.enum(["onboarding", "reveal"]),
+  // Only account-setup mail is sent to participants. The team reveal is
+  // published by marking a run final — it appears on their dashboard, and no
+  // mail is spent on it (the daily quota is smaller than the cohort).
+  type: z.enum(["onboarding"]),
   /**
    * Which half of the cohort to send to. Daily provider quotas can be smaller
    * than the cohort, so a blast can be split across a quota reset. The split is
@@ -84,52 +81,14 @@ export async function POST(request: NextRequest) {
   }
 
   const cohort = safeCohort(parsed.data.cohort)
-  let items: BatchEmailItem[]
 
-  if (parsed.data.type === "onboarding") {
-    const participants = await prisma.impactLabParticipant.findMany({
-      where: { cohort },
-      select: { email: true, fullName: true },
-    })
-    items = participants.map((p) =>
-      impactLabAccountEmail({ to: p.email, firstName: firstNameOf(p.fullName) })
-    )
-  } else {
-    const run = await prisma.impactLabMatchRun.findFirst({
-      where: { cohort, isFinal: true },
-      orderBy: { createdAt: "desc" },
-      select: { id: true, result: true },
-    })
-    if (!run) {
-      return NextResponse.json(
-        { success: false, error: "No final run — mark a run as final before announcing teams." },
-        { status: 409 }
-      )
-    }
-    const teams = extractFrozenTeams(run.result)
-    if (!teams) {
-      return NextResponse.json(
-        { success: false, error: "The final run's result is malformed." },
-        { status: 409 }
-      )
-    }
-
-    const teamNameById = new Map<string, string>()
-    for (const team of teams) {
-      for (const id of team.memberIds) teamNameById.set(id, team.name)
-    }
-    const assigned = await prisma.impactLabParticipant.findMany({
-      where: { cohort, id: { in: [...teamNameById.keys()] } },
-      select: { id: true, email: true, fullName: true },
-    })
-    items = assigned.map((p) =>
-      impactLabRevealEmail({
-        to: p.email,
-        firstName: firstNameOf(p.fullName),
-        teamName: teamNameById.get(p.id) ?? "your team",
-      })
-    )
-  }
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { cohort },
+    select: { email: true, fullName: true },
+  })
+  const items: BatchEmailItem[] = participants.map((p) =>
+    impactLabAccountEmail({ to: p.email, firstName: firstNameOf(p.fullName) })
+  )
 
   const selected = selectGroup(items, parsed.data.group)
   const { sent, failed } = await sendEmailBatch(selected)

--- a/src/app/api/signup/route.ts
+++ b/src/app/api/signup/route.ts
@@ -7,6 +7,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { zodSanitizeEmail, zodSanitizeString } from "@/lib/input-sanitization"
 import { sendEmailVerificationEmail } from "@/lib/email"
+import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification"
 
 const VERIFICATION_TTL_HOURS = 24
 
@@ -65,6 +66,27 @@ export async function POST(request: NextRequest) {
   }
 
   const passwordHash = await bcrypt.hash(password, 12)
+
+  // With verification off, no token is minted and no mail is sent — the quota
+  // stays available for password resets. See @/lib/email-verification.
+  if (!REQUIRE_EMAIL_VERIFICATION) {
+    await prisma.user.create({
+      data: {
+        email,
+        passwordHash,
+        firstName,
+        lastName,
+        role: "MEMBER",
+        active: true,
+        emailVerified: true,
+      },
+    })
+    return NextResponse.json({
+      success: true,
+      message: "Account created. You can sign in now.",
+    })
+  }
+
   const verificationToken = crypto.randomBytes(32).toString("hex")
   const verificationExpires = new Date(Date.now() + VERIFICATION_TTL_HOURS * 60 * 60_000)
 

--- a/src/components/admin/impact-lab/RunsTab.tsx
+++ b/src/components/admin/impact-lab/RunsTab.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { Fragment, useCallback, useEffect, useState } from "react"
-import { Loader2, Trash2, Download, CheckCircle2, ChevronRight, ChevronDown, Pencil, Save, X, Send } from "lucide-react"
+import { Loader2, Trash2, Download, CheckCircle2, ChevronRight, ChevronDown, Pencil, Save, X } from "lucide-react"
 import { apiGet, apiSend } from "./api"
 import { RunDetail } from "./RunDetail"
 import type { ParticipantRow, RunSummary } from "./types"
@@ -9,18 +9,6 @@ import type { ParticipantRow, RunSummary } from "./types"
 interface RunsTabProps {
   cohort: string
   refreshKey: number
-}
-
-/** Which slice of the cohort a notify blast targets — see /api/admin/impact-lab/notify. */
-type EmailGroup = "all" | "first" | "second"
-const GROUP_LABEL: Record<EmailGroup, string> = { all: "All", first: "1st half", second: "2nd half" }
-
-interface NotifyResult {
-  sent: number
-  failed: number
-  recipients: number
-  group: EmailGroup
-  cohortSize: number
 }
 
 export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
@@ -37,10 +25,6 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
   const [nameDraft, setNameDraft] = useState("")
   const [editingNotesId, setEditingNotesId] = useState<string | null>(null)
   const [notesDraft, setNotesDraft] = useState("")
-
-  const [notifyingRunId, setNotifyingRunId] = useState<string | null>(null)
-  const [notifyingGroup, setNotifyingGroup] = useState<EmailGroup | null>(null)
-  const [notifyResult, setNotifyResult] = useState<NotifyResult | null>(null)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -130,45 +114,9 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
     }
   }
 
-  async function emailReveal(run: RunSummary, group: EmailGroup) {
-    const confirmText =
-      group === "all"
-        ? "Email every matched participant that their team is ready? This sends real email."
-        : `Email the ${group === "first" ? "first" : "second"} half of matched participants that their team is ready? This sends real email.`
-    if (!window.confirm(confirmText)) return
-    setNotifyingRunId(run.id)
-    setNotifyingGroup(group)
-    setError(null)
-    setNotifyResult(null)
-    try {
-      const result = await apiSend<NotifyResult>(
-        "/api/admin/impact-lab/notify",
-        "POST",
-        { type: "reveal", group }
-      )
-      setNotifyResult(result)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to send emails")
-    } finally {
-      setNotifyingRunId(null)
-      setNotifyingGroup(null)
-    }
-  }
-
   return (
     <div className="space-y-4">
       {error && <div className="p-2 bg-[#ff3333]/10 border border-[#ff3333]/30 rounded text-[11px] font-mono text-[#ff3333]">{error}</div>}
-      {notifyResult && (
-        <div role="status" className="p-2 bg-[#00ff41]/10 border border-[#00ff41]/30 rounded text-[11px] font-mono text-[#00ff41] flex items-center justify-between gap-2">
-          <span>
-            {GROUP_LABEL[notifyResult.group]}: sent {notifyResult.sent} of {notifyResult.recipients} emails
-            {notifyResult.failed > 0 && <span className="text-[#ff3333]">, {notifyResult.failed} failed</span>}
-          </span>
-          <button onClick={() => setNotifyResult(null)} aria-label="Dismiss notification status" className="text-[#00ff41]/60 hover:text-[#00ff41]">
-            <X className="w-3 h-3" />
-          </button>
-        </div>
-      )}
       <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
         {loading ? (
           <div className="p-8 text-center"><Loader2 className="w-5 h-5 animate-spin text-[#333] mx-auto" /></div>
@@ -259,7 +207,10 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
                       <td className="px-4 py-3 text-[11px] font-mono text-[#888]">{run.unassignedCount}</td>
                       <td className="px-4 py-3">
                         {run.isFinal ? (
-                          <span className="text-[10px] font-mono px-2 py-0.5 rounded bg-[#00ff41]/10 border border-[#00ff41]/30 text-[#00ff41]">FINAL</span>
+                          <div className="flex flex-col gap-1">
+                            <span className="text-[10px] font-mono px-2 py-0.5 rounded bg-[#00ff41]/10 border border-[#00ff41]/30 text-[#00ff41] w-fit">FINAL</span>
+                            <span className="text-[10px] font-mono text-[#00ff41]">LIVE on participant dashboards</span>
+                          </div>
                         ) : (
                           <span className="text-[10px] font-mono text-[#555]">draft</span>
                         )}
@@ -268,35 +219,6 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
                         <div className="flex items-center justify-end gap-2">
                           {!run.isFinal && (
                             <button onClick={() => markFinal(run.id)} disabled={busy} title="Mark final" className="text-[#00ff41]/70 hover:text-[#00ff41] disabled:opacity-40"><CheckCircle2 className="w-3.5 h-3.5" /></button>
-                          )}
-                          {run.isFinal && (
-                            <div className="flex items-center gap-1.5">
-                              <button
-                                onClick={() => emailReveal(run, "all")}
-                                disabled={busy || notifyingRunId !== null}
-                                title="Email team reveal to all"
-                                aria-label={`Email team reveal to all matched participants for ${run.name}`}
-                                className="text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
-                              >
-                                {notifyingRunId === run.id && notifyingGroup === "all" ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
-                              </button>
-                              <button
-                                onClick={() => emailReveal(run, "first")}
-                                disabled={busy || notifyingRunId !== null}
-                                aria-label={`Email team reveal to the first half for ${run.name}`}
-                                className="text-[10px] font-mono text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
-                              >
-                                {notifyingRunId === run.id && notifyingGroup === "first" ? <Loader2 className="w-3 h-3 animate-spin" /> : "1st half"}
-                              </button>
-                              <button
-                                onClick={() => emailReveal(run, "second")}
-                                disabled={busy || notifyingRunId !== null}
-                                aria-label={`Email team reveal to the second half for ${run.name}`}
-                                className="text-[10px] font-mono text-[#ffb000]/70 hover:text-[#ffb000] disabled:opacity-40"
-                              >
-                                {notifyingRunId === run.id && notifyingGroup === "second" ? <Loader2 className="w-3 h-3 animate-spin" /> : "2nd half"}
-                              </button>
-                            </div>
                           )}
                           <a href={`/api/admin/impact-lab/runs/${run.id}/export`} title="Export teams CSV" className="text-[#00d4ff]/70 hover:text-[#00d4ff]"><Download className="w-3.5 h-3.5" /></a>
                           <button onClick={() => remove(run.id)} disabled={busy} title="Delete" className="text-[#ff3333]/70 hover:text-[#ff3333] disabled:opacity-40"><Trash2 className="w-3.5 h-3.5" /></button>

--- a/src/lib/email-verification.ts
+++ b/src/lib/email-verification.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether member-facing surfaces require a verified email address.
+ *
+ * OFF by default, deliberately. The transactional email quota (100/day) is
+ * smaller than the Impact Lab cohort (~125), so spending it on verification
+ * would lock most participants out of their own team reveal AND leave nothing
+ * for password resets — the one transactional email that must always work.
+ *
+ * With the gate off, signup marks the account verified without sending mail and
+ * the member surfaces stop checking. The tradeoff is accepted knowingly: someone
+ * could sign up with another registrant's address and see that person's team
+ * (teammate names and contacts within the cohort). Set
+ * REQUIRE_EMAIL_VERIFICATION=true to restore the gate once quota allows.
+ */
+export const REQUIRE_EMAIL_VERIFICATION =
+  process.env.REQUIRE_EMAIL_VERIFICATION === "true"

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -435,10 +435,11 @@ export async function sendPasswordResetEmail(data: {
 }
 
 /**
- * Impact Lab: account-setup instructions, sent to every approved participant
- * before matching goes live. The recipient's own address is spelled out because
- * signing up with a DIFFERENT email is the one mistake that locks them out of
- * their team reveal.
+ * Impact Lab: how to reach your team. Optional backup for the Luma
+ * announcement — teams are published to the dashboard, never emailed. The
+ * recipient's own address is spelled out because signing up with a DIFFERENT
+ * email is the one mistake that hides their team from them. Sign-up needs no
+ * confirmation mail, so the steps are only two.
  */
 export function impactLabAccountEmail(data: {
   to: string
@@ -446,48 +447,22 @@ export function impactLabAccountEmail(data: {
 }): BatchEmailItem {
   const html = `
     <div style="font-family:monospace;background:#0a0a0a;color:#e0e0e0;padding:24px;border-radius:8px;border:1px solid #00ff41;">
-      <h2 style="color:#00ff41;">Impact Lab: your team drops tonight</h2>
+      <h2 style="color:#00ff41;">Impact Lab: meet your team</h2>
       <p>Hi ${esc(data.firstName)},</p>
-      <p>You're approved for <strong>Impact Lab: AI Mashinani</strong> (25&ndash;26 July). Teams are being matched tonight — here's how to see yours the moment it lands:</p>
+      <p>Teams for <strong>Impact Lab: AI Mashinani</strong> are matched. Here's how to see yours:</p>
       <ol style="line-height:1.8;">
-        <li><a href="${APP_URL}/signup" style="color:#00ff41;">Create your account</a> using <strong>this exact email address</strong> (${esc(data.to)}) — it's how we match you to your registration.</li>
-        <li>Verify your email (the link arrives right after signup).</li>
-        <li>Open <a href="${APP_URL}/dashboard/impact-lab" style="color:#00ff41;">your Impact Lab dashboard</a> and check your matching profile — your Luma answers are pre-filled and editable.</li>
+        <li><a href="${APP_URL}/signup" style="color:#00ff41;">Create your account</a> using <strong>this exact email address</strong> (${esc(data.to)}) — it's how we find your registration. A different one won't match.</li>
+        <li>Open <a href="${APP_URL}/dashboard/impact-lab" style="color:#00ff41;">your Impact Lab dashboard</a>.</li>
       </ol>
-      <p>Already set up? You're done — your team will appear on that same page.</p>
+      <p>You'll find your teammates and how to reach them, what each person brings, why your team was put together this way, and a suggested direction for your build.</p>
       <p style="margin:24px 0;">
-        <a href="${APP_URL}/signup" style="display:inline-block;background:#00ff41;color:#0a0a0a;padding:12px 24px;text-decoration:none;border-radius:4px;font-weight:bold;">Create my account →</a>
+        <a href="${APP_URL}/dashboard/impact-lab" style="display:inline-block;background:#00ff41;color:#0a0a0a;padding:12px 24px;text-decoration:none;border-radius:4px;font-weight:bold;">See my team →</a>
       </p>
+      <p style="color:#8a8a8a;font-size:12px;">Already have an account? Just open the dashboard link.</p>
       <p style="color:#8a8a8a;font-size:12px;">Claude Community Kenya · ${APP_URL}</p>
     </div>
   `
-  return { to: data.to, subject: "Impact Lab: set up your account — teams drop tonight", html }
-}
-
-/**
- * Impact Lab: the team-is-ready announcement. Deliberately contains only the
- * team name — teammates, contacts, and the writeup live behind the verified
- * dashboard, never in email.
- */
-export function impactLabRevealEmail(data: {
-  to: string
-  firstName: string
-  teamName: string
-}): BatchEmailItem {
-  const html = `
-    <div style="font-family:monospace;background:#0a0a0a;color:#e0e0e0;padding:24px;border-radius:8px;border:1px solid #00ff41;">
-      <h2 style="color:#00ff41;">Your Impact Lab team is ready</h2>
-      <p>Hi ${esc(data.firstName)},</p>
-      <p>Matching is done — you're on <strong>${esc(data.teamName)}</strong>.</p>
-      <p>Your teammates, their contacts, and why this team was put together are waiting on your dashboard:</p>
-      <p style="margin:24px 0;">
-        <a href="${APP_URL}/dashboard/impact-lab" style="display:inline-block;background:#00ff41;color:#0a0a0a;padding:12px 24px;text-decoration:none;border-radius:4px;font-weight:bold;">Meet ${esc(data.teamName)} →</a>
-      </p>
-      <p style="color:#8a8a8a;font-size:12px;">No account yet? <a href="${APP_URL}/signup" style="color:#00ff41;">Sign up</a> with this exact email address (${esc(data.to)}), verify it, and your team unlocks on the dashboard.</p>
-      <p style="color:#8a8a8a;font-size:12px;">See you at the venue. Claude Community Kenya · ${APP_URL}</p>
-    </div>
-  `
-  return { to: data.to, subject: `Impact Lab: you're on ${data.teamName}`, html }
+  return { to: data.to, subject: "Impact Lab: meet your team", html }
 }
 
 export async function sendApplicationReviewEmail(data: {

--- a/src/lib/impact-lab/member.ts
+++ b/src/lib/impact-lab/member.ts
@@ -13,6 +13,7 @@ import { auth } from "@/auth"
 import { prisma } from "@/lib/prisma"
 import type { ImpactLabParticipant } from "@/generated/prisma/client"
 import type { Team } from "@/lib/matching"
+import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification"
 import { participantDraftSchema } from "./participant-schema"
 
 // ─── Member-editable profile ─────────────────────────────────────────────────
@@ -171,7 +172,7 @@ export async function checkMemberAccess(): Promise<MemberAccessResult> {
       ),
     }
   }
-  if (!user.emailVerified) {
+  if (REQUIRE_EMAIL_VERIFICATION && !user.emailVerified) {
     return {
       authorized: false,
       response: NextResponse.json(


### PR DESCRIPTION
## Read first

**#58 merged one commit too early.** Its merge took `297709b`; this commit (`2dea6ff`) landed on the branch moments later and is **not in production**. So right now:

- ✅ in prod: save fix, explain-truncation fix, auto-save, email halves, Ed's polish (#59)
- ❌ **not** in prod: **signup still demands a verification email**

That last one blocks tonight: verification mail for ~125 participants against a 100/day quota means most people never get the link, can't sign in, and never see their team — and it would burn the quota that password resets need.

## What this contains

- **`REQUIRE_EMAIL_VERIFICATION` flag, off unless set to `"true"`.** Signup creates the account already verified and sends no mail; the member gate stops checking. Password reset is untouched. Set the env var to restore the gate once quota allows.
- Tradeoff documented in `src/lib/email-verification.ts`: with the gate off, someone could sign up with another registrant's address and see that person's team (teammate names + contacts inside the cohort). Accepted knowingly for the event.
- **Reveal email removed entirely** — marking a run final publishes teams to dashboards, and the Runs tab now shows **"LIVE on participant dashboards"**. Only the optional account-setup mail remains, rewritten to two steps with no confirmation link.
- Participant-facing copy describes the team write-up **without attributing it**; the `claude` source tag stays admin-side only.

Gates: `tsc --noEmit` clean, `eslint` clean on touched files, `next build` compiled.

**Merge this before posting the Luma message** — the message says "no confirmation email needed", which is only true once this ships.

@Spidey-Acer