### PR TITLE
feat(impact-lab): optional Claude reading help on the judge card

### DIFF
--- a/src/app/api/admin/impact-lab/judging/assist/route.ts
+++ b/src/app/api/admin/impact-lab/judging/assist/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { generateObject } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { readJudgeSession } from "@/lib/impact-lab/judge-access"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { JUDGING_CRITERIA } from "@/lib/impact-lab/judging"
+
+/**
+ * Optional reading assistance for a judge, on one team's written submission.
+ *
+ * Deliberately returns NO scores and NO ranking. A suggested number would
+ * anchor the judge before they had formed their own view, and there is a prize
+ * attached to the result — so this reads what the team wrote and hands back
+ * observations and questions worth asking during the demo. The judgement stays
+ * with the human.
+ *
+ * It also only ever sees what the team submitted. It cannot see other teams,
+ * other judges' scores, or the leaderboard, so it has nothing to be biased by.
+ */
+
+export const maxDuration = 60
+
+const MODEL = "claude-sonnet-5"
+const anthropic = createAnthropic()
+
+const bodySchema = z.object({ teamId: z.string().min(1).max(64) })
+
+const assistSchema = z.object({
+  readsAs: z
+    .string()
+    .describe("One sentence: what this project appears to be, in plain terms."),
+  observations: z
+    .array(
+      z.object({
+        criterion: z.string().describe("The criterion label this speaks to."),
+        note: z
+          .string()
+          .describe(
+            "What the submission does or does not tell you about this criterion. Neutral, no score."
+          ),
+      })
+    )
+    .describe("One entry per criterion, in the order given."),
+  questionsToAsk: z
+    .array(z.string())
+    .describe("Two or three specific questions to ask this team during the demo."),
+  watchFor: z
+    .string()
+    .describe(
+      "One thing to verify live, e.g. a claim in the writeup the demo should prove."
+    ),
+})
+
+const SYSTEM = `You help a hackathon judge read one team's written submission before their live demo.
+
+You do not score, rank, or recommend. You never say a team is good, strong, weak, or better than anyone. A judge forms their own view; your job is to help them read faster and ask sharper questions.
+
+Ground every statement in what the team actually wrote. If the submission does not say something, say that it does not say it — never infer, never fill gaps, never flatter. "The writeup does not say who the beneficiary is" is a useful sentence; inventing one is not.
+
+Be brief. A judge is standing up between demos.
+
+Plain English. No jargon.`
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  // Same two doors as the rest of judging: a code-gated judge, or staff.
+  const judge = await readJudgeSession()
+  if (!judge) {
+    const check = await checkApiPermission("impact-lab", "view")
+    if (!check.authorized) return check.response
+  }
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick a team." },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  })
+  if (!run) {
+    return NextResponse.json(
+      { success: false, error: "No final run." },
+      { status: 409 }
+    )
+  }
+
+  const submission = await prisma.impactLabSubmission.findUnique({
+    where: { runId_teamId: { runId: run.id, teamId: parsed.data.teamId } },
+    select: {
+      projectName: true,
+      pitch: true,
+      description: true,
+      worksVsMocked: true,
+      claudeUsage: true,
+      track: true,
+      problemTackled: true,
+    },
+  })
+
+  if (!submission) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "This team has not submitted anything yet, so there is nothing to read.",
+        code: "NO_SUBMISSION",
+      },
+      { status: 404 }
+    )
+  }
+
+  const criteria = JUDGING_CRITERIA.map(
+    (c) => `- ${c.label}: ${c.guidance}`
+  ).join("\n")
+
+  const prompt = `The judge will score this team on these criteria:
+${criteria}
+
+The team's submission:
+
+Project: ${submission.projectName}
+Track: ${submission.track}
+One-line pitch: ${submission.pitch}
+Problem tackled: ${submission.problemTackled}
+What it does: ${submission.description}
+What works vs what is mocked: ${submission.worksVsMocked}
+How they used Claude: ${submission.claudeUsage}`
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic(MODEL),
+      schema: assistSchema,
+      system: SYSTEM,
+      prompt,
+      maxOutputTokens: 2_000,
+    })
+
+    return NextResponse.json({ success: true, data: object })
+  } catch (error) {
+    // Never block scoring on this. The judge can always read the submission
+    // themselves, so a failure here is an inconvenience, not an outage.
+    console.error("[judging/assist] generation failed", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Could not read that submission right now. Score it yourself — nothing is blocked.",
+      },
+      { status: 502 }
+    )
+  }
+}

--- a/src/app/judge/JudgeScoring.tsx
+++ b/src/app/judge/JudgeScoring.tsx
@@ -46,6 +46,10 @@ export function JudgeScoring() {
   const [saving, setSaving] = useState<string | null>(null);
   const [saved, setSaved] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  // "Unscored" first, because the failure at 5 AM is a team nobody reached —
+  // and that is invisible on a list sorted by table number.
+  const [filter, setFilter] = useState<"all" | "unscored" | "scored">("all");
 
   const load = useCallback(async () => {
     try {
@@ -132,9 +136,72 @@ export function JudgeScoring() {
     return <p className="text-sm text-text-dim">No teams are published yet.</p>;
   }
 
+  const scoredIds = new Set(
+    Object.entries(sheets)
+      .filter(([, sheet]) => Object.keys(sheet ?? {}).length > 0)
+      .map(([id]) => id)
+  );
+
+  const needle = query.trim().toLowerCase();
+  const visible = data.teams.filter((team) => {
+    if (filter === "scored" && !scoredIds.has(team.teamId)) return false;
+    if (filter === "unscored" && scoredIds.has(team.teamId)) return false;
+    if (!needle) return true;
+    // Judges are told "table 12" over a microphone, so the table number in the
+    // team name has to match as readily as the project title.
+    return (
+      team.teamName.toLowerCase().includes(needle) ||
+      (team.submission?.projectName ?? "").toLowerCase().includes(needle)
+    );
+  });
+
+  const FILTERS: { key: "all" | "unscored" | "scored"; label: string }[] = [
+    { key: "all", label: `All ${data.teams.length}` },
+    { key: "unscored", label: `Not scored ${data.teams.length - scoredIds.size}` },
+    { key: "scored", label: `Scored ${scoredIds.size}` },
+  ];
+
   return (
     <div className="space-y-3">
-      {data.teams.map((team) => {
+      <div className="sticky top-0 z-10 -mx-1 space-y-2 bg-bg-primary px-1 pb-2 pt-1">
+        <label htmlFor="judge-team-search" className="sr-only">
+          Search teams
+        </label>
+        <input
+          id="judge-team-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search table number or project"
+          autoComplete="off"
+          className="w-full rounded-lg border border-border-default bg-bg-card px-3 py-3 text-base text-text-primary placeholder:text-text-dim focus:border-green-primary focus:outline-none"
+        />
+        <div className="flex gap-2">
+          {FILTERS.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setFilter(f.key)}
+              aria-pressed={filter === f.key}
+              className={`flex-1 rounded-lg border px-2 py-2 font-mono text-[11px] uppercase tracking-wider transition-colors ${
+                filter === f.key
+                  ? "border-green-primary bg-green-primary/15 text-green-primary"
+                  : "border-border-default bg-bg-card text-text-secondary"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {visible.length === 0 && (
+        <p className="py-6 text-center text-sm text-text-dim">
+          No team matches that.
+        </p>
+      )}
+
+      {visible.map((team) => {
         const sheet = sheets[team.teamId] ?? {};
         const total = weightedTotal(sheet);
         const scoredCount = JUDGING_CRITERIA.filter(

--- a/src/app/judge/JudgeScoring.tsx
+++ b/src/app/judge/JudgeScoring.tsx
@@ -23,6 +23,13 @@ interface TeamRow {
   } | null;
 }
 
+interface AssistResult {
+  readsAs: string;
+  observations: { criterion: string; note: string }[];
+  questionsToAsk: string[];
+  watchFor: string;
+}
+
 interface Payload {
   teams: TeamRow[];
   mine: Record<string, { scores: ScoreSheet; feedback: string | null }>;
@@ -50,6 +57,8 @@ export function JudgeScoring() {
   // "Unscored" first, because the failure at 5 AM is a team nobody reached —
   // and that is invisible on a list sorted by table number.
   const [filter, setFilter] = useState<"all" | "unscored" | "scored">("all");
+  const [assist, setAssist] = useState<Record<string, AssistResult>>({});
+  const [assisting, setAssisting] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -85,6 +94,30 @@ export function JudgeScoring() {
     // A new edit means the previous "saved" confirmation no longer describes
     // what is on screen.
     setSaved((prev) => ({ ...prev, [teamId]: false }));
+  }
+
+  // Optional reading help. Returns observations and questions, never scores —
+  // a suggested number would anchor the judge before they had formed a view.
+  async function askClaude(teamId: string) {
+    setAssisting(teamId);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/impact-lab/judging/assist", {
+        method: "POST",
+        headers: await csrfHeaders(),
+        body: JSON.stringify({ teamId }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "Could not read that submission.");
+        return;
+      }
+      setAssist((prev) => ({ ...prev, [teamId]: json.data as AssistResult }));
+    } catch {
+      setError("Could not read that submission. Check your connection.");
+    } finally {
+      setAssisting(null);
+    }
   }
 
   async function save(teamId: string) {
@@ -271,6 +304,56 @@ export function JudgeScoring() {
                     </div>
                   </div>
                 )}
+
+                <div className="mb-6">
+                  {!assist[team.teamId] ? (
+                    <button
+                      type="button"
+                      onClick={() => void askClaude(team.teamId)}
+                      disabled={assisting === team.teamId || !team.submission}
+                      className="w-full rounded-lg border border-cyan/30 bg-cyan/5 px-3 py-2.5 font-mono text-xs uppercase tracking-wider text-cyan transition-colors hover:bg-cyan/10 disabled:opacity-40"
+                    >
+                      {assisting === team.teamId
+                        ? "Reading the submission…"
+                        : team.submission
+                          ? "Ask Claude to read this submission"
+                          : "Nothing submitted to read"}
+                    </button>
+                  ) : (
+                    <div className="rounded-lg border border-cyan/30 bg-cyan/5 p-4">
+                      <p className="font-mono text-[10px] uppercase tracking-wider text-cyan">
+                        Reading help · not a score
+                      </p>
+                      <p className="mt-2 text-sm text-text-primary">
+                        {assist[team.teamId].readsAs}
+                      </p>
+                      <ul className="mt-3 space-y-2">
+                        {assist[team.teamId].observations.map((o) => (
+                          <li key={o.criterion} className="text-xs leading-relaxed">
+                            <span className="text-text-dim">{o.criterion}: </span>
+                            <span className="text-text-secondary">{o.note}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="mt-3 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                        Ask them
+                      </p>
+                      <ul className="mt-1 list-disc space-y-1 pl-4">
+                        {assist[team.teamId].questionsToAsk.map((q) => (
+                          <li key={q} className="text-xs text-text-secondary">
+                            {q}
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="mt-3 text-xs text-amber">
+                        Watch for: {assist[team.teamId].watchFor}
+                      </p>
+                      <p className="mt-3 text-[11px] text-text-dim">
+                        Claude read only what this team wrote. The score is yours.
+                      </p>
+                    </div>
+                  )}
+                </div>
 
                 <div className="space-y-6">
                   {JUDGING_CRITERIA.map((criterion) => (


### PR DESCRIPTION
A judge gets three minutes of demo and two of questions. On request, Claude reads that team's written submission and returns observations plus questions worth asking, so the judge arrives already knowing what to probe.

**It returns no scores and no ranking, deliberately.** A suggested number would anchor the judge before they formed their own view, and there is a prize attached. The card is labelled "reading help · not a score" and closes with "the score is yours".

- Grounded in what the team wrote; instructed to say when the writeup omits something rather than inferring it
- Sees only that one team's submission — never other teams, other judges' scores, or the leaderboard
- Opt-in per team, never automatic
- A failure tells the judge to score it themselves; it can never block scoring
- Same two doors as the rest of judging (code-gated judge or staff), CSRF + rate limited

Uses the `ANTHROPIC_API_KEY` already configured in Vercel.

Gates: tsc clean, eslint clean, build clean.

@Spidey-Acer

https://claude.ai/code/session_01BKvw1498HcqAFqR9ZzJbDj