### PR TITLE
fix(impact-lab): raise submission field limits — teams are being cut off mid-write

### DIFF
--- a/scripts/verify-submissions.ts
+++ b/scripts/verify-submissions.ts
@@ -197,7 +197,7 @@ assert(
   "a javascript: URL is rejected rather than silently emptied"
 )
 assert(
-  !submissionInputSchema.safeParse({ ...validInput, pitch: "x".repeat(300) })
+  !submissionInputSchema.safeParse({ ...validInput, pitch: "x".repeat(600) })
     .success,
   "an over-long pitch is rejected"
 )

--- a/src/lib/impact-lab/submission-schema.ts
+++ b/src/lib/impact-lab/submission-schema.ts
@@ -21,7 +21,12 @@ import {
   zodSanitizeUrl,
 } from "@/lib/input-sanitization"
 
-const MAX_LONG_TEXT = 2000
+// Raised mid-event: teams were hitting the ceiling while writing up what
+// works versus what is mocked, and a submission you cannot finish is worse
+// than a long one. Every one of these columns is Postgres `text` (Prisma
+// `String`/`@db.Text`), so there is no storage limit behind these numbers —
+// they exist only to bound abuse, and can be raised freely.
+const MAX_LONG_TEXT = 10_000
 
 /** Adds https:// when a scheme is absent; leaves empty input untouched. */
 function withScheme(value: string): string {
@@ -32,7 +37,7 @@ function withScheme(value: string): string {
 
 const requiredUrl = z
   .string()
-  .max(300)
+  .max(1000)
   .transform(withScheme)
   .refine((v) => v !== "", { message: "A link is required" })
   .transform(zodSanitizeUrl)
@@ -42,7 +47,7 @@ const requiredUrl = z
 // rejected scheme surfaces as a validation error instead of a silent null.
 const optionalUrl = z
   .string()
-  .max(300)
+  .max(1000)
   .optional()
   .transform((v) => withScheme(v ?? ""))
   .transform((v) => (v === "" ? null : zodSanitizeUrl(v)))
@@ -71,13 +76,13 @@ function requiredMultilineText(max: number) {
 }
 
 export const submissionInputSchema = z.object({
-  projectName: requiredText(120),
-  pitch: requiredText(200),
+  projectName: requiredText(200),
+  pitch: requiredText(500),
   description: requiredMultilineText(MAX_LONG_TEXT),
   worksVsMocked: requiredMultilineText(MAX_LONG_TEXT),
   claudeUsage: requiredMultilineText(MAX_LONG_TEXT),
-  track: requiredText(80),
-  problemTackled: requiredText(300),
+  track: requiredText(200),
+  problemTackled: requiredText(1000),
   repoUrl: requiredUrl,
   demoUrl: optionalUrl,
   videoUrl: optionalUrl,


### PR DESCRIPTION
Live issue: teams hit the character ceiling while writing their submission and could not save at all.

No migration needed — every affected column is Postgres `text` (Prisma `String` / `@db.Text`), so storage was never the constraint. These limits only bound abuse.

| Field | Was | Now |
|---|---|---|
| Description, works-vs-mocked, Claude usage | 2,000 | 10,000 |
| Project name | 120 | 200 |
| Pitch | 200 | 500 |
| Problem tackled | 300 | 1,000 |
| Track | 80 | 200 |
| URLs | 300 | 1,000 |

The harness assertion for an over-long pitch moves with the limit so it still fails against a too-long value rather than silently passing.

Gates: tsc clean, eslint clean, verify:submissions all passing.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj