### PR TITLE
feat(impact-lab): judging — code-gated /judge, published criteria, track winners

### DIFF
--- a/docs/impact-lab/15-judging-form.md
+++ b/docs/impact-lab/15-judging-form.md
@@ -1,0 +1,128 @@
+# Impact Lab: AI Mashinani — Judging Card
+
+The scoring instrument for the live demos. This document is the source of
+truth; the in-product judging screen implements exactly this and nothing else.
+
+**Design principle:** builders were told, in writing, what they would be scored
+on. The card scores those five things at those five weights. Anything a judge
+was never told to look for — a revenue model, a go-to-market plan — is not on
+this card, because no team was asked to build one.
+
+**Constraint that shaped it:** three minutes of demo, two minutes of questions,
+then the judge moves to the next table. Every question is answerable from what
+just happened in front of them, with a phone in one hand.
+
+---
+
+## Header
+
+> **Impact Lab: AI Mashinani — Judging Card**
+>
+> One card per team. Score what you saw, not what you think they meant.
+> You can revise a card until scoring closes.
+
+---
+
+## Q1 · Judge
+
+**Type:** taken from the signed-in account (no typed name)
+**Required:** yes, implicitly
+
+Judges sign in, so a card is tied to a real person. This replaces a free-text
+name field, which allows typos, duplicates, and a second card from the same
+judge silently double-counting their opinion.
+
+---
+
+## Q2 · Which team are you scoring?
+
+**Type:** searchable list of the real teams
+**Required:** yes
+
+Each entry shows **table number, track, and project name**, with links to the
+repo and demo. A judge picks a team the way they perceive it — "Table 12,
+Kilimo, Sokoni" — rather than translating it into a number.
+
+Every team in the final run appears. There is no fixed upper bound.
+
+---
+
+## Q3–Q7 · The five criteria
+
+Each scored **1–5**, each anchored identically so judges calibrate the same way:
+
+| Score | Meaning |
+|---|---|
+| **1** | Not shown / insufficient |
+| **2** | Attempted, unsatisfactory |
+| **3** | Neutral |
+| **4** | Good |
+| **5** | Outstanding |
+
+A **1 earns zero points**, not a fifth of the marks. "Not shown" must not be
+worth anything.
+
+### Q3 · Impact on the named beneficiary — 25 points
+> Does this measurably help the specific person the team named? Not a market —
+> a person.
+
+### Q4 · A working demo — 25 points
+> Did it actually run in front of you? Working software only — what is real
+> versus stubbed.
+
+### Q5 · Use of Claude — 20 points
+> How well did the team use Claude to get further than they could have alone?
+
+### Q6 · Beneficiary clarity — 15 points
+> Can they say who this helps and what that person struggles with today, in one
+> sentence?
+
+### Q7 · Presentation — 15 points
+> Was the three minutes clear, honest, and well used?
+
+**Total: 100 points.**
+
+---
+
+## Q8 · What should this team hear?
+
+**Type:** long answer
+**Required:** no
+
+Optional on purpose. Feedback is the most valuable thing a judge produces and
+the first thing to get skipped when demos run late — but a judge who cannot
+save a score without writing a paragraph will write "good" five times and mean
+none of it. Optional and prominent beats required and hollow.
+
+Every judge's written feedback reaches the team.
+
+---
+
+## How scores become results
+
+- **A judge's card** → weighted total out of 100: `(score − 1) ÷ 4 × weight`,
+  summed across the five criteria.
+- **A team's standing** → the **mean** of its judges' totals. Averaged, never
+  summed, so a team seen by four judges is not beaten by an identical team seen
+  by three.
+- **Ties** break by team id, so the leaderboard never reorders itself between
+  two loads of the same page.
+- **Track winner** → the highest-scoring team within each of the five tracks.
+- **Overall champion** → the highest-scoring team across all tracks.
+- **Partial cards count.** A judge who scores four criteria and gets pulled away
+  contributes what they scored. Unscored criteria earn nothing rather than
+  voiding the card.
+- **Nobody scored yet** is surfaced explicitly. At 5 AM the failure mode is a
+  team no judge reached, and silence looks identical to a low score.
+
+---
+
+## What is deliberately not on the card
+
+- **Business model, market size, go-to-market.** Never in the brief. Scoring
+  them would mark teams against a brief they never received.
+- **Free-text sector.** The track is already known per team; asking a judge to
+  retype it produces five spellings of "Kilimo".
+- **A typed judge name.** Sign-in is the identity.
+- **Per-judge score visibility.** A judge sees their own card and the aggregate,
+  never another judge's individual numbers — seeing them anchors scoring.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "verify:matching": "tsx scripts/verify-matching.ts",
     "verify:submissions": "tsx scripts/verify-submissions.ts",
     "verify:rematch": "tsx scripts/verify-rematch.ts",
