### PR TITLE
fix(rbac): let ADMIN mark an Impact Lab run final

### DIFF
--- a/src/lib/rbac.ts
+++ b/src/lib/rbac.ts
@@ -62,7 +62,12 @@ const rolePermissions: Record<
     community: ["view", "edit", "approve"],
     team: ["view", "edit"],
     photos: ["view", "create", "edit", "delete"],
-    "impact-lab": ["view", "create", "edit", "delete"],
+    // `approve` is what marks a match run final, which is the action that
+    // publishes teams to participants' dashboards. Withholding it from ADMIN
+    // left organisers able to generate, save and even delete runs but not
+    // reveal them — the one step the whole event depends on. ADMIN already
+    // holds `delete` here, which is strictly more destructive.
+    "impact-lab": ["view", "create", "edit", "delete", "approve"],
   },
   MODERATOR: {
     dashboard: ["view"],


### PR DESCRIPTION
Marking a match run final is gated behind the `approve` permission on `impact-lab`, which only SUPER_ADMIN held. An ADMIN organiser could generate, save, and even delete runs — but got a silent 403 on the one action that publishes teams to participants' dashboards.

Participants were waiting on a reveal that could never fire.

ADMIN already holds `delete` on this resource, which is strictly more destructive than approving, so granting `approve` closes an inconsistency rather than widening access.

- `src/lib/rbac.ts` — add `approve` to ADMIN's `impact-lab` permissions
- Gate: `npx tsc --noEmit` clean

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj