### PR TITLE
feat(impact-lab): team roster self-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ next-env.d.ts
 # Local scratch / dev screenshots
 .tmp/
 .gstack/
+
+# Script output — contains participant names/ids; never commit (public repo)
+scripts/output/

--- a/src/app/api/impact-lab/team/roster/route.ts
+++ b/src/app/api/impact-lab/team/roster/route.ts
@@ -1,0 +1,215 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
+import type { Team } from "@/lib/matching"
+
+/**
+ * Team roster self-service.
+ *
+ * Groups shifted physically on the night — people moved tables and some never
+ * arrived — so any member of a team may add someone to their own team or drop
+ * a no-show. The caller's team is resolved server-side from the session, so a
+ * member can only ever edit the team they are on.
+ *
+ * Adding somebody who is on another team MOVES them: the room is the truth,
+ * and refusing would leave the two lists disagreeing with where people are
+ * actually sitting.
+ */
+
+const bodySchema = z.object({ participantId: z.string().min(1).max(64) })
+
+interface Resolved {
+  runId: string
+  teams: Team[]
+  myTeamIndex: number
+  meId: string
+}
+
+async function resolveCaller(email: string): Promise<Resolved | null> {
+  const participant = await prisma.impactLabParticipant.findUnique({
+    where: { cohort_email: { cohort: DEFAULT_COHORT, email } },
+    select: { id: true },
+  })
+  if (!participant) return null
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort: DEFAULT_COHORT, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+  if (!run) return null
+
+  const teams = extractFrozenTeams(run.result)
+  if (!teams) return null
+
+  const myTeamIndex = teams.findIndex((t) => t.memberIds.includes(participant.id))
+  if (myTeamIndex < 0) return null
+
+  return { runId: run.id, teams, myTeamIndex, meId: participant.id }
+}
+
+function noTeam(): NextResponse {
+  return NextResponse.json(
+    {
+      success: false,
+      error: "You are not on a team yet, so there is no roster to edit.",
+      code: "NO_TEAM",
+    },
+    { status: 403 }
+  )
+}
+
+/**
+ * Persist an edited team list. Takes a row lock first: two teammates editing at
+ * the same moment would otherwise read the same JSON, and the second write
+ * would silently discard the first person's change.
+ */
+async function writeTeams(runId: string, mutate: (teams: Team[]) => Team[] | null) {
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT id FROM impact_lab_match_runs WHERE id = ${runId} FOR UPDATE`
+
+    const fresh = await tx.impactLabMatchRun.findUnique({
+      where: { id: runId },
+      select: { result: true },
+    })
+    const teams = extractFrozenTeams(fresh?.result)
+    if (!teams) return null
+
+    const next = mutate(teams)
+    if (!next) return null
+
+    const result = { ...(fresh?.result as object), teams: next }
+    await tx.impactLabMatchRun.update({
+      where: { id: runId },
+      data: { result: JSON.parse(JSON.stringify(result)) },
+    })
+    return next
+  })
+}
+
+/** Add a participant to the caller's team, moving them off another if needed. */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many changes. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick someone from the list." },
+      { status: 400 }
+    )
+  }
+
+  const me = await resolveCaller(check.email)
+  if (!me) return noTeam()
+
+  const target = await prisma.impactLabParticipant.findFirst({
+    where: { id: parsed.data.participantId, cohort: DEFAULT_COHORT },
+    select: { id: true, fullName: true },
+  })
+  if (!target) {
+    return NextResponse.json(
+      { success: false, error: "That person is not registered for this hackathon." },
+      { status: 404 }
+    )
+  }
+
+  const myTeamId = me.teams[me.myTeamIndex].id
+
+  const next = await writeTeams(me.runId, (teams) => {
+    const mine = teams.find((t) => t.id === myTeamId)
+    if (!mine) return null
+    if (mine.memberIds.includes(target.id)) return teams // already here — idempotent
+
+    return teams.map((t) =>
+      t.id === myTeamId
+        ? { ...t, memberIds: [...t.memberIds, target.id] }
+        : { ...t, memberIds: t.memberIds.filter((id) => id !== target.id) }
+    )
+  })
+
+  if (!next) return noTeam()
+
+  return NextResponse.json({
+    success: true,
+    message: `${target.fullName} is now on your team.`,
+  })
+}
+
+/** Remove someone from the caller's team — typically a no-show. */
+export async function DELETE(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many changes. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick someone to remove." },
+      { status: 400 }
+    )
+  }
+
+  const me = await resolveCaller(check.email)
+  if (!me) return noTeam()
+
+  // Removing yourself would drop you out of the only team you can still edit,
+  // with no way back in. Moving tables is the other team adding you instead.
+  if (parsed.data.participantId === me.meId) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          "You cannot remove yourself. Ask your new team to add you — that moves you across.",
+        code: "CANNOT_REMOVE_SELF",
+      },
+      { status: 400 }
+    )
+  }
+
+  const myTeamId = me.teams[me.myTeamIndex].id
+
+  const next = await writeTeams(me.runId, (teams) => {
+    const mine = teams.find((t) => t.id === myTeamId)
+    if (!mine) return null
+    if (!mine.memberIds.includes(parsed.data.participantId)) return teams
+
+    return teams.map((t) =>
+      t.id === myTeamId
+        ? {
+            ...t,
+            memberIds: t.memberIds.filter((id) => id !== parsed.data.participantId),
+          }
+        : t
+    )
+  })
+
+  if (!next) return noTeam()
+
+  return NextResponse.json({ success: true, message: "Removed from your team." })
+}

--- a/src/app/api/impact-lab/team/search/route.ts
+++ b/src/app/api/impact-lab/team/search/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
+
+/**
+ * Search the cohort so a team can find the person sitting with them.
+ *
+ * Returns names only, never emails or phone numbers — this is a lookup for
+ * adding a teammate, not a directory of a hundred people's contact details.
+ * `onTeam` tells the caller the person is currently placed elsewhere, so the
+ * UI can say "this will move them" before anything happens.
+ */
+export async function GET(request: NextRequest) {
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many searches. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const q = (request.nextUrl.searchParams.get("q") ?? "").trim()
+  // Two characters is the floor: one letter would return most of the cohort and
+  // turn a teammate lookup into a roster dump.
+  if (q.length < 2) {
+    return NextResponse.json({ success: true, results: [] })
+  }
+
+  const people = await prisma.impactLabParticipant.findMany({
+    where: { cohort: DEFAULT_COHORT, fullName: { contains: q, mode: "insensitive" } },
+    select: { id: true, fullName: true },
+    orderBy: { fullName: "asc" },
+    take: 10,
+  })
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort: DEFAULT_COHORT, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { result: true },
+  })
+  const teams = extractFrozenTeams(run?.result) ?? []
+  const teamNameById = new Map<string, string>()
+  for (const team of teams) {
+    for (const id of team.memberIds) teamNameById.set(id, team.name)
+  }
+
+  return NextResponse.json({
+    success: true,
+    results: people.map((p) => ({
+      id: p.id,
+      fullName: p.fullName,
+      onTeam: teamNameById.get(p.id) ?? null,
+    })),
+  })
+}

--- a/src/app/dashboard/impact-lab/TeamReveal.tsx
+++ b/src/app/dashboard/impact-lab/TeamReveal.tsx
@@ -5,7 +5,9 @@ import { motion, useReducedMotion } from "framer-motion";
 import { Check, Copy, Lightbulb, Mail, PartyPopper, UserCheck, Users } from "lucide-react";
 import type { TeamRevealView } from "@/lib/impact-lab/member";
 import { csrfHeaders } from "@/lib/csrf-client";
+import { useRouter } from "next/navigation";
 import { SubmitProject } from "./SubmitProject";
+import { TeamRoster } from "./TeamRoster";
 
 interface TeamResponse {
   success?: boolean;
@@ -22,6 +24,7 @@ const TEAMMATE_POLL_INTERVAL_MS = 30_000;
  */
 export function TeamReveal({ team }: { team: TeamRevealView }) {
   const prefersReducedMotion = useReducedMotion();
+  const router = useRouter();
 
   // Seeded from the team payload (the caller is always one of the members),
   // then flipped locally the moment the check-in call succeeds — no reload
@@ -297,6 +300,16 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
           </li>
         </ol>
       </motion.section>
+
+      <TeamRoster
+        members={team.members}
+        onChanged={() => {
+          // The roster lives in the server-rendered payload, so a change is
+          // only visible after a refetch — reload rather than patch local
+          // state, so everyone sees the same roster the server now holds.
+          router.refresh();
+        }}
+      />
 
       <SubmitProject />
     </motion.div>

--- a/src/app/dashboard/impact-lab/TeamRoster.tsx
+++ b/src/app/dashboard/impact-lab/TeamRoster.tsx
@@ -1,0 +1,246 @@
+"use client";
+
+import { useState } from "react";
+import { useReducedMotion } from "framer-motion";
+import { UserPlus, UserMinus, Search, Loader2 } from "lucide-react";
+import { csrfHeaders } from "@/lib/csrf-client";
+import type { TeamMemberView } from "@/lib/impact-lab/member";
+
+interface SearchHit {
+  id: string;
+  fullName: string;
+  onTeam: string | null;
+}
+
+/**
+ * Roster self-service for a team.
+ *
+ * Groups shifted on the night — people moved tables, some never arrived — so
+ * any member can add whoever is actually sitting with them and drop a no-show,
+ * without queueing at the check-in desk. The server resolves the caller's team
+ * from their session, so this can only ever edit your own team.
+ */
+export function TeamRoster({
+  members,
+  onChanged,
+}: {
+  members: TeamMemberView[];
+  onChanged: () => void;
+}) {
+  const reduceMotion = useReducedMotion();
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<SearchHit[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runSearch(value: string) {
+    setQuery(value);
+    setError(null);
+    if (value.trim().length < 2) {
+      setHits([]);
+      return;
+    }
+    setSearching(true);
+    try {
+      const res = await fetch(
+        `/api/impact-lab/team/search?q=${encodeURIComponent(value.trim())}`
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "Search failed. Try again.");
+        setHits([]);
+        return;
+      }
+      setHits(json.results as SearchHit[]);
+    } catch {
+      setError("Search failed. Check your connection.");
+      setHits([]);
+    } finally {
+      setSearching(false);
+    }
+  }
+
+  async function mutate(participantId: string, method: "POST" | "DELETE") {
+    setBusyId(participantId);
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/impact-lab/team/roster", {
+        method,
+        headers: await csrfHeaders(),
+        body: JSON.stringify({ participantId }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "That did not work. Try again.");
+        return;
+      }
+      setNotice(json.message ?? "Team updated.");
+      setQuery("");
+      setHits([]);
+      onChanged();
+    } catch {
+      setError("That did not work. Check your connection.");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  const memberIds = new Set(members.map((m) => m.id));
+
+  return (
+    <section className="mt-8 rounded-xl border border-border-default bg-bg-card p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="font-mono text-sm uppercase tracking-wider text-text-primary">
+            Fix your team
+          </h3>
+          <p className="mt-1 text-sm text-text-dim">
+            Add whoever is actually sitting with you, or drop someone who never
+            showed up.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="rounded-lg border border-border-default px-3 py-2 font-mono text-xs uppercase tracking-wider text-text-secondary transition-colors hover:border-green-primary/40 hover:text-green-primary"
+          aria-expanded={open}
+        >
+          {open ? "Done" : "Edit team"}
+        </button>
+      </div>
+
+      {open && (
+        <div className="mt-5 space-y-5">
+          <div>
+            <label
+              htmlFor="roster-search"
+              className="font-mono text-xs uppercase tracking-wider text-text-dim"
+            >
+              Search everyone registered
+            </label>
+            <div className="relative mt-2">
+              <Search
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-dim"
+                aria-hidden="true"
+              />
+              <input
+                id="roster-search"
+                type="text"
+                value={query}
+                onChange={(e) => runSearch(e.target.value)}
+                placeholder="Type at least two letters of their name"
+                autoComplete="off"
+                className="w-full rounded-lg border border-border-default bg-bg-primary py-2.5 pl-9 pr-3 text-sm text-text-primary placeholder:text-text-dim focus:border-green-primary focus:outline-none"
+              />
+              {searching && (
+                <Loader2
+                  className={`absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-dim ${
+                    reduceMotion ? "" : "animate-spin"
+                  }`}
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+
+            {hits.length > 0 && (
+              <ul className="mt-3 divide-y divide-border-default overflow-hidden rounded-lg border border-border-default">
+                {hits.map((hit) => {
+                  const already = memberIds.has(hit.id);
+                  return (
+                    <li
+                      key={hit.id}
+                      className="flex items-center justify-between gap-3 bg-bg-primary px-3 py-2.5"
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate text-sm text-text-primary">
+                          {hit.fullName}
+                        </span>
+                        {hit.onTeam && !already && (
+                          <span className="block text-xs text-amber">
+                            Currently on {hit.onTeam} — adding moves them here
+                          </span>
+                        )}
+                      </span>
+                      <button
+                        type="button"
+                        disabled={already || busyId === hit.id}
+                        onClick={() => mutate(hit.id, "POST")}
+                        className="shrink-0 rounded-md border border-green-primary/30 bg-green-primary/10 px-2.5 py-1.5 font-mono text-[11px] uppercase tracking-wider text-green-primary transition-colors hover:bg-green-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
+                      >
+                        {already ? (
+                          "on your team"
+                        ) : (
+                          <>
+                            <UserPlus className="mr-1 inline h-3 w-3" aria-hidden="true" />
+                            add
+                          </>
+                        )}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            {query.trim().length >= 2 && !searching && hits.length === 0 && (
+              <p className="mt-3 text-sm text-text-dim">
+                Nobody registered matches that name.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <p className="font-mono text-xs uppercase tracking-wider text-text-dim">
+              Remove a no-show
+            </p>
+            <ul className="mt-2 space-y-2">
+              {members
+                .filter((m) => !m.isSelf)
+                .map((m) => (
+                  <li
+                    key={m.id}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-border-default bg-bg-primary px-3 py-2.5"
+                  >
+                    <span className="min-w-0 truncate text-sm text-text-primary">
+                      {m.fullName}
+                      {!m.checkedIn && (
+                        <span className="ml-2 text-xs text-amber">not checked in</span>
+                      )}
+                    </span>
+                    <button
+                      type="button"
+                      disabled={busyId === m.id}
+                      onClick={() => mutate(m.id, "DELETE")}
+                      className="shrink-0 rounded-md border border-red/30 bg-red/10 px-2.5 py-1.5 font-mono text-[11px] uppercase tracking-wider text-red transition-colors hover:bg-red/20 disabled:opacity-40"
+                    >
+                      <UserMinus className="mr-1 inline h-3 w-3" aria-hidden="true" />
+                      remove
+                    </button>
+                  </li>
+                ))}
+            </ul>
+            <p className="mt-2 text-xs text-text-dim">
+              You cannot remove yourself. If you have moved tables, ask your new
+              team to add you — that moves you across.
+            </p>
+          </div>
+
+          {notice && (
+            <p role="status" className="text-sm text-green-primary">
+              {notice}
+            </p>
+          )}
+          {error && (
+            <p role="alert" className="text-sm text-red">
+              {error}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}


### PR DESCRIPTION
Any member can add whoever is actually sitting with them and remove a no-show.

- Caller's team resolved **server-side from the session** — you can only edit your own team
- Adding someone already placed elsewhere **moves** them; the UI warns before it happens
- **Self-removal refused** — it would strand you with no way back in; the new team adds you instead
- **Row lock before read-modify-write** on the run JSON, so two teammates editing at once cannot clobber each other
- Search returns names only, no contact details; two-character minimum so it can't be used as a roster dump
- Members already show a "not checked in" hint, so no-shows are easy to spot

Gates: tsc clean, eslint clean, build clean.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj