### PR TITLE
feat(impact-lab): projector countdown at /timer

### DIFF
--- a/src/app/timer/TimerCountdown.tsx
+++ b/src/app/timer/TimerCountdown.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useReducedMotion } from "framer-motion";
+
+interface TimerCountdownProps {
+  /** Deadline as an ISO string with an offset. Rendered in the viewer's zone. */
+  deadlineIso: string;
+  label: string;
+}
+
+interface Remaining {
+  hours: number;
+  minutes: number;
+  seconds: number;
+  totalMs: number;
+}
+
+function remainingFrom(deadlineMs: number, nowMs: number): Remaining {
+  const totalMs = Math.max(0, deadlineMs - nowMs);
+  const totalSeconds = Math.floor(totalMs / 1000);
+  return {
+    hours: Math.floor(totalSeconds / 3600),
+    minutes: Math.floor((totalSeconds % 3600) / 60),
+    seconds: totalSeconds % 60,
+    totalMs,
+  };
+}
+
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * Projector-facing countdown to the submission deadline.
+ *
+ * Renders nothing until mounted: the server and the room's clock will disagree
+ * by seconds, and a hydration mismatch on the one screen everybody is watching
+ * is worse than a beat of blankness.
+ */
+export function TimerCountdown({ deadlineIso, label }: TimerCountdownProps) {
+  const reduceMotion = useReducedMotion();
+  const deadlineMs = new Date(deadlineIso).getTime();
+  const [left, setLeft] = useState<Remaining | null>(null);
+
+  useEffect(() => {
+    const tick = () => setLeft(remainingFrom(deadlineMs, Date.now()));
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, [deadlineMs]);
+
+  if (!Number.isFinite(deadlineMs)) {
+    return (
+      <p className="font-mono text-2xl text-red">
+        That deadline is not a valid date.
+      </p>
+    );
+  }
+
+  if (!left) {
+    return (
+      <div
+        className="h-[22vw] min-h-[140px]"
+        aria-hidden="true"
+        // Reserve the space the clock will occupy so nothing jumps on mount.
+      />
+    );
+  }
+
+  const closed = left.totalMs === 0;
+  // Under five minutes the room needs to feel it, not read it.
+  const urgent = !closed && left.totalMs <= 5 * 60 * 1000;
+  const warning = !closed && !urgent && left.totalMs <= 30 * 60 * 1000;
+
+  const colour = closed
+    ? "text-red"
+    : urgent
+      ? "text-red"
+      : warning
+        ? "text-amber"
+        : "text-green-primary";
+
+  const deadlineLocal = new Date(deadlineMs).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className="flex flex-col items-center gap-6 text-center">
+      <p className="font-mono text-sm uppercase tracking-[0.35em] text-text-dim sm:text-base">
+        {closed ? "Submissions closed" : label}
+      </p>
+
+      <div
+        role="timer"
+        aria-live={urgent ? "assertive" : "off"}
+        aria-label={
+          closed
+            ? "Submissions are closed"
+            : `${left.hours} hours ${left.minutes} minutes remaining`
+        }
+        className={`font-mono font-bold tabular-nums leading-none ${colour} ${
+          urgent && !reduceMotion ? "animate-pulse" : ""
+        }`}
+        style={{ fontSize: "clamp(3.5rem, 18vw, 16rem)" }}
+      >
+        {closed
+          ? "00:00:00"
+          : `${pad(left.hours)}:${pad(left.minutes)}:${pad(left.seconds)}`}
+      </div>
+
+      {!closed && (
+        <p className="font-mono text-xs uppercase tracking-[0.3em] text-text-dim sm:text-sm">
+          hours · minutes · seconds
+        </p>
+      )}
+
+      <p className="mt-2 font-mono text-base text-text-secondary sm:text-xl">
+        {closed ? (
+          <>The clock is the fairest judge in the room.</>
+        ) : (
+          <>
+            Submissions close at{" "}
+            <span className="text-text-primary">{deadlineLocal}</span>
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/src/app/timer/page.tsx
+++ b/src/app/timer/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { TimerCountdown } from "./TimerCountdown";
+
+/**
+ * Projector countdown for the Impact Lab build window.
+ *
+ * Deliberately unlinked from the navigation and excluded from search: this is a
+ * room display for one night, not part of the site's information architecture.
+ *
+ * The deadline defaults to 3:00 PM East Africa Time today and can be overridden
+ * per-load with `?at=` (an ISO string, or `HH:MM` for today), so a slipped
+ * schedule is a URL change rather than a deploy — which is the difference
+ * between fixing the clock in ten seconds and fixing it in ten minutes.
+ */
+export const metadata: Metadata = {
+  title: "Time remaining | Impact Lab",
+  description: "Countdown to submissions close.",
+  robots: { index: false, follow: false },
+};
+
+/** East Africa Time is UTC+3 year-round — no DST to account for. */
+const EAT_OFFSET = "+03:00";
+const DEFAULT_CLOSE = "15:00";
+
+/**
+ * Resolve the deadline to an offset-bearing ISO string. Anything unparseable
+ * falls back to the default rather than rendering an invalid clock.
+ */
+function resolveDeadline(at: string | undefined): string {
+  const today = new Date().toLocaleDateString("en-CA", {
+    timeZone: "Africa/Nairobi",
+  });
+
+  if (at) {
+    const hhmm = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(at.trim());
+    if (hhmm) {
+      const hh = hhmm[1].padStart(2, "0");
+      return `${today}T${hh}:${hhmm[2]}:00${EAT_OFFSET}`;
+    }
+    if (!Number.isNaN(new Date(at).getTime())) return at;
+  }
+
+  return `${today}T${DEFAULT_CLOSE}:00${EAT_OFFSET}`;
+}
+
+export default async function TimerPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ at?: string; label?: string }>;
+}) {
+  const { at, label } = await searchParams;
+  const deadlineIso = resolveDeadline(at);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-bg-primary px-6 py-16">
+      <div className="mb-10 flex items-center gap-3">
+        <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-green-primary" />
+        <span className="font-mono text-xs uppercase tracking-[0.3em] text-text-dim sm:text-sm">
+          Impact Lab · AI Mashinani
+        </span>
+      </div>
+
+      <TimerCountdown
+        deadlineIso={deadlineIso}
+        label={label?.slice(0, 60) || "Time left to submit"}
+      />
+
+      <footer className="mt-16 font-mono text-[11px] uppercase tracking-[0.3em] text-text-dim">
+        Claude Community Kenya
+      </footer>
+    </main>
+  );
+}

--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -33,6 +33,9 @@ export function ConditionalLayout({
   const pathname = usePathname();
   const isAdmin = pathname.startsWith("/admin");
   const isDashboard = pathname.startsWith("/dashboard");
+  // /timer is a projector display for the room — no nav, no footer, no chrome
+  // competing with a clock people read from across a hall.
+  const isBareDisplay = pathname.startsWith("/timer");
   // Karibu (warm-light) is the default identity. Routes still on the Terminal
   // Noir chrome are listed here and removed as they get converted — unknown
   // paths (404s) fall through to Karibu so dead links stay on-brand.
@@ -53,7 +56,7 @@ export function ConditionalLayout({
   ];
   const isKaribu = !legacyPrefixes.some((p) => pathname.startsWith(p));
 
-  if (isAdmin) {
+  if (isAdmin || isBareDisplay) {
     return <>{children}</>;
   }
 


### PR DESCRIPTION
A room-facing countdown to submissions close.

- **Unlinked**: not in either nav, not in the sitemap, `noindex`
- **Branded**: Terminal Noir tokens, monospace, tabular numerals
- **Default 3:00 PM EAT today**, overridable with `?at=15:30` or a full ISO string — a slipped schedule is a URL change, not a deploy
- Amber under 30 minutes, red and pulsing under five (pulse respects `prefers-reduced-motion`)
- Clock renders after mount so the projector never shows a hydration mismatch
- `aria-live` goes assertive only in the final five minutes

Gates: tsc clean, eslint clean.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj