### PR TITLE
Fix WhatsApp group link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/CkD9QWjsHm
     about: Ask questions and get help from the community on Discord.
   - name: WhatsApp Group
-    url: https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa
+    url: https://chat.whatsapp.com/HSNkqvKklyZBvI3zcpEMhX
     about: Join the WhatsApp community group.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ npm run db:seed          # Seed database
 |---------|-----|
 | Website | https://www.claudekenya.org |
 | Discord | https://discord.gg/CkD9QWjsHm |
-| WhatsApp | https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa |
+| WhatsApp | https://chat.whatsapp.com/HSNkqvKklyZBvI3zcpEMhX |
 | Nairobi Events (Luma) | https://luma.com/sbsa789m |
 | Mombasa Events (Luma) | https://luma.com/vsf5re14 |
 | Global Claude Community | https://luma.com/claudecommunity |

--- a/DEMO-CHEATSHEET.md
+++ b/DEMO-CHEATSHEET.md
@@ -165,7 +165,7 @@ claude "/commit"
 
 - **Website:** https://www.claudekenya.org
 - **Discord:** https://discord.gg/CkD9QWjsHm
-- **WhatsApp:** https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa
+- **WhatsApp:** https://chat.whatsapp.com/HSNkqvKklyZBvI3zcpEMhX
 - **Nairobi Events:** https://luma.com/sbsa789m
 - **Mombasa Events:** https://luma.com/vsf5re14
 - **Anthropic Courses:** https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [CONTRIBUTORS.md](./CONTRIBUTORS.md) for the people behind the code.
 | Platform | Link |
 |----------|------|
 | Discord | [discord.gg/CkD9QWjsHm](https://discord.gg/CkD9QWjsHm) |
-| WhatsApp | [Join group](https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa) |
+| WhatsApp | [Join group](https://chat.whatsapp.com/HSNkqvKklyZBvI3zcpEMhX) |
 | Events (Nairobi) | [luma.com/sbsa789m](https://luma.com/sbsa789m) |
 | Events (Mombasa) | [luma.com/vsf5re14](https://luma.com/vsf5re14) |
 

--- a/src/app/resources/links/page.tsx
+++ b/src/app/resources/links/page.tsx
@@ -8,6 +8,7 @@ import {
   getResourceCategories,
   getResourcesByCategory,
 } from "@/data/resources";
+import { SOCIAL_LINKS } from "@/lib/constants";
 
 export const metadata: Metadata = {
   title: "Curated Links | Claude Community Kenya",
@@ -165,7 +166,7 @@ export default function LinksPage() {
             </a>
             {", "}
             <a
-              href="https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa"
+              href={SOCIAL_LINKS.whatsapp}
               target="_blank"
               rel="noopener noreferrer"
               className="text-cyan hover:underline"

--- a/src/components/sections/PersonalizedHero.tsx
+++ b/src/components/sections/PersonalizedHero.tsx
@@ -5,6 +5,7 @@ import { useSkin } from "@/contexts/SkinContext";
 import { HeroTerminal, type FeedItem, type CommunityStats } from "./HeroTerminal";
 import { HeroPro } from "./HeroPro";
 import type { Audience } from "@/lib/karibu/types";
+import { SOCIAL_LINKS } from "@/lib/constants";
 
 const COPY: Record<
   Audience,
@@ -26,7 +27,7 @@ const COPY: Record<
     headline: "Start your AI journey with us",
     sub: "Free meetups, study groups, mentorship — built for Kenyan students",
     ctaLabel: "Join WhatsApp",
-    ctaHref: "https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa",
+    ctaHref: SOCIAL_LINKS.whatsapp,
   },
   founder: {
     headline: "Build your AI company in Nairobi",

--- a/src/data/resources.ts
+++ b/src/data/resources.ts
@@ -1,3 +1,5 @@
+import { SOCIAL_LINKS } from "@/lib/constants";
+
 export interface Resource {
   id: string;
   title: string;
@@ -187,7 +189,7 @@ export const resources: Resource[] = [
   {
     id: "cck-whatsapp",
     title: "CCK WhatsApp Group",
-    url: "https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa",
+    url: SOCIAL_LINKS.whatsapp,
     category: "Community & Social",
     description: "Join the community WhatsApp group for quick updates and discussion.",
   },

--- a/src/lib/chat/community-context.ts
+++ b/src/lib/chat/community-context.ts
@@ -7,6 +7,7 @@ import {
   getFeaturedProjects,
   getTeamMembers,
 } from "@/lib/data";
+import { SOCIAL_LINKS } from "@/lib/constants";
 
 export async function buildCommunityContext(): Promise<string> {
   // Single source of truth: the DB. Empty arrays on failure are intentional —
@@ -69,7 +70,7 @@ export async function buildCommunityContext(): Promise<string> {
 - Cities: Nairobi + Mombasa (expanding)
 - Website: https://www.claudekenya.org
 - Discord: https://discord.gg/CkD9QWjsHm
-- WhatsApp: https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa
+- WhatsApp: ${SOCIAL_LINKS.whatsapp}
 - Nairobi Events (Luma): https://luma.com/sbsa789m
 - Mombasa Events (Luma): https://luma.com/vsf5re14
 - Global Claude Community: https://luma.com/claudecommunity

--- a/src/lib/chat/system-prompt.ts
+++ b/src/lib/chat/system-prompt.ts
@@ -1,4 +1,5 @@
 import { buildCommunityContext } from "./community-context";
+import { SOCIAL_LINKS } from "@/lib/constants";
 
 export type ChatPersona = "dev" | "pro";
 
@@ -30,7 +31,7 @@ Available action types and their real URLs:
 - resources → /resources
 - faq → /faq
 - discord → https://discord.gg/CkD9QWjsHm
-- whatsapp → https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa
+- whatsapp → ${SOCIAL_LINKS.whatsapp}
 - nairobi-events → https://luma.com/sbsa789m
 - mombasa-events → https://luma.com/vsf5re14
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -54,7 +54,9 @@ export const NAV_LINKS: ReadonlyArray<NavLink> = [
 export const SOCIAL_LINKS = {
   twitter: "https://twitter.com/ClaudeCommunityKE",
   discord: "https://discord.gg/CkD9QWjsHm",
-  whatsapp: "https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa",
+  // Points at the currently joinable group. The first group (Hpx42q1A…) is full
+  // but still active — members stay, new joiners come here.
+  whatsapp: "https://chat.whatsapp.com/HSNkqvKklyZBvI3zcpEMhX",
   linkedin: "https://linkedin.com/company/claude-community-kenya",
   lumaNairobi: "https://luma.com/sbsa789m",
   lumaMombasa: "https://luma.com/vsf5re14",

--- a/src/lib/karibu/system-prompt.ts
+++ b/src/lib/karibu/system-prompt.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@/lib/prisma";
+import { SOCIAL_LINKS } from "@/lib/constants";
 
 interface KaribuContextData {
   upcomingEvents: Array<{ title: string; date: Date; city: string; audiences: string[] }>;
@@ -97,7 +98,7 @@ TOP RESOURCES:
 ${resourcesBlock || "- (none yet)"}
 
 DISCORD: https://discord.gg/CkD9QWjsHm
-WHATSAPP: https://chat.whatsapp.com/Hpx42q1ADsrFNN3hHtZcQa
+WHATSAPP: ${SOCIAL_LINKS.whatsapp}
 
 # Output style
 Conversational. Warm but efficient. No emoji except the opening 👋. No markdown headers. Plain text and short bullet lists only.


### PR DESCRIPTION
The WhatsApp group hit its member cap, so every "Join on WhatsApp" CTA on the site led to a group nobody could actually join. This points the invite at the new group and consolidates the URL onto `SOCIAL_LINKS.whatsapp`, which it was hardcoded alongside in six places.

Both groups stay active — only one can take new members, so this replaces the link rather than listing both. A CTA that asks the visitor to pick between two unlabelled links, one of which dead-ends, converts worse than a single working one.

Worth noting the three chatbot prompts (`lib/chat/system-prompt.ts`, `lib/chat/community-context.ts`, `lib/karibu/system-prompt.ts`) each had their own copy of the URL — the bot was handing out the full group while its own guardrail says to only use real community URLs.

`npx tsc --noEmit` and `npm run build` both clean.

## Side notes, your call

**a) Stale member-count fallbacks.** `src/app/api/stats/route.ts` and the hero fallbacks in `HeroPro.tsx` / `HeroTerminal.tsx` / `about/page.tsx` hardcode `whatsappMembers: 96` and `120`. Those assume a single group; the real figure is now split across two. Not touched here since it needs a number only you two can confirm.

**b) WhatsApp Community.** A Community holds multiple groups under one invite link and routes new joiners automatically. Doing that would stop this churn recurring when group two fills — which it will. Ops change, not a code one.

Separately, the four "Africa's first/only" overclaims left over from the pre-hackathon polish pass (`JoinSwitcher.tsx`, `signup/page.tsx`, `HeroTerminal.tsx`, `ConsoleWelcome.tsx`) are still open and still yours to call. Deliberately not bundled here — this PR is a one-line link fix and mixing copy decisions into it would muddy the review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