+    "verify:judging": "tsx scripts/verify-judging.ts",
     "import:manual-teams": "tsx scripts/import-manual-teams.ts"
   },
   "prisma": {

--- a/prisma/migrations/20260726030000_impact_lab_scores/migration.sql
+++ b/prisma/migrations/20260726030000_impact_lab_scores/migration.sql
@@ -1,0 +1,29 @@
+-- Judge scorecards for Impact Lab. One row per judge per team; the weighted
+-- total is derived in application code, never stored, so a correction to the
+-- published weights cannot leave a stale total behind.
+-- Additive only: safe to apply ahead of the code deploy.
+CREATE TABLE "impact_lab_scores" (
+    "id" TEXT NOT NULL,
+    "cohort" TEXT NOT NULL,
+    "runId" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "judgeEmail" TEXT NOT NULL,
+    "judgeName" TEXT NOT NULL,
+    "scores" JSONB NOT NULL,
+    "feedback" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "impact_lab_scores_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "impact_lab_scores_runId_teamId_judgeEmail_key"
+    ON "impact_lab_scores"("runId", "teamId", "judgeEmail");
+
+CREATE INDEX "impact_lab_scores_cohort_teamId_idx"
+    ON "impact_lab_scores"("cohort", "teamId");
+
+ALTER TABLE "impact_lab_scores"
+    ADD CONSTRAINT "impact_lab_scores_runId_fkey"
+    FOREIGN KEY ("runId") REFERENCES "impact_lab_match_runs"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -713,6 +713,7 @@ model ImpactLabMatchRun {
   /// change, not a database edit.
   submissionsCloseAt   DateTime?
   submissions          ImpactLabSubmission[]
+  scores               ImpactLabScore[]
   createdById          String?
   createdBy            User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdAt            DateTime @default(now())
@@ -764,4 +765,34 @@ model ImpactLabSubmission {
   @@unique([runId, teamId])
   @@index([cohort, status])
   @@map("impact_lab_submissions")
+}
+
+/// One judge's scorecard for one team. Judges score independently and the
+/// leaderboard averages them, so a team seen by four judges is not beaten by
+/// an identical team seen by three.
+///
+/// `scores` holds the raw 1-5 value per criterion key (see lib/impact-lab/
+/// judging.ts). The weighted total is derived, never stored: the weights are
+/// published and may be corrected, and a stored total would silently disagree
+/// with the criteria it claims to represent.
+model ImpactLabScore {
+  id         String   @id @default(cuid())
+  cohort     String
+  runId      String
+  /// Team id from the run's result JSON — teams have no table, so no FK.
+  teamId     String
+  judgeEmail String
+  judgeName  String
+  scores     Json
+  feedback   String?  @db.Text
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  run ImpactLabMatchRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  /// One scorecard per judge per team: a second submission edits the first
+  /// rather than double-counting that judge's opinion.
+  @@unique([runId, teamId, judgeEmail])
+  @@index([cohort, teamId])
+  @@map("impact_lab_scores")
 }

--- a/scripts/verify-judging.ts
+++ b/scripts/verify-judging.ts
@@ -1,0 +1,141 @@
+/**
+ * Impact Lab judging — verification harness.
+ *
+ * This repo has no unit-test framework; scripts/verify-matching.ts is the
+ * established pattern. Judging arithmetic decides who wins a hackathon, so the
+ * weighting, the partial-sheet behaviour, and the tie-ordering are asserted
+ * here rather than trusted.
+ *
+ * Run with: npm run verify:judging
+ * Exits 0 on success, 1 on any failed assertion.
+ */
+
+import {
+  JUDGING_CRITERIA,
+  weightedTotal,
+  isComplete,
+  standings,
+  type ScoreSheet,
+} from "../src/lib/impact-lab/judging"
+
+let failures = 0
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`  ✓ ${message}`)
+  } else {
+    console.error(`  ✗ ${message}`)
+    failures += 1
+  }
+}
+
+const sheetOf = (value: number): ScoreSheet =>
+  Object.fromEntries(JUDGING_CRITERIA.map((c) => [c.key, value]))
+
+console.log("\nWeights")
+assert(
+  JUDGING_CRITERIA.reduce((n, c) => n + c.weight, 0) === 100,
+  "the published weights sum to exactly 100"
+)
+assert(JUDGING_CRITERIA.length === 5, "there are five criteria")
+assert(
+  new Set(JUDGING_CRITERIA.map((c) => c.key)).size === JUDGING_CRITERIA.length,
+  "criterion keys are unique"
+)
+
+console.log("\nWeighted total")
+assert(weightedTotal(sheetOf(5)) === 100, "all fives is a perfect 100")
+assert(
+  weightedTotal(sheetOf(1)) === 0,
+  "all ones is 0 — 'not shown' must earn nothing, not a fifth of the marks"
+)
+assert(weightedTotal(sheetOf(3)) === 50, "all threes is exactly half")
+assert(weightedTotal({}) === 0, "an empty sheet is 0, not NaN")
+
+const partial: ScoreSheet = { impact: 5 }
+assert(
+  weightedTotal(partial) === 25,
+  "a partial sheet scores only what was filled in (impact alone = its 25)"
+)
+assert(!isComplete(partial), "a partial sheet is reported incomplete")
+assert(isComplete(sheetOf(4)), "a full sheet is reported complete")
+
+assert(
+  weightedTotal({ ...sheetOf(3), impact: 99 }) === weightedTotal({ ...sheetOf(3), impact: 5 }),
+  "out-of-range high scores clamp to 5 rather than inflating the total"
+)
+assert(
+  weightedTotal({ ...sheetOf(3), impact: -4 }) === weightedTotal({ ...sheetOf(3), impact: 1 }),
+  "out-of-range low scores clamp to 1"
+)
+
+// A criterion's weight must actually drive the total — catches a mapping that
+// silently applies the same weight to everything.
+const impactOnly = weightedTotal({ impact: 5 })
+const presentationOnly = weightedTotal({ presentation: 5 })
+const distinctWeights = new Set(
+  JUDGING_CRITERIA.map((c) => weightedTotal({ [c.key]: 5 }))
+)
+assert(
+  impactOnly === 25 && presentationOnly === 15 && distinctWeights.size > 1,
+  "each criterion contributes its own weight, not a shared one"
+)
+
+console.log("\nStandings")
+const table = standings([
+  { judgeEmail: "a@x.io", teamId: "table-2", sheet: sheetOf(5) },
+  { judgeEmail: "b@x.io", teamId: "table-2", sheet: sheetOf(3) },
+  { judgeEmail: "a@x.io", teamId: "table-1", sheet: sheetOf(4) },
+])
+assert(table.length === 2, "one row per team")
+assert(table[0].teamId === "table-1", "the higher average sorts first")
+assert(table[0].average === 75, "all fours averages to 75")
+// table-2 was scored 100 and 50 by two judges: the mean is 75, the sum is 150.
+assert(
+  table[1].teamId === "table-2" && table[1].average === 75,
+  "two judges on one team average (75) rather than sum (150)"
+)
+assert(
+  standings([
+    { judgeEmail: "a@x.io", teamId: "table-9", sheet: sheetOf(5) },
+    { judgeEmail: "b@x.io", teamId: "table-9", sheet: sheetOf(5) },
+    { judgeEmail: "c@x.io", teamId: "table-9", sheet: sheetOf(5) },
+  ])[0].judgeCount === 3,
+  "judgeCount reflects how many judges scored the team"
+)
+
+// Four judges scoring 5 must not beat three judges scoring 5.
+const three = standings([
+  { judgeEmail: "a@x.io", teamId: "t1", sheet: sheetOf(5) },
+  { judgeEmail: "b@x.io", teamId: "t1", sheet: sheetOf(5) },
+  { judgeEmail: "c@x.io", teamId: "t1", sheet: sheetOf(5) },
+])[0].average
+const four = standings([
+  { judgeEmail: "a@x.io", teamId: "t2", sheet: sheetOf(5) },
+  { judgeEmail: "b@x.io", teamId: "t2", sheet: sheetOf(5) },
+  { judgeEmail: "c@x.io", teamId: "t2", sheet: sheetOf(5) },
+  { judgeEmail: "d@x.io", teamId: "t2", sheet: sheetOf(5) },
+])[0].average
+assert(three === four, "being seen by more judges is not an advantage")
+
+const tied = standings([
+  { judgeEmail: "a@x.io", teamId: "table-9", sheet: sheetOf(4) },
+  { judgeEmail: "a@x.io", teamId: "table-3", sheet: sheetOf(4) },
+])
+assert(
+  tied[0].teamId === "table-3",
+  "ties break deterministically by team id, so the leaderboard never reshuffles itself"
+)
+
+assert(
+  standings([{ judgeEmail: "a@x.io", teamId: "t", sheet: { impact: 5, demo: 3 } }])[0]
+    .criterionAverages.impact === 5,
+  "per-criterion averages report the raw 1-5 value for the breakdown"
+)
+
+console.log(
+  failures === 0
+    ? "\nALL CHECKS PASSED\n"
+    : `\n${failures} CHECK(S) FAILED\n`
+)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify-judging.ts
+++ b/scripts/verify-judging.ts
@@ -15,6 +15,8 @@ import {
   weightedTotal,
   isComplete,
   standings,
+  trackOf,
+  trackWinners,
   type ScoreSheet,
 } from "../src/lib/impact-lab/judging"
 
@@ -131,6 +133,42 @@ assert(
   standings([{ judgeEmail: "a@x.io", teamId: "t", sheet: { impact: 5, demo: 3 } }])[0]
     .criterionAverages.impact === 5,
   "per-criterion averages report the raw 1-5 value for the breakdown"
+)
+
+console.log("\nTracks and winners")
+assert(
+  trackOf("Table 12 — Kilimo (Agriculture)") === "Kilimo (Agriculture)",
+  "the track is read off the team name"
+)
+assert(trackOf("Table 4") === "Unassigned", "a name with no track is Unassigned, not a crash")
+assert(trackOf("") === "Unassigned", "an empty name is Unassigned")
+
+const names = new Map([
+  ["t-afya-1", "Table 1 — Afya (Health)"],
+  ["t-afya-2", "Table 2 — Afya (Health)"],
+  ["t-kilimo-1", "Table 9 — Kilimo (Agriculture)"],
+  ["t-unjudged", "Table 30 — Biashara (Small Business)"],
+])
+const scored = standings([
+  { judgeEmail: "a@x.io", teamId: "t-afya-1", sheet: sheetOf(3) },
+  { judgeEmail: "a@x.io", teamId: "t-afya-2", sheet: sheetOf(5) },
+  { judgeEmail: "a@x.io", teamId: "t-kilimo-1", sheet: sheetOf(4) },
+])
+const { winners, champion } = trackWinners(scored, names)
+
+assert(winners.length === 2, "one winner per track that was actually judged")
+assert(
+  winners.find((w) => w.track === "Afya (Health)")?.teamId === "t-afya-2",
+  "the higher-scoring team wins its track"
+)
+assert(champion?.teamId === "t-afya-2", "the champion is the best across all tracks")
+assert(
+  !winners.some((w) => w.teamId === "t-unjudged"),
+  "a team nobody scored cannot win a track — an unjudged zero is not an earned zero"
+)
+assert(
+  trackWinners([], new Map()).champion === null,
+  "no scores means no champion, rather than a phantom winner"
 )
 
 console.log(

--- a/src/app/admin/impact-lab/judge/JudgeScoringScreen.tsx
+++ b/src/app/admin/impact-lab/judge/JudgeScoringScreen.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { ChevronDown, Loader2 } from "lucide-react"
+import { apiGet, apiSend } from "@/components/admin/impact-lab/api"
+import { isComplete, type ScoreSheet } from "@/lib/impact-lab/judging"
+import { TeamScoreCard, type Draft, type JudgeTeam } from "./TeamScoreCard"
+
+interface JudgingData {
+  finalRunId: string | null
+  teams: JudgeTeam[]
+  mine: Record<string, { scores: ScoreSheet; feedback: string | null }>
+  standings: { teamId: string; average: number; judgeCount: number }[]
+}
+
+const EMPTY_DRAFT: Draft = { scores: {}, feedback: "" }
+
+/**
+ * Judge-facing scoring screen. One team open at a time (an accordion, not a
+ * long scroll of forms) so a judge holding a phone can find their place
+ * again after a demo interrupts them. A partial card is always saveable —
+ * this replaces a form that made feedback required, and demos run too fast
+ * to let that block a score again.
+ */
+export function JudgeScoringScreen({ cohort }: { cohort: string }) {
+  const [data, setData] = useState<JudgingData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [drafts, setDrafts] = useState<Record<string, Draft>>({})
+  const [savedSnapshot, setSavedSnapshot] = useState<Record<string, Draft>>({})
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [savingId, setSavingId] = useState<string | null>(null)
+  const [saveErrors, setSaveErrors] = useState<Record<string, string>>({})
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const res = await apiGet<JudgingData>(
+        `/api/admin/impact-lab/judging?cohort=${cohort}`
+      )
+      setData(res)
+
+      const initial: Record<string, Draft> = {}
+      for (const team of res.teams) {
+        const mine = res.mine[team.teamId]
+        initial[team.teamId] = { scores: mine?.scores ?? {}, feedback: mine?.feedback ?? "" }
+      }
+      setDrafts(initial)
+      setSavedSnapshot(initial)
+
+      // Land on the first team this judge hasn't finished, so opening the
+      // page mid-event drops them where they left off rather than at the top.
+      const firstUnfinished = res.teams.find(
+        (t) => !isComplete(initial[t.teamId]?.scores ?? {})
+      )
+      setExpanded(firstUnfinished?.teamId ?? res.teams[0]?.teamId ?? null)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to load teams")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  function updateDraft(teamId: string, patch: Partial<Draft>) {
+    setDrafts((prev) => ({
+      ...prev,
+      [teamId]: { ...(prev[teamId] ?? EMPTY_DRAFT), ...patch },
+    }))
+  }
+
+  async function save(teamId: string) {
+    const draft = drafts[teamId] ?? EMPTY_DRAFT
+    if (Object.keys(draft.scores).length === 0) {
+      setSaveErrors((prev) => ({
+        ...prev,
+        [teamId]: "Score at least one criterion before saving.",
+      }))
+      return
+    }
+    setSavingId(teamId)
+    setSaveErrors((prev) => ({ ...prev, [teamId]: "" }))
+    try {
+      await apiSend(`/api/admin/impact-lab/judging?cohort=${cohort}`, "POST", {
+        teamId,
+        scores: draft.scores,
+        feedback: draft.feedback,
+      })
+      setSavedSnapshot((prev) => ({ ...prev, [teamId]: draft }))
+    } catch (e) {
+      setSaveErrors((prev) => ({
+        ...prev,
+        [teamId]: e instanceof Error ? e.message : "Failed to save",
+      }))
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  const progress = useMemo(() => {
+    const teams = data?.teams ?? []
+    const done = teams.filter((t) => isComplete(drafts[t.teamId]?.scores ?? {})).length
+    return { done, total: teams.length }
+  }, [data, drafts])
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (loadError || !data) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-3 text-[12px] font-mono text-[#ff3333]">
+        {loadError ?? "No data"}
+      </div>
+    )
+  }
+
+  if (!data.finalRunId || data.teams.length === 0) {
+    return (
+      <div className="rounded border border-[#ffb000]/30 bg-[#ffb000]/10 p-4 text-[12px] font-mono text-[#ffb000]">
+        No final run is published for this cohort yet — there is nothing to judge until an
+        organiser marks a run final.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="sticky top-0 z-10 -mx-4 sm:-mx-0 border-b border-[#1e1e1e] bg-[#0a0a0a]/95 px-4 sm:px-0 py-2 backdrop-blur">
+        <p className="text-[11px] font-mono text-[#888]">
+          <span className="font-semibold text-[#00ff41]">{progress.done}</span> / {progress.total}{" "}
+          teams scored
+        </p>
+      </div>
+
+      {data.teams.map((team) => {
+        const draft = drafts[team.teamId] ?? EMPTY_DRAFT
+        const snapshot = savedSnapshot[team.teamId] ?? EMPTY_DRAFT
+        const unsaved = JSON.stringify(draft) !== JSON.stringify(snapshot)
+        const complete = isComplete(draft.scores)
+        const isOpen = expanded === team.teamId
+
+        return (
+          <div
+            key={team.teamId}
+            className="overflow-hidden rounded-lg border border-[#1e1e1e] bg-[#0d0d0d]"
+          >
+            <button
+              type="button"
+              onClick={() => setExpanded(isOpen ? null : team.teamId)}
+              aria-expanded={isOpen}
+              className="flex w-full items-center justify-between gap-3 px-4 py-4 text-left"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-[13px] font-mono font-semibold text-[#e0e0e0]">
+                  {team.teamName}
+                </p>
+                <p className="truncate text-[11px] font-mono text-[#666]">
+                  {team.submission?.projectName ?? "no submission"}
+                </p>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[10px] font-mono ${
+                    complete
+                      ? "bg-[#00ff41]/10 text-[#00ff41]"
+                      : Object.keys(draft.scores).length > 0
+                        ? "bg-[#ffb000]/10 text-[#ffb000]"
+                        : "bg-[#1e1e1e] text-[#666]"
+                  }`}
+                >
+                  {complete
+                    ? unsaved
+                      ? "unsaved"
+                      : "scored"
+                    : Object.keys(draft.scores).length > 0
+                      ? "in progress"
+                      : "not started"}
+                </span>
+                <ChevronDown
+                  className={`h-4 w-4 text-[#555] transition-transform ${isOpen ? "rotate-180" : ""}`}
+                />
+              </div>
+            </button>
+
+            {isOpen && (
+              <div className="border-t border-[#1e1e1e]">
+                <TeamScoreCard
+                  team={team}
+                  draft={draft}
+                  saving={savingId === team.teamId}
+                  unsaved={unsaved}
+                  saveError={saveErrors[team.teamId] ?? ""}
+                  onScore={(key, value) =>
+                    updateDraft(team.teamId, { scores: { ...draft.scores, [key]: value } })
+                  }
+                  onFeedback={(value) => updateDraft(team.teamId, { feedback: value })}
+                  onSave={() => save(team.teamId)}
+                />
+              </div>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/app/admin/impact-lab/judge/TeamScoreCard.tsx
+++ b/src/app/admin/impact-lab/judge/TeamScoreCard.tsx
@@ -1,0 +1,212 @@
+"use client"
+
+import { ExternalLink, Loader2 } from "lucide-react"
+import {
+  JUDGING_CRITERIA,
+  MAX_SCORE,
+  MIN_SCORE,
+  SCORE_LABELS,
+  weightedTotal,
+  type ScoreSheet,
+} from "@/lib/impact-lab/judging"
+
+export interface JudgeTeam {
+  teamId: string
+  teamName: string
+  memberCount: number
+  submission: {
+    teamId: string
+    projectName: string
+    pitch: string
+    repoUrl: string
+    demoUrl: string | null
+  } | null
+}
+
+export interface Draft {
+  scores: ScoreSheet
+  feedback: string
+}
+
+interface TeamScoreCardProps {
+  team: JudgeTeam
+  draft: Draft
+  saving: boolean
+  unsaved: boolean
+  saveError: string
+  onScore: (criterionKey: string, value: number) => void
+  onFeedback: (value: string) => void
+  onSave: () => void
+}
+
+const SCALE = Array.from(
+  { length: MAX_SCORE - MIN_SCORE + 1 },
+  (_, i) => MIN_SCORE + i
+)
+
+/**
+ * One team's scorecard — the five criteria as full-width, thumb-sized 1–5
+ * rows (not a slider or a tooltip) so a judge standing up can read every
+ * anchor label before tapping, and a running total that always comes from
+ * `weightedTotal` rather than a second calculation living in this component.
+ */
+export function TeamScoreCard({
+  team,
+  draft,
+  saving,
+  unsaved,
+  saveError,
+  onScore,
+  onFeedback,
+  onSave,
+}: TeamScoreCardProps) {
+  const total = weightedTotal(draft.scores)
+
+  return (
+    <div className="space-y-5 p-4 sm:p-5">
+      <div>
+        <p className="text-sm font-mono font-semibold text-[#e0e0e0]">
+          {team.submission?.projectName ?? "(no submission)"}
+        </p>
+        {team.submission?.pitch && (
+          <p className="mt-1 text-[12px] font-mono leading-relaxed text-[#999]">
+            {team.submission.pitch}
+          </p>
+        )}
+        <p className="mt-1.5 text-[10px] font-mono text-[#555]">
+          {team.teamName} · {team.memberCount} member{team.memberCount === 1 ? "" : "s"}
+        </p>
+        {team.submission && (
+          <div className="mt-2 flex flex-wrap gap-3">
+            {team.submission.repoUrl && (
+              <a
+                href={team.submission.repoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-[11px] font-mono text-[#00d4ff] hover:underline"
+              >
+                repo <ExternalLink className="h-2.5 w-2.5" />
+              </a>
+            )}
+            {team.submission.demoUrl && (
+              <a
+                href={team.submission.demoUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 text-[11px] font-mono text-[#00d4ff] hover:underline"
+              >
+                demo <ExternalLink className="h-2.5 w-2.5" />
+              </a>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-5">
+        {JUDGING_CRITERIA.map((criterion) => {
+          const selected = draft.scores[criterion.key]
+          return (
+            <div key={criterion.key}>
+              <div className="flex items-baseline justify-between gap-2">
+                <p className="text-[12px] font-mono font-semibold text-[#e0e0e0]">
+                  {criterion.label}
+                </p>
+                <span className="shrink-0 text-[10px] font-mono text-[#555]">
+                  {criterion.weight} pts
+                </span>
+              </div>
+              <p className="mt-0.5 text-[11px] font-mono leading-relaxed text-[#888]">
+                {criterion.guidance}
+              </p>
+
+              <div
+                role="radiogroup"
+                aria-label={criterion.label}
+                className="mt-2 grid grid-cols-1 gap-1.5"
+              >
+                {SCALE.map((value) => {
+                  const isSelected = selected === value
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      role="radio"
+                      aria-checked={isSelected}
+                      onClick={() => onScore(criterion.key, value)}
+                      className={`flex items-center gap-2.5 rounded border px-3 py-3 text-left text-[12px] font-mono transition-colors ${
+                        isSelected
+                          ? "border-[#00ff41]/50 bg-[#00ff41]/10 text-[#00ff41]"
+                          : "border-[#1e1e1e] bg-[#111] text-[#999] hover:bg-[#161616]"
+                      }`}
+                    >
+                      <span
+                        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border text-[11px] font-bold ${
+                          isSelected
+                            ? "border-[#00ff41] text-[#00ff41]"
+                            : "border-[#333] text-[#666]"
+                        }`}
+                      >
+                        {value}
+                      </span>
+                      {SCORE_LABELS[value]}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      <div className="rounded-lg border border-[#1e1e1e] bg-[#111] p-3 text-center">
+        <p className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+          Weighted total
+        </p>
+        <p className="text-2xl font-mono font-bold text-[#00ff41]">
+          {total}
+          <span className="text-sm text-[#444]"> / 100</span>
+        </p>
+      </div>
+
+      <div>
+        <label
+          htmlFor={`feedback-${team.teamId}`}
+          className="block text-[11px] font-mono text-[#888] mb-1"
+        >
+          Feedback for the team (optional)
+        </label>
+        <textarea
+          id={`feedback-${team.teamId}`}
+          value={draft.feedback}
+          onChange={(e) => onFeedback(e.target.value)}
+          rows={3}
+          placeholder="What stood out, what to work on…"
+          className="w-full rounded border border-[#1e1e1e] bg-[#0d0d0d] px-3 py-2 text-[12px] font-mono text-[#e0e0e0] placeholder:text-[#444] focus:outline-none focus:border-[#00ff41]/40"
+        />
+      </div>
+
+      {saveError && (
+        <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 px-3 py-2 text-[11px] font-mono text-[#ff3333]">
+          {saveError}
+        </div>
+      )}
+
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={saving}
+        className="flex w-full items-center justify-center gap-2 rounded-lg border border-[#00ff41]/40 bg-[#00ff41]/10 py-3.5 text-[13px] font-mono font-semibold text-[#00ff41] transition-colors hover:bg-[#00ff41]/20 disabled:opacity-50"
+      >
+        {saving ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" /> Saving…
+          </>
+        ) : unsaved ? (
+          "Save score"
+        ) : (
+          "Saved — tap to resave"
+        )}
+      </button>
+    </div>
+  )
+}

--- a/src/app/admin/impact-lab/judge/page.tsx
+++ b/src/app/admin/impact-lab/judge/page.tsx
@@ -1,0 +1,16 @@
+import { AdminHeader } from "@/components/admin/AdminHeader"
+import { JudgeScoringScreen } from "./JudgeScoringScreen"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+
+export const dynamic = "force-dynamic"
+
+export default function ImpactLabJudgePage() {
+  return (
+    <div>
+      <AdminHeader title="Judge scoring" />
+      <div className="p-4 sm:p-6">
+        <JudgeScoringScreen cohort={DEFAULT_COHORT} />
+      </div>
+    </div>
+  )
+}

--- a/src/app/api/admin/impact-lab/judging/export/route.ts
+++ b/src/app/api/admin/impact-lab/judging/export/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import { toCsv } from "@/lib/impact-lab/csv"
+import { JUDGING_CRITERIA, standings, type ScoreSheet } from "@/lib/impact-lab/judging"
+
+const HEADERS = [
+  "Team",
+  "Project",
+  "Judges",
+  "Weighted average (/100)",
+  ...JUDGING_CRITERIA.map((c) => `${c.label} (avg /5)`),
+  "Judge feedback",
+]
+
+/**
+ * The sheet the winner is read from: one row per team, sorted by weighted
+ * average descending. Reuses `standings` for the maths rather than
+ * re-averaging here, and `toCsv` for escaping — including the
+ * formula-injection guard, since a team or project name is free text a
+ * participant chose.
+ */
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+
+  const filename = `impact-lab-judging-${cohort}.csv`
+  const csvHeaders = {
+    "Content-Type": "text/csv; charset=utf-8",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+  }
+
+  if (!run) {
+    return new NextResponse(toCsv(HEADERS, []), { headers: csvHeaders })
+  }
+
+  const teams = extractFrozenTeams(run.result) ?? []
+
+  const [submissions, scores] = await Promise.all([
+    prisma.impactLabSubmission.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, projectName: true },
+    }),
+    prisma.impactLabScore.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, judgeName: true, judgeEmail: true, scores: true, feedback: true },
+    }),
+  ])
+
+  const projectByTeam = new Map(submissions.map((s) => [s.teamId, s.projectName]))
+
+  const feedbackByTeam = new Map<string, string>()
+  for (const teamId of new Set(scores.map((s) => s.teamId))) {
+    const written = scores
+      .filter((s) => s.teamId === teamId && s.feedback?.trim())
+      .map((s) => `${s.judgeName || s.judgeEmail}: ${s.feedback}`)
+    feedbackByTeam.set(teamId, written.join(" | "))
+  }
+
+  const table = standings(
+    scores.map((s) => ({
+      judgeEmail: s.judgeEmail,
+      teamId: s.teamId,
+      sheet: (s.scores ?? {}) as ScoreSheet,
+    }))
+  )
+  const standingByTeam = new Map(table.map((t) => [t.teamId, t]))
+
+  const rows = teams
+    .map((t) => {
+      const standing = standingByTeam.get(t.id)
+      return {
+        average: standing?.average ?? 0,
+        cells: [
+          t.name,
+          projectByTeam.get(t.id) ?? "",
+          standing?.judgeCount ?? 0,
+          standing?.average ?? 0,
+          ...JUDGING_CRITERIA.map((c) => standing?.criterionAverages[c.key] ?? 0),
+          feedbackByTeam.get(t.id) ?? "",
+        ],
+      }
+    })
+    .sort((a, b) => b.average - a.average)
+    .map((r) => r.cells)
+
+  return new NextResponse(toCsv(HEADERS, rows), { headers: csvHeaders })
+}

--- a/src/app/api/admin/impact-lab/judging/route.ts
+++ b/src/app/api/admin/impact-lab/judging/route.ts
@@ -1,0 +1,211 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { readJudgeSession } from "@/lib/impact-lab/judge-access"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import {
+  CRITERION_KEYS,
+  MAX_SCORE,
+  MIN_SCORE,
+  standings,
+  weightedTotal,
+  type ScoreSheet,
+} from "@/lib/impact-lab/judging"
+
+/**
+ * Judging surface.
+ *
+ * Judges hold the MODERATOR role, whose `impact-lab` grant is `view` — they
+ * read the field and record their own opinion, and must never be able to edit
+ * runs, teams, or submissions. So the write here is gated on `view` plus
+ * ownership of the scorecard: a judge can only ever write the row keyed to
+ * their own signed-in email, enforced by the unique constraint rather than by
+ * trusting a field from the client.
+ */
+
+/**
+ * Who is scoring: a signed-in staff member, or a code-gated judge.
+ *
+ * Staff keep their existing RBAC guard untouched. The code-gated branch is
+ * ADDITIONAL and strictly narrower — it reaches only this route, which reads
+ * the judging payload and writes score rows, and nothing else in the admin
+ * surface. A code-gated identity is always prefixed `name:`, so it can never
+ * collide with a real account's email in the unique constraint.
+ */
+async function resolveJudge(): Promise<
+  | { ok: true; identity: string; displayName: string }
+  | { ok: false; response: NextResponse }
+> {
+  const judge = await readJudgeSession()
+  if (judge) return { ok: true, identity: judge.identity, displayName: judge.displayName }
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return { ok: false, response: check.response }
+  return { ok: true, identity: check.user.email, displayName: check.user.name }
+}
+
+const scoreSchema = z.object({
+  teamId: z.string().min(1).max(64),
+  scores: z.record(
+    z.string().max(40),
+    z.number().int().min(MIN_SCORE).max(MAX_SCORE)
+  ),
+  feedback: z.string().max(4000).optional(),
+})
+
+/** GET — every team, its submission, and this judge's own scorecards. */
+export async function GET(request: NextRequest) {
+  const judge = await resolveJudge()
+  if (!judge.ok) return judge.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+
+  if (!run) {
+    return NextResponse.json({
+      success: true,
+      data: { teams: [], mine: {}, standings: [], finalRunId: null },
+    })
+  }
+
+  const teams = extractFrozenTeams(run.result) ?? []
+
+  const [submissions, allScores] = await Promise.all([
+    prisma.impactLabSubmission.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, projectName: true, pitch: true, repoUrl: true, demoUrl: true },
+    }),
+    prisma.impactLabScore.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, judgeEmail: true, judgeName: true, scores: true, feedback: true },
+    }),
+  ])
+
+  const submissionByTeam = new Map(submissions.map((s) => [s.teamId, s]))
+
+  // A judge sees their own sheet to edit it, and the aggregate — but never
+  // another judge's individual scores, which would anchor them.
+  const mine: Record<string, { scores: ScoreSheet; feedback: string | null }> = {}
+  for (const row of allScores) {
+    if (row.judgeEmail === judge.identity) {
+      mine[row.teamId] = {
+        scores: (row.scores ?? {}) as ScoreSheet,
+        feedback: row.feedback,
+      }
+    }
+  }
+
+  const table = standings(
+    allScores.map((s) => ({
+      judgeEmail: s.judgeEmail,
+      teamId: s.teamId,
+      sheet: (s.scores ?? {}) as ScoreSheet,
+    }))
+  )
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      finalRunId: run.id,
+      teams: teams.map((t) => ({
+        teamId: t.id,
+        teamName: t.name,
+        memberCount: t.memberIds.length,
+        submission: submissionByTeam.get(t.id) ?? null,
+      })),
+      mine,
+      standings: table,
+    },
+  })
+}
+
+/** POST — record or update this judge's scorecard for one team. */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const judge = await resolveJudge()
+  if (!judge.ok) return judge.response
+
+  const parsed = scoreSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Scores must be whole numbers from 1 to 5." },
+      { status: 400 }
+    )
+  }
+
+  // Drop unknown keys rather than storing them: the criteria are fixed, and a
+  // stray key would silently do nothing while looking like it counted.
+  const scores: ScoreSheet = {}
+  for (const key of CRITERION_KEYS) {
+    const value = parsed.data.scores[key]
+    if (typeof value === "number") scores[key] = value
+  }
+  if (Object.keys(scores).length === 0) {
+    return NextResponse.json(
+      { success: false, error: "Score at least one criterion." },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+  if (!run) {
+    return NextResponse.json(
+      { success: false, error: "No final run to judge against." },
+      { status: 409 }
+    )
+  }
+
+  const teams = extractFrozenTeams(run.result) ?? []
+  if (!teams.some((t) => t.id === parsed.data.teamId)) {
+    return NextResponse.json(
+      { success: false, error: "That team is not in the final run." },
+      { status: 404 }
+    )
+  }
+
+  // judgeEmail comes from the session, never the body — that is what makes the
+  // unique constraint an actual guarantee of one scorecard per judge.
+  await prisma.impactLabScore.upsert({
+    where: {
+      runId_teamId_judgeEmail: {
+        runId: run.id,
+        teamId: parsed.data.teamId,
+        judgeEmail: judge.identity,
+      },
+    },
+    create: {
+      cohort,
+      runId: run.id,
+      teamId: parsed.data.teamId,
+      judgeEmail: judge.identity,
+      judgeName: judge.displayName,
+      scores,
+      feedback: parsed.data.feedback?.trim() || null,
+    },
+    update: {
+      scores,
+      feedback: parsed.data.feedback?.trim() || null,
+      judgeName: judge.displayName,
+    },
+  })
+
+  return NextResponse.json({
+    success: true,
+    data: { teamId: parsed.data.teamId, total: weightedTotal(scores) },
+  })
+}

--- a/src/app/api/impact-lab/judge-access/route.ts
+++ b/src/app/api/impact-lab/judge-access/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import {
+  JUDGE_COOKIE,
+  codeMatches,
+  encodeJudgeSession,
+  judgeIdentity,
+} from "@/lib/impact-lab/judge-access"
+
+/**
+ * Exchange the shared access code plus a name for a judge session cookie.
+ *
+ * Rate limited so a four-digit code cannot simply be walked. The response says
+ * only whether it worked — never which part was wrong, and never the code.
+ */
+
+const bodySchema = z.object({
+  code: z.string().min(1).max(64),
+  name: z.string().min(2).max(80),
+})
+
+export async function POST(request: NextRequest) {
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many attempts. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Enter your name and the access code." },
+      { status: 400 }
+    )
+  }
+
+  if (!codeMatches(parsed.data.code)) {
+    return NextResponse.json(
+      { success: false, error: "That code is not right." },
+      { status: 401 }
+    )
+  }
+
+  const identity = judgeIdentity(parsed.data.name)
+  if (!identity) {
+    return NextResponse.json(
+      { success: false, error: "Enter your name using letters." },
+      { status: 400 }
+    )
+  }
+
+  const displayName = parsed.data.name.trim().replace(/\s+/g, " ")
+  const response = NextResponse.json({ success: true, judge: displayName })
+
+  response.cookies.set(JUDGE_COOKIE, encodeJudgeSession({ identity, displayName }), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    // Long enough to cover a night of demos and deliberation without a judge
+    // being logged out mid-scoring, short enough not to linger for weeks.
+    maxAge: 60 * 60 * 12,
+  })
+
+  return response
+}
+
+/** Sign out — used by the "not you?" link on the judge screen. */
+export async function DELETE() {
+  const response = NextResponse.json({ success: true })
+  response.cookies.set(JUDGE_COOKIE, "", { path: "/", maxAge: 0 })
+  return response
+}

--- a/src/app/judge/JudgeGate.tsx
+++ b/src/app/judge/JudgeGate.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { JudgeScoring } from "./JudgeScoring";
+
+/**
+ * The code door. Once a judge is through, this stays mounted only to hold the
+ * "not you?" escape hatch — the scoring screen owns everything else.
+ */
+export function JudgeGate({ initialJudge }: { initialJudge: string | null }) {
+  const [judge, setJudge] = useState<string | null>(initialJudge);
+  const [name, setName] = useState("");
+  const [code, setCode] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function enter(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/impact-lab/judge-access", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, code }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "That did not work.");
+        return;
+      }
+      setJudge(json.judge as string);
+    } catch {
+      setError("That did not work. Check your connection.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function signOut() {
+    await fetch("/api/impact-lab/judge-access", { method: "DELETE" });
+    setJudge(null);
+    setName("");
+    setCode("");
+  }
+
+  if (judge) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <header className="mb-6 flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-[0.3em] text-green-primary">
+              Impact Lab · judging
+            </p>
+            <h1 className="mt-1 font-mono text-2xl font-bold text-text-primary">
+              Scoring as {judge}
+            </h1>
+          </div>
+          <button
+            type="button"
+            onClick={signOut}
+            className="rounded-lg border border-border-default px-3 py-2 font-mono text-xs uppercase tracking-wider text-text-secondary hover:border-green-primary/40 hover:text-green-primary"
+          >
+            Not you?
+          </button>
+        </header>
+        <JudgeScoring />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-sm pt-10">
+      <p className="font-mono text-[11px] uppercase tracking-[0.3em] text-green-primary">
+        Impact Lab · AI Mashinani
+      </p>
+      <h1 className="mt-2 font-mono text-2xl font-bold text-text-primary">
+        Judging
+      </h1>
+      <p className="mt-2 text-sm text-text-secondary">
+        Enter your name and the access code from the organisers.
+      </p>
+
+      <form onSubmit={enter} className="mt-6 space-y-4">
+        <div>
+          <label
+            htmlFor="judge-name"
+            className="font-mono text-xs uppercase tracking-wider text-text-dim"
+          >
+            Your name
+          </label>
+          <input
+            id="judge-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoComplete="name"
+            required
+            className="mt-2 w-full rounded-lg border border-border-default bg-bg-card px-3 py-3 text-base text-text-primary focus:border-green-primary focus:outline-none"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor="judge-code"
+            className="font-mono text-xs uppercase tracking-wider text-text-dim"
+          >
+            Access code
+          </label>
+          <input
+            id="judge-code"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            // Numeric keypad on a phone: judges are standing up, one-handed.
+            inputMode="numeric"
+            autoComplete="off"
+            required
+            className="mt-2 w-full rounded-lg border border-border-default bg-bg-card px-3 py-3 text-base tracking-[0.4em] text-text-primary focus:border-green-primary focus:outline-none"
+          />
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-red">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={busy}
+          className="w-full rounded-lg border border-green-primary/40 bg-green-primary/10 px-4 py-3 font-mono text-sm uppercase tracking-wider text-green-primary hover:bg-green-primary/20 disabled:opacity-50"
+        >
+          {busy ? "Checking…" : "Start judging"}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/judge/JudgeScoring.tsx
+++ b/src/app/judge/JudgeScoring.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { csrfHeaders } from "@/lib/csrf-client";
+import {
+  JUDGING_CRITERIA,
+  SCORE_LABELS,
+  MIN_SCORE,
+  MAX_SCORE,
+  weightedTotal,
+  type ScoreSheet,
+} from "@/lib/impact-lab/judging";
+
+interface TeamRow {
+  teamId: string;
+  teamName: string;
+  memberCount: number;
+  submission: {
+    projectName: string;
+    pitch: string;
+    repoUrl: string;
+    demoUrl: string | null;
+  } | null;
+}
+
+interface Payload {
+  teams: TeamRow[];
+  mine: Record<string, { scores: ScoreSheet; feedback: string | null }>;
+}
+
+const SCALE = Array.from(
+  { length: MAX_SCORE - MIN_SCORE + 1 },
+  (_, i) => MIN_SCORE + i
+);
+
+/**
+ * One team at a time. A judge is standing up holding a phone between demos —
+ * a long scrolling grid of every team is unusable in that posture, so the list
+ * collapses to the team being scored.
+ */
+export function JudgeScoring() {
+  const [data, setData] = useState<Payload | null>(null);
+  const [openTeam, setOpenTeam] = useState<string | null>(null);
+  const [sheets, setSheets] = useState<Record<string, ScoreSheet>>({});
+  const [feedback, setFeedback] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState<string | null>(null);
+  const [saved, setSaved] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/impact-lab/judging");
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "Could not load the teams.");
+        return;
+      }
+      const payload = json.data as Payload;
+      setData(payload);
+      setSheets(
+        Object.fromEntries(
+          Object.entries(payload.mine).map(([id, v]) => [id, v.scores])
+        )
+      );
+      setFeedback(
+        Object.fromEntries(
+          Object.entries(payload.mine).map(([id, v]) => [id, v.feedback ?? ""])
+        )
+      );
+    } catch {
+      setError("Could not load the teams. Check your connection.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function setScore(teamId: string, key: string, value: number) {
+    setSheets((prev) => ({ ...prev, [teamId]: { ...prev[teamId], [key]: value } }));
+    // A new edit means the previous "saved" confirmation no longer describes
+    // what is on screen.
+    setSaved((prev) => ({ ...prev, [teamId]: false }));
+  }
+
+  async function save(teamId: string) {
+    setSaving(teamId);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/impact-lab/judging", {
+        method: "POST",
+        headers: await csrfHeaders(),
+        body: JSON.stringify({
+          teamId,
+          scores: sheets[teamId] ?? {},
+          feedback: feedback[teamId] ?? "",
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "That did not save.");
+        return;
+      }
+      setSaved((prev) => ({ ...prev, [teamId]: true }));
+    } catch {
+      setError("That did not save. Check your connection.");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  if (error && !data) {
+    return (
+      <div className="rounded-xl border border-red/30 bg-red/5 p-5">
+        <p className="text-sm text-red">{error}</p>
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="mt-3 rounded-lg border border-border-default px-3 py-2 font-mono text-xs uppercase tracking-wider text-text-secondary"
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return <p className="text-sm text-text-dim">Loading teams…</p>;
+  }
+
+  if (data.teams.length === 0) {
+    return <p className="text-sm text-text-dim">No teams are published yet.</p>;
+  }
+
+  return (
+    <div className="space-y-3">
+      {data.teams.map((team) => {
+        const sheet = sheets[team.teamId] ?? {};
+        const total = weightedTotal(sheet);
+        const scoredCount = JUDGING_CRITERIA.filter(
+          (c) => typeof sheet[c.key] === "number"
+        ).length;
+        const isOpen = openTeam === team.teamId;
+
+        return (
+          <section
+            key={team.teamId}
+            className="overflow-hidden rounded-xl border border-border-default bg-bg-card"
+          >
+            <button
+              type="button"
+              onClick={() => setOpenTeam(isOpen ? null : team.teamId)}
+              aria-expanded={isOpen}
+              className="flex w-full items-center justify-between gap-3 px-4 py-4 text-left"
+            >
+              <span className="min-w-0">
+                <span className="block truncate font-mono text-sm text-text-primary">
+                  {team.teamName}
+                </span>
+                <span className="block truncate text-xs text-text-dim">
+                  {team.submission?.projectName ?? "No submission yet"}
+                </span>
+              </span>
+              <span className="shrink-0 text-right">
+                <span
+                  className={`block font-mono text-sm ${
+                    scoredCount > 0 ? "text-green-primary" : "text-text-dim"
+                  }`}
+                >
+                  {scoredCount > 0 ? `${total}/100` : "—"}
+                </span>
+                <span className="block font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                  {scoredCount}/{JUDGING_CRITERIA.length} scored
+                </span>
+              </span>
+            </button>
+
+            {isOpen && (
+              <div className="border-t border-border-default px-4 py-5">
+                {team.submission && (
+                  <div className="mb-5 rounded-lg border border-border-default bg-bg-primary p-3">
+                    <p className="text-sm text-text-secondary">
+                      {team.submission.pitch}
+                    </p>
+                    <div className="mt-2 flex flex-wrap gap-3 font-mono text-xs">
+                      <a
+                        href={team.submission.repoUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-cyan underline"
+                      >
+                        repo
+                      </a>
+                      {team.submission.demoUrl && (
+                        <a
+                          href={team.submission.demoUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-cyan underline"
+                        >
+                          demo
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                <div className="space-y-6">
+                  {JUDGING_CRITERIA.map((criterion) => (
+                    <fieldset key={criterion.key}>
+                      <legend className="font-mono text-xs uppercase tracking-wider text-text-primary">
+                        {criterion.label}{" "}
+                        <span className="text-text-dim">
+                          · {criterion.weight} pts
+                        </span>
+                      </legend>
+                      <p className="mt-1 text-xs leading-relaxed text-text-dim">
+                        {criterion.guidance}
+                      </p>
+                      <div className="mt-3 grid grid-cols-5 gap-2">
+                        {SCALE.map((value) => {
+                          const active = sheet[criterion.key] === value;
+                          return (
+                            <button
+                              key={value}
+                              type="button"
+                              onClick={() =>
+                                setScore(team.teamId, criterion.key, value)
+                              }
+                              aria-pressed={active}
+                              aria-label={`${criterion.label}: ${value} — ${SCORE_LABELS[value]}`}
+                              className={`rounded-lg border px-2 py-3 font-mono text-base transition-colors ${
+                                active
+                                  ? "border-green-primary bg-green-primary/15 text-green-primary"
+                                  : "border-border-default bg-bg-primary text-text-secondary"
+                              }`}
+                            >
+                              {value}
+                            </button>
+                          );
+                        })}
+                      </div>
+                      <p className="mt-2 text-[11px] text-text-dim">
+                        {sheet[criterion.key]
+                          ? SCORE_LABELS[sheet[criterion.key]]
+                          : `1 = ${SCORE_LABELS[1]} · 5 = ${SCORE_LABELS[5]}`}
+                      </p>
+                    </fieldset>
+                  ))}
+                </div>
+
+                <div className="mt-6">
+                  <label
+                    htmlFor={`fb-${team.teamId}`}
+                    className="font-mono text-xs uppercase tracking-wider text-text-dim"
+                  >
+                    What should this team hear? (optional)
+                  </label>
+                  <textarea
+                    id={`fb-${team.teamId}`}
+                    rows={3}
+                    value={feedback[team.teamId] ?? ""}
+                    onChange={(e) => {
+                      setFeedback((prev) => ({
+                        ...prev,
+                        [team.teamId]: e.target.value,
+                      }));
+                      setSaved((prev) => ({ ...prev, [team.teamId]: false }));
+                    }}
+                    className="mt-2 w-full rounded-lg border border-border-default bg-bg-primary px-3 py-2 text-sm text-text-primary focus:border-green-primary focus:outline-none"
+                  />
+                </div>
+
+                <div className="mt-4 flex flex-wrap items-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => void save(team.teamId)}
+                    disabled={saving === team.teamId}
+                    className="rounded-lg border border-green-primary/40 bg-green-primary/10 px-4 py-3 font-mono text-sm uppercase tracking-wider text-green-primary hover:bg-green-primary/20 disabled:opacity-50"
+                  >
+                    {saving === team.teamId ? "Saving…" : "Save score"}
+                  </button>
+                  <span className="font-mono text-sm text-text-secondary">
+                    {total}/100
+                  </span>
+                  {saved[team.teamId] && (
+                    <span role="status" className="text-sm text-green-primary">
+                      Saved
+                    </span>
+                  )}
+                </div>
+
+                {error && (
+                  <p role="alert" className="mt-3 text-sm text-red">
+                    {error}
+                  </p>
+                )}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/judge/page.tsx
+++ b/src/app/judge/page.tsx
@@ -1,0 +1,26 @@
+import type { Metadata } from "next";
+import { readJudgeSession } from "@/lib/impact-lab/judge-access";
+import { JudgeGate } from "./JudgeGate";
+
+/**
+ * Judge entry point.
+ *
+ * Deliberately outside /admin and unlinked from navigation: judges have no
+ * accounts tonight, so this is a code-gated door rather than a staff surface.
+ * noindex because it is a one-night operational page, not site content.
+ */
+export const metadata: Metadata = {
+  title: "Judging | Impact Lab",
+  description: "Score the Impact Lab demos.",
+  robots: { index: false, follow: false },
+};
+
+export default async function JudgePage() {
+  const session = await readJudgeSession();
+
+  return (
+    <main className="min-h-screen bg-bg-primary px-4 py-10 sm:px-6">
+      <JudgeGate initialJudge={session?.displayName ?? null} />
+    </main>
+  );
+}

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -1,15 +1,16 @@
 "use client"
 
 import { useState } from "react"
-import { Users, Network, Save, FileText, UserCheck } from "lucide-react"
+import { Users, Network, Save, FileText, UserCheck, Trophy } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ParticipantsTab } from "./ParticipantsTab"
 import { MatchingTab } from "./MatchingTab"
 import { RunsTab } from "./RunsTab"
 import { SubmissionsTab } from "./SubmissionsTab"
 import { CheckInTab } from "./CheckInTab"
+import { LeaderboardTab } from "./LeaderboardTab"
 
-type Tab = "participants" | "matching" | "runs" | "submissions" | "checkin"
+type Tab = "participants" | "matching" | "runs" | "submissions" | "checkin" | "leaderboard"
 
 const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "participants", label: "Participants", icon: Users },
@@ -17,6 +18,7 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "runs", label: "Runs", icon: Save },
   { key: "submissions", label: "Submissions", icon: FileText },
   { key: "checkin", label: "Check-in", icon: UserCheck },
+  { key: "leaderboard", label: "Leaderboard", icon: Trophy },
 ]
 
 export function ImpactLabDashboard({ cohort }: { cohort: string }) {
@@ -56,6 +58,7 @@ export function ImpactLabDashboard({ cohort }: { cohort: string }) {
       {tab === "runs" && <RunsTab cohort={cohort} refreshKey={runsKey} />}
       {tab === "submissions" && <SubmissionsTab cohort={cohort} />}
       {tab === "checkin" && <CheckInTab cohort={cohort} />}
+      {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
     </div>
   )
 }

--- a/src/components/admin/impact-lab/LeaderboardTab.tsx
+++ b/src/components/admin/impact-lab/LeaderboardTab.tsx
@@ -1,0 +1,164 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { AlertTriangle, Download, Loader2 } from "lucide-react"
+import { apiGet } from "./api"
+import { JUDGING_CRITERIA } from "@/lib/impact-lab/judging"
+
+interface LeaderboardTeam {
+  teamId: string
+  teamName: string
+  memberCount: number
+  submission: { projectName: string } | null
+}
+
+interface Standing {
+  teamId: string
+  average: number
+  judgeCount: number
+  criterionAverages: Record<string, number>
+}
+
+interface JudgingData {
+  finalRunId: string | null
+  teams: LeaderboardTeam[]
+  standings: Standing[]
+}
+
+/**
+ * Organiser-facing leaderboard. Reuses the same `standings` the judge screen
+ * writes to — this is not a second aggregation, just a second view of it.
+ * `standings()` only returns teams that have at least one score, so a team
+ * nobody has touched never appears there; those are the ones most likely to
+ * be missed at 5am, so they get their own flagged section here instead of
+ * silently sorting to the bottom.
+ */
+export function LeaderboardTab({ cohort }: { cohort: string }) {
+  const [data, setData] = useState<JudgingData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setData(await apiGet<JudgingData>(`/api/admin/impact-lab/judging?cohort=${cohort}`))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load standings")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+        {error ?? "No data"}
+      </div>
+    )
+  }
+
+  if (!data.finalRunId) {
+    return (
+      <p className="p-8 text-center text-sm font-mono text-[#555]">
+        No final run published yet — mark a run final to start judging.
+      </p>
+    )
+  }
+
+  const nameByTeam = new Map(data.teams.map((t) => [t.teamId, t]))
+  const scoredIds = new Set(data.standings.map((s) => s.teamId))
+  const unscored = data.teams.filter((t) => !scoredIds.has(t.teamId))
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-mono text-[#555]">
+          <span className="font-semibold text-[#00ff41]">{data.standings.length}</span> /{" "}
+          {data.teams.length} teams have at least one score
+        </p>
+        <a
+          href={`/api/admin/impact-lab/judging/export?cohort=${cohort}`}
+          className="flex items-center gap-1.5 rounded border border-[#1e1e1e] bg-[#1a1a1a] px-3 py-1.5 text-[11px] font-mono text-[#888] hover:bg-[#222]"
+        >
+          <Download className="h-3 w-3" /> Download results CSV
+        </a>
+      </div>
+
+      {unscored.length > 0 && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-3 text-[11px] font-mono text-[#ff3333]"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Not yet scored by any judge:{" "}
+            {unscored.map((t) => t.teamName).join(", ")}
+          </span>
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border border-[#1e1e1e] bg-[#0d0d0d]">
+        {data.standings.length === 0 ? (
+          <p className="p-8 text-center text-sm font-mono text-[#555]">No scores recorded yet.</p>
+        ) : (
+          <table className="w-full">
+            <thead>
+              <tr className="border-b border-[#1e1e1e]">
+                {["Rank", "Team", "Project", "Judges", "Average", ...JUDGING_CRITERIA.map((c) => c.label)].map(
+                  (h) => (
+                    <th
+                      key={h}
+                      className="whitespace-nowrap px-4 py-3 text-left text-[10px] font-mono font-semibold uppercase tracking-wider text-[#555]"
+                    >
+                      {h}
+                    </th>
+                  )
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-[#141414]">
+              {data.standings.map((s, i) => {
+                const team = nameByTeam.get(s.teamId)
+                return (
+                  <tr key={s.teamId} className="hover:bg-[#111]">
+                    <td className="px-4 py-3 text-[11px] font-mono text-[#555]">{i + 1}</td>
+                    <td className="px-4 py-3 text-[11px] font-mono text-[#e0e0e0]">
+                      {team?.teamName ?? s.teamId}
+                    </td>
+                    <td className="px-4 py-3 text-[11px] font-mono text-[#888]">
+                      {team?.submission?.projectName ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 text-[11px] font-mono text-[#888]">
+                      {s.judgeCount}
+                    </td>
+                    <td className="px-4 py-3 text-[11px] font-mono font-semibold text-[#00ff41]">
+                      {s.average}
+                    </td>
+                    {JUDGING_CRITERIA.map((c) => (
+                      <td key={c.key} className="px-4 py-3 text-[11px] font-mono text-[#888]">
+                        {s.criterionAverages[c.key] ?? 0}
+                      </td>
+                    ))}
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -35,7 +35,7 @@ export function ConditionalLayout({
   const isDashboard = pathname.startsWith("/dashboard");
   // /timer is a projector display for the room — no nav, no footer, no chrome
   // competing with a clock people read from across a hall.
-  const isBareDisplay = pathname.startsWith("/timer");
+  const isBareDisplay = pathname.startsWith("/timer") || pathname.startsWith("/judge");
   // Karibu (warm-light) is the default identity. Routes still on the Terminal
   // Noir chrome are listed here and removed as they get converted — unknown
   // paths (404s) fall through to Karibu so dead links stay on-brand.

--- a/src/lib/impact-lab/judge-access.ts
+++ b/src/lib/impact-lab/judge-access.ts
@@ -1,0 +1,111 @@
+/**
+ * Judge access by shared code.
+ *
+ * Judges do not have accounts — there was no time to create them mid-event —
+ * so a shared code plus a typed name is the entry path. This is deliberately
+ * weaker than the signed-in staff path, and the difference is contained:
+ *
+ * - A code-gated caller may ONLY read the judging payload and write their own
+ *   score rows. It can never reach runs, teams, participants, or submissions.
+ * - The staff path (`checkApiPermission("impact-lab", "view")`) is untouched.
+ *   This is an additional branch, never a relaxation of that one.
+ *
+ * The tradeoff is accepted knowingly: anyone who learns the code can submit
+ * scores under any name they type. For one night in one room that is fine;
+ * change JUDGE_ACCESS_CODE afterwards.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto"
+import { cookies } from "next/headers"
+
+export const JUDGE_COOKIE = "il_judge"
+
+/** Overridable without a deploy; falls back to the code agreed for the event. */
+export const JUDGE_ACCESS_CODE = process.env.JUDGE_ACCESS_CODE || "2077"
+
+/**
+ * The cookie is signed. Without a signature anyone could hand-craft the cookie
+ * value and skip the code entirely, which would make the gate decorative.
+ */
+const SIGNING_SECRET =
+  process.env.AUTH_SECRET || process.env.CSRF_SECRET || JUDGE_ACCESS_CODE
+
+function sign(payload: string): string {
+  return createHmac("sha256", SIGNING_SECRET).update(payload).digest("base64url")
+}
+
+
+/**
+ * Constant-time-ish comparison. The code is short and the endpoint is rate
+ * limited, so this is belt-and-braces rather than load-bearing — but a plain
+ * `===` on a secret is a habit worth not forming.
+ */
+export function codeMatches(input: string): boolean {
+  const a = input.trim()
+  const b = JUDGE_ACCESS_CODE
+  if (a.length !== b.length) return false
+  let diff = 0
+  for (let i = 0; i < a.length; i += 1) diff |= a.charCodeAt(i) ^ b.charCodeAt(i)
+  return diff === 0
+}
+
+/**
+ * A judge's identity for the `(runId, teamId, judgeEmail)` unique constraint.
+ *
+ * Code-gated judges have no email, so their typed name becomes a stable slug
+ * in that column. The `name:` prefix keeps it from ever colliding with a real
+ * signed-in judge's email, and the slug keeps "Favor Ruhiu", "favor ruhiu" and
+ * "Favor  Ruhiu" as one judge rather than three scorecards for the same person.
+ */
+export function judgeIdentity(name: string): string {
+  const slug = name
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return slug ? `name:${slug}` : ""
+}
+
+export interface JudgeSession {
+  /** The value stored in ImpactLabScore.judgeEmail. */
+  identity: string
+  /** The name as typed, for display and for the export. */
+  displayName: string
+}
+
+/**
+ * Read the judge session from the signed cookie, or null when absent or
+ * malformed. Malformed is treated as absent rather than throwing: a stale
+ * cookie must send someone back to the code screen, not error their page.
+ */
+export async function readJudgeSession(): Promise<JudgeSession | null> {
+  const store = await cookies()
+  const raw = store.get(JUDGE_COOKIE)?.value
+  if (!raw) return null
+  try {
+    const [body, signature] = raw.split(".")
+    if (!body || !signature) return null
+    const expected = sign(body)
+    const given = Buffer.from(signature)
+    const want = Buffer.from(expected)
+    if (given.length !== want.length || !timingSafeEqual(given, want)) return null
+
+    const parsed: unknown = JSON.parse(
+      Buffer.from(body, "base64url").toString("utf8")
+    )
+    if (typeof parsed !== "object" || parsed === null) return null
+    const { identity, displayName } = parsed as Record<string, unknown>
+    if (typeof identity !== "string" || typeof displayName !== "string") return null
+    if (!identity.startsWith("name:")) return null
+    return { identity, displayName }
+  } catch {
+    return null
+  }
+}
+
+/** Encode a judge session for the cookie value. */
+export function encodeJudgeSession(session: JudgeSession): string {
+  const body = Buffer.from(JSON.stringify(session), "utf8").toString("base64url")
+  return `${body}.${sign(body)}`
+}

--- a/src/lib/impact-lab/judging.ts
+++ b/src/lib/impact-lab/judging.ts
@@ -1,0 +1,159 @@
+/**
+ * Impact Lab judging — criteria, weights, and score arithmetic.
+ *
+ * Pure and dependency-free (no Prisma, no Next) so the arithmetic can be
+ * asserted by a script, the same way the matching engine is.
+ *
+ * The criteria and weights are the ones published to builders in the program.
+ * That matters more than it looks: teams spent the night optimising against
+ * these five things, so judging on anything else — a revenue model nobody
+ * asked them for, say — would score them on a brief they never received.
+ */
+
+export interface JudgingCriterion {
+  key: string
+  label: string
+  /** Points this criterion contributes to a 100-point total. */
+  weight: number
+  /** What a judge is actually being asked to look at. */
+  guidance: string
+}
+
+export const JUDGING_CRITERIA: readonly JudgingCriterion[] = [
+  {
+    key: "impact",
+    label: "Impact on the named beneficiary",
+    weight: 25,
+    guidance:
+      "Does this measurably help the specific person the team named? Not a market — a person.",
+  },
+  {
+    key: "demo",
+    label: "A working demo",
+    weight: 25,
+    guidance:
+      "Did it actually run in front of you? Working software only — what is real versus stubbed.",
+  },
+  {
+    key: "claude",
+    label: "Use of Claude",
+    weight: 20,
+    guidance:
+      "How well did the team use Claude to get further than they could have alone?",
+  },
+  {
+    key: "clarity",
+    label: "Beneficiary clarity",
+    guidance:
+      "Can they say who this helps and what that person struggles with today, in one sentence?",
+    weight: 15,
+  },
+  {
+    key: "presentation",
+    label: "Presentation",
+    weight: 15,
+    guidance: "Was the three minutes clear, honest, and well used?",
+  },
+] as const
+
+export const CRITERION_KEYS = JUDGING_CRITERIA.map((c) => c.key)
+
+/** Anchors shown beside the 1–5 scale so judges calibrate the same way. */
+export const SCORE_LABELS: Record<number, string> = {
+  1: "Not shown / insufficient",
+  2: "Attempted, unsatisfactory",
+  3: "Neutral",
+  4: "Good",
+  5: "Outstanding",
+}
+
+export const MIN_SCORE = 1
+export const MAX_SCORE = 5
+
+export type ScoreSheet = Record<string, number>
+
+/**
+ * Weighted total out of 100.
+ *
+ * A score of 1 means "not shown" and therefore earns zero of that criterion's
+ * weight — mapping 1 to a fifth of the points would hand marks to a team that
+ * did not do the thing at all. So the scale is normalised (score - 1) / 4.
+ *
+ * Missing or out-of-range criteria contribute nothing rather than throwing:
+ * a half-filled sheet during live demos should still produce a usable number.
+ */
+export function weightedTotal(sheet: ScoreSheet): number {
+  let total = 0
+  for (const criterion of JUDGING_CRITERIA) {
+    const raw = sheet[criterion.key]
+    if (typeof raw !== "number" || Number.isNaN(raw)) continue
+    const clamped = Math.min(MAX_SCORE, Math.max(MIN_SCORE, raw))
+    total += ((clamped - MIN_SCORE) / (MAX_SCORE - MIN_SCORE)) * criterion.weight
+  }
+  return Math.round(total * 10) / 10
+}
+
+/** True when every criterion has a usable score — used to flag partial sheets. */
+export function isComplete(sheet: ScoreSheet): boolean {
+  return JUDGING_CRITERIA.every((c) => {
+    const raw = sheet[c.key]
+    return typeof raw === "number" && raw >= MIN_SCORE && raw <= MAX_SCORE
+  })
+}
+
+export interface JudgeScore {
+  judgeEmail: string
+  teamId: string
+  sheet: ScoreSheet
+}
+
+export interface TeamStanding {
+  teamId: string
+  /** Mean of each judge's weighted total. */
+  average: number
+  judgeCount: number
+  /** Per-criterion mean of the raw 1–5 scores, for the breakdown view. */
+  criterionAverages: Record<string, number>
+}
+
+/**
+ * Aggregate every judge's sheet into one standing per team.
+ *
+ * Averages judges rather than summing them, so a team seen by three judges is
+ * not beaten by an identical team seen by four. Ordering is by average
+ * descending, then teamId, so the result is deterministic — a tie must not
+ * reorder itself between two loads of the leaderboard.
+ */
+export function standings(scores: JudgeScore[]): TeamStanding[] {
+  const byTeam = new Map<string, JudgeScore[]>()
+  for (const score of scores) {
+    const list = byTeam.get(score.teamId)
+    if (list) list.push(score)
+    else byTeam.set(score.teamId, [score])
+  }
+
+  const rows: TeamStanding[] = []
+  for (const [teamId, sheets] of byTeam) {
+    const totals = sheets.map((s) => weightedTotal(s.sheet))
+    const average = totals.reduce((a, b) => a + b, 0) / (totals.length || 1)
+
+    const criterionAverages: Record<string, number> = {}
+    for (const criterion of JUDGING_CRITERIA) {
+      const values = sheets
+        .map((s) => s.sheet[criterion.key])
+        .filter((v): v is number => typeof v === "number" && !Number.isNaN(v))
+      criterionAverages[criterion.key] = values.length
+        ? Math.round((values.reduce((a, b) => a + b, 0) / values.length) * 10) / 10
+        : 0
+    }
+
+    rows.push({
+      teamId,
+      average: Math.round(average * 10) / 10,
+      judgeCount: sheets.length,
+      criterionAverages,
+    })
+  }
+
+  return rows.sort((a, b) => b.average - a.average || a.teamId.localeCompare(b.teamId))
+}

--- a/src/lib/impact-lab/judging.ts
+++ b/src/lib/impact-lab/judging.ts
@@ -157,3 +157,70 @@ export function standings(scores: JudgeScore[]): TeamStanding[] {
 
   return rows.sort((a, b) => b.average - a.average || a.teamId.localeCompare(b.teamId))
 }
+
+/**
+ * The track a team belongs to, read from its name.
+ *
+ * Teams carry their track in the name they were assigned at the door — e.g.
+ * "Table 12 — Kilimo (Agriculture)". There is no track column because there is
+ * no team table at all, so the name is the only place it lives. Anything
+ * unparseable becomes "Unassigned" rather than throwing: a malformed name must
+ * not be able to hide a team from the track winners at 5 AM.
+ */
+export function trackOf(teamName: string): string {
+  const dash = teamName.split(/[—–-]/)
+  const tail = dash.length > 1 ? dash.slice(1).join("-").trim() : ""
+  return tail || "Unassigned"
+}
+
+export interface TrackWinner {
+  track: string
+  teamId: string
+  teamName: string
+  average: number
+  judgeCount: number
+}
+
+/**
+ * Top team per track, plus the overall champion.
+ *
+ * The program promises track winners AND an overall champion, so both are
+ * derived here rather than left to be eyeballed off a leaderboard at 5:30 AM.
+ * Teams nobody scored are excluded — a zero from "not judged" would otherwise
+ * be indistinguishable from a zero that was earned.
+ */
+export function trackWinners(
+  table: TeamStanding[],
+  nameById: Map<string, string>
+): { winners: TrackWinner[]; champion: TrackWinner | null } {
+  const best = new Map<string, TrackWinner>()
+
+  for (const row of table) {
+    if (row.judgeCount === 0) continue
+    const teamName = nameById.get(row.teamId) ?? row.teamId
+    const track = trackOf(teamName)
+    const candidate: TrackWinner = {
+      track,
+      teamId: row.teamId,
+      teamName,
+      average: row.average,
+      judgeCount: row.judgeCount,
+    }
+    const current = best.get(track)
+    // `table` arrives already sorted by average desc then id, so the first
+    // sighting of a track is its winner; keep it and ignore the rest.
+    if (!current) best.set(track, candidate)
+  }
+
+  const winners = [...best.values()].sort((a, b) => a.track.localeCompare(b.track))
+  const champion =
+    winners.length === 0
+      ? null
+      : winners.reduce((top, w) =>
+          w.average > top.average || (w.average === top.average && w.teamId < top.teamId)
+            ? w
+            : top
+        )
+
+  return { winners, champion }
+}


### PR DESCRIPTION
Judges score from a phone at `/judge` using a shared access code. No accounts needed.

**Scoring matches what builders were promised** — impact on the named beneficiary 25, working demo 25, use of Claude 20, beneficiary clarity 15, presentation 15. A score of 1 means "not shown" and earns **zero**, not a fifth of the marks.

- **Judges are averaged, not summed** — a team seen by four judges is not beaten by an identical team seen by three
- **Ties break deterministically**, so the leaderboard never reshuffles between refreshes
- **Track winners and an overall champion** are both derived; a team nobody scored cannot win, since an unjudged zero is not an earned zero
- **Partial cards count** — a judge pulled away mid-card contributes what they scored
- All teams in the final run, not a fixed list

**Access:** code from `JUDGE_ACCESS_CODE` (falls back to the code agreed for the event), exchanged for an **HMAC-signed httpOnly cookie**. Unsigned, the gate would be decorative. Rate limited so a short code cannot be walked.

**Containment:** the code path is additional, never a relaxation. Staff RBAC is untouched; a code-gated caller reaches only the judging route and can never touch runs, teams, participants, or submissions. Code-gated identities are prefixed `name:` so they cannot collide with real accounts in the `(runId, teamId, judgeEmail)` constraint.

Migration `20260726030000_impact_lab_scores` is **already applied to production and verified**.

Gates: tsc clean, eslint clean, verify:judging 27 assertions, build clean.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj