### PR TITLE
HOTFIX: dashboards demand email verification that is never sent

### DIFF
--- a/src/app/dashboard/impact-lab/page.tsx
+++ b/src/app/dashboard/impact-lab/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { ArrowLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification";
 import { VerifyEmailBanner } from "../VerifyEmailBanner";
 import { ImpactLabClient } from "./ImpactLabClient";
 
@@ -47,7 +48,12 @@ export default async function ImpactLabPage() {
           </p>
         </header>
 
-        {!user.emailVerified ? (
+        {/* Gate on the same flag the API uses. When verification is off we send
+            no verification mail, so blocking here on emailVerified alone locks
+            out every account created before the flag flipped, with no way to
+            comply — the participant is told to check an inbox nothing was sent
+            to. */}
+        {REQUIRE_EMAIL_VERIFICATION && !user.emailVerified ? (
           <>
             <VerifyEmailBanner />
             <p className="font-mono text-sm text-text-secondary">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { Metadata } from "next";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
+import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification";
 import { getUpcomingEvents } from "@/lib/data";
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants";
@@ -84,7 +85,10 @@ export default async function DashboardPage() {
 
   // Impact Lab hackathon status — mirrors the states on /dashboard/impact-lab.
   let impactLabStatus: ImpactLabStatus = "verify";
-  if (user.emailVerified) {
+  // Same flag the API and the Impact Lab page use: with verification off we
+  // send no verification mail, so gating on emailVerified alone would strand
+  // every pre-flag account on the "verify" card permanently.
+  if (!REQUIRE_EMAIL_VERIFICATION || user.emailVerified) {
     // No .catch(() => null) here: swallowing a DB error would show a
     // registered participant the affirmative "Registration not found" copy.
     // A down DB surfaces via the page error boundary, same as the user query.
@@ -147,7 +151,7 @@ export default async function DashboardPage() {
           </div>
         </header>
 
-        {!user.emailVerified && <VerifyEmailBanner />}
+        {REQUIRE_EMAIL_VERIFICATION && !user.emailVerified && <VerifyEmailBanner />}
 
         <section className="mb-8" aria-label="Impact Lab hackathon">
           <ImpactLabCard status={impactLabStatus} />


### PR DESCRIPTION
Participants report being asked to verify their email with no way to do it.

`REQUIRE_EMAIL_VERIFICATION` is unset in production (verified via `vercel env pull`), so the API gate is off and signup marks new accounts verified. But both dashboard pages gated on `user.emailVerified` directly, ignoring the flag. Any account created before that flag existed has `emailVerified = false` and receives no verification mail — permanently locked out of their team.

Both pages now consult the same flag as `checkMemberAccess`.

Gates: tsc clean, eslint clean.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj