### PR TITLE
feat(impact-lab): self-declared team leader

### DIFF
--- a/src/app/api/impact-lab/team/leader/route.ts
+++ b/src/app/api/impact-lab/team/leader/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
+import type { Team } from "@/lib/matching"
+
+/**
+ * Team leader — self-declared.
+ *
+ * Somebody has to be the one who presents and who organisers chase, and at
+ * 3 AM the fastest way to settle that is for a member to claim it. Any member
+ * may claim, and a later claim replaces an earlier one: teams re-decide, and a
+ * first-come lock would leave a team stuck with whoever tapped fastest.
+ *
+ * The leader is stored as `leaderId` on the team object inside the run's
+ * result JSON. `extractFrozenTeams` validates only `memberIds`, so this extra
+ * field is ignored everywhere that does not look for it — runs written before
+ * this existed simply have no leader, and nothing that reads a team breaks.
+ */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many changes. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const participant = await prisma.impactLabParticipant.findUnique({
+    where: { cohort_email: { cohort: DEFAULT_COHORT, email: check.email } },
+    select: { id: true, fullName: true },
+  })
+  if (!participant) {
+    return NextResponse.json(
+      { success: false, error: "No hackathon registration found for your account.", code: "NO_TEAM" },
+      { status: 403 }
+    )
+  }
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort: DEFAULT_COHORT, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  })
+  if (!run) {
+    return NextResponse.json(
+      { success: false, error: "Teams are not published yet.", code: "NO_TEAM" },
+      { status: 403 }
+    )
+  }
+
+  // Lock before the read-modify-write: two teammates claiming at the same
+  // moment would otherwise both read the old JSON and the second write would
+  // discard the first.
+  const updated = await prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT id FROM impact_lab_match_runs WHERE id = ${run.id} FOR UPDATE`
+
+    const fresh = await tx.impactLabMatchRun.findUnique({
+      where: { id: run.id },
+      select: { result: true },
+    })
+    const teams = extractFrozenTeams(fresh?.result)
+    if (!teams) return null
+
+    const mine = teams.find((t) => t.memberIds.includes(participant.id))
+    if (!mine) return null
+
+    const next: (Team & { leaderId?: string })[] = teams.map((t) =>
+      t.id === mine.id ? { ...t, leaderId: participant.id } : t
+    )
+
+    await tx.impactLabMatchRun.update({
+      where: { id: run.id },
+      data: {
+        result: JSON.parse(
+          JSON.stringify({ ...(fresh?.result as object), teams: next })
+        ),
+      },
+    })
+    return mine.id
+  })
+
+  if (!updated) {
+    return NextResponse.json(
+      { success: false, error: "You are not on a team yet.", code: "NO_TEAM" },
+      { status: 403 }
+    )
+  }
+
+  return NextResponse.json({
+    success: true,
+    message: `${participant.fullName} is now the team leader.`,
+  })
+}

--- a/src/app/api/impact-lab/team/route.ts
+++ b/src/app/api/impact-lab/team/route.ts
@@ -114,6 +114,9 @@ export async function GET() {
       primaryRole: liveP?.primaryRole ?? snap?.primaryRole ?? "",
       suggestedInternalRole: explanation.suggestedInternalRoles?.[id] ?? null,
       isSelf,
+      // leaderId is an optional extra field on the frozen team; runs written
+      // before leaders existed simply have none.
+      isLeader: (team as { leaderId?: string }).leaderId === id,
       email: shareEmail ? (liveP?.email ?? (isSelf ? check.email : null)) : null,
       checkedIn: Boolean(liveP?.checkedInAt),
     }

--- a/src/app/dashboard/impact-lab/TeamRoster.tsx
+++ b/src/app/dashboard/impact-lab/TeamRoster.tsx
@@ -90,6 +90,35 @@ export function TeamRoster({
   }
 
   const memberIds = new Set(members.map((m) => m.id));
+  const leader = members.find((m) => m.isLeader) ?? null;
+  const iAmLeader = leader?.isSelf ?? false;
+
+  // Somebody has to be the one who presents and who organisers chase. Any
+  // member may claim it and a later claim replaces an earlier one — teams
+  // re-decide, and a first-come lock would leave a team stuck with whoever
+  // tapped fastest.
+  async function claimLeadership() {
+    setBusyId("leader");
+    setError(null);
+    setNotice(null);
+    try {
+      const res = await fetch("/api/impact-lab/team/leader", {
+        method: "POST",
+        headers: await csrfHeaders(),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "That did not work. Try again.");
+        return;
+      }
+      setNotice(json.message ?? "You are now the team leader.");
+      onChanged();
+    } catch {
+      setError("That did not work. Check your connection.");
+    } finally {
+      setBusyId(null);
+    }
+  }
 
   return (
     <section className="mt-8 rounded-xl border border-border-default bg-bg-card p-5">
@@ -111,6 +140,33 @@ export function TeamRoster({
         >
           {open ? "Done" : "Edit team"}
         </button>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3 border-t border-border-default pt-4">
+        <span className="font-mono text-xs uppercase tracking-wider text-text-dim">
+          Team leader
+        </span>
+        {leader ? (
+          <span className="rounded border border-green-primary/30 bg-green-primary/10 px-2.5 py-1 font-mono text-xs text-green-primary">
+            {leader.isSelf ? "You" : leader.fullName}
+          </span>
+        ) : (
+          <span className="text-sm text-text-dim">Nobody yet</span>
+        )}
+        {!iAmLeader && (
+          <button
+            type="button"
+            onClick={claimLeadership}
+            disabled={busyId === "leader"}
+            className="rounded-lg border border-border-default px-3 py-1.5 font-mono text-xs uppercase tracking-wider text-text-secondary transition-colors hover:border-green-primary/40 hover:text-green-primary disabled:opacity-50"
+          >
+            {busyId === "leader"
+              ? "Saving…"
+              : leader
+                ? "Take over as leader"
+                : "I'll be team leader"}
+          </button>
+        )}
       </div>
 
       {open && (

--- a/src/lib/impact-lab/member.ts
+++ b/src/lib/impact-lab/member.ts
@@ -98,6 +98,8 @@ export interface TeamMemberView {
   primaryRole: string
   suggestedInternalRole: string | null
   isSelf: boolean
+  /** Self-declared team leader. Absent on runs written before leaders existed. */
+  isLeader: boolean
   /** Only set for self, or for teammates with consentToShareContact = true. */
   email: string | null
   /**


### PR DESCRIPTION
Any member can claim team leader from their dashboard; a later claim replaces an earlier one, because teams re-decide and a first-come lock would strand a team with whoever tapped fastest.

**Designed so it cannot break anything else** — the explicit requirement. The leader is an extra `leaderId` field on the team object inside the run's result JSON. `extractFrozenTeams` validates only `memberIds`, so every existing reader ignores it, and runs written before this simply have no leader.

- Row lock before the read-modify-write, so simultaneous claims can't clobber each other
- Team resolved server-side from the session — you can only claim on your own team
- CSRF + rate limited, same guard order as the other member writes

Gates: tsc clean, eslint clean. The local production build could not run in this worktree (Turbopack rejects the junctioned `node_modules`); the Vercel preview build is the check.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj