### PR TITLE
Post-hackathon hardening: privacy, stale event state, accessibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,25 +8,52 @@ Kenya's independent, volunteer-run Claude developer community. Live at **claudek
 | Framework | Next.js 16, App Router, TypeScript strict |
 | Styling | Tailwind CSS v4 (`@theme` blocks) + CSS variables |
 | Motion | Framer Motion |
-| Database | PostgreSQL via Prisma 7 (17 models) |
+| Database | PostgreSQL via Prisma 7 (24 models) |
 | Auth | NextAuth v5 (credentials) |
 | Storage | Supabase Storage (uploads, avatars) |
 | Rate Limiting | Upstash Redis |
 | Email | Resend |
 | Icons | Lucide React |
-| Fonts | JetBrains Mono (headings/code) + IBM Plex Sans (body) via `next/font` |
+| Fonts | Fraunces (display) + Inter (body) on the public site; Newsreader (serif) and JetBrains Mono / IBM Plex Sans also loaded — all via `next/font` |
 | Deploy | Vercel |
 
-## Design System: Terminal Noir
+## Design systems — two, and they are scoped
 
-Colors defined as CSS custom properties in `src/app/globals.css`, registered as Tailwind theme tokens in the `@theme inline` block.
+The public site and the staff surfaces do not share a look. Getting this
+backwards is the most common way to write code that looks wrong in review.
+
+### Karibu (warm light) — the public site
+
+Every public page. Components live in `src/components/karibu/`. Tokens are CSS
+custom properties in `src/app/globals.css`, registered in the `@theme inline`
+block as Tailwind utilities (`bg-paper`, `text-ink`, `border-sand`, …).
+
+- **Surfaces:** `--paper` (#F4EEE3), `--paper-card` (#FBF7F0), `--paper-alt`
+- **Text:** `--ink` (#23201B), `--ink-soft`, `--ink-muted`, `--ink-faint`
+- **Accent:** `--clay` (#A84E2D), `--clay-dark`, `--clay-light`
+- **Lines:** `--sand` (#E4DAC8), `--sand-2`
+
+**Adaptive dark mode** re-defines the paper/ink/clay/sand tokens (system
+preference, overridable by an explicit `data-theme` on `<html>`). Anything that
+must stay dark in *both* themes uses the non-inverting `--panel-dark` /
+`--on-panel-dark` / `--on-panel-dark-muted` trio instead of `--ink` — the
+footer and the feature cards do. Reaching for `bg-ink` to build a dark panel is
+the bug that made the footer 1.59:1.
+
+### Terminal Noir (dark) — admin and Impact Lab only
+
+`/admin/*`, `/dashboard/*`, `/judge`, `/timer`. Not used on any public
+marketing page.
 
 - **Backgrounds:** `--bg-primary` (#0a0a0a), `--bg-secondary`, `--bg-card`, `--bg-elevated`
 - **Green (primary):** `--green-primary` (#00ff41), `--green-dim`, `--green-muted`
 - **Accents:** `--amber` (#ffb000), `--red` (#ff3333), `--cyan` (#00d4ff)
 - **Text:** `--text-primary`, `--text-secondary`, `--text-dim`
 
-**Persona system** switches between Dev mode (terminal aesthetic) and Pro mode (glassmorphism + Anthropic brand). Toggle lives in the navbar. Context in `src/components/persona/`.
+`<html>` carries `persona-pro` globally (`layout.tsx`), which sets
+`h1/h2/h3` to `--font-display` (Fraunces). That rule outranks the
+`font-newsreader` utility, so Newsreader on a heading is a no-op — a known
+wart, see Known Issues.
 
 ## Architecture
 
@@ -152,3 +179,15 @@ npm run db:seed          # Seed database
 - `TerminalApplication.tsx` is 1,356 lines — needs refactoring into sub-components
 - Team avatars reference `/images/team/*.jpg` — files may not exist
 - CommandPalette FAQ links may point to wrong routes
+- **Dead font utility:** `.persona-pro h1,h2,h3` (specificity 0,1,1) beats the
+  `font-newsreader` utility (0,1,0), so ~66 heading usages of `font-newsreader`
+  render Fraunces. The ~28 non-heading usages *do* apply — do not blanket-delete
+  the class. Either drop `persona-pro` from Karibu routes or re-layer the rule.
+- **Five font families load globally** in `layout.tsx` while the public site
+  paints mainly Fraunces + Inter. Newsreader alone pulls 5 weights plus italics.
+- **Metadata gaps:** 11 public pages export no `metadata` and fall back to the
+  root title; `/code-of-conduct` and `/resources/links` have no
+  `alternates.canonical` so they self-report as the homepage.
+- **Prisma client goes stale after a GitHub Desktop pull** (no postinstall
+  hook), producing dozens of phantom "property does not exist on PrismaClient"
+  type errors. `npx prisma generate` fixes it — do not chase them as real.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "verify:submissions": "tsx scripts/verify-submissions.ts",
     "verify:rematch": "tsx scripts/verify-rematch.ts",
     "verify:judging": "tsx scripts/verify-judging.ts",
-    "import:manual-teams": "tsx scripts/import-manual-teams.ts"
+    "import:manual-teams": "tsx scripts/import-manual-teams.ts",
+    "purge:closed-cohorts": "tsx scripts/purge-closed-cohorts.ts"
   },
   "prisma": {
     "seed": "tsx prisma/seed.ts"

--- a/scripts/purge-closed-cohorts.ts
+++ b/scripts/purge-closed-cohorts.ts
@@ -1,0 +1,150 @@
+/**
+ * Purge the two most sensitive fields from Impact Lab participants once their
+ * cohort is closed.
+ *
+ * `blockedTeammates` is a list of people someone did not want to work with. The
+ * schema comment already says it is never shown publicly, and once matching is
+ * done it has no remaining purpose — but it is still sitting in the database,
+ * still readable by anyone with admin export rights, and still the single most
+ * damaging row on the site if it ever leaked. `phone` is the same story with a
+ * lower ceiling: needed to reach people during the event, needed by nobody
+ * after it.
+ *
+ * The rows themselves stay. Name, email, skills, and team assignment are the
+ * historical record of who built what, and deleting participants would orphan
+ * the match runs and submissions that reference them. Only the two fields are
+ * cleared.
+ *
+ * Cleared, not hashed. A hash would only be worth keeping if something still
+ * needed to compare these values, and nothing does — a hashed phone number is
+ * just a slower way to retain a phone number.
+ *
+ * Irreversible. There is no undo and no backup of the cleared values, which is
+ * exactly why it is dry-run by default and prints every row it would touch:
+ *
+ *   npm run purge:closed-cohorts              # report only, writes nothing
+ *   npm run purge:closed-cohorts -- --apply   # actually clears
+ *   npm run purge:closed-cohorts -- --cohort impact-lab-2026-07
+ *
+ * The active cohort (IMPACT_LAB_ACTIVE_COHORT) is skipped unless you name it
+ * explicitly with --cohort, so running this mid-event cannot wipe the phone
+ * numbers the organisers are relying on to reach people in the room.
+ */
+
+import { PrismaClient } from "../src/generated/prisma/client"
+import { PrismaPg } from "@prisma/adapter-pg"
+import { ACTIVE_COHORT } from "../src/lib/impact-lab/constants"
+
+const apply = process.argv.includes("--apply")
+const cohortFlagIndex = process.argv.indexOf("--cohort")
+const cohortFilter =
+  cohortFlagIndex !== -1 ? process.argv[cohortFlagIndex + 1] ?? null : null
+
+/** Mask an email for the report — enough to identify a row, not enough to be a leak. */
+function maskEmail(email: string): string {
+  const [user, domain] = email.split("@")
+  if (!domain) return "***"
+  const head = user.slice(0, 2)
+  return `${head}${"*".repeat(Math.max(user.length - 2, 1))}@${domain}`
+}
+
+async function main() {
+  // Same driver-adapter construction the app uses (src/lib/prisma.ts) — the
+  // generated client has no default constructor in this setup.
+  const connectionString = process.env.DATABASE_URL
+  if (!connectionString) {
+    console.error(
+      "DATABASE_URL is not set. Run with the target database URL, e.g.\n" +
+        '  DATABASE_URL="postgres://..." npm run purge:closed-cohorts',
+    )
+    process.exitCode = 1
+    return
+  }
+  const prisma = new PrismaClient({
+    adapter: new PrismaPg({ connectionString, max: 5 }),
+  })
+
+  try {
+    await run(prisma)
+  } finally {
+    await prisma.$disconnect()
+  }
+}
+
+async function run(prisma: PrismaClient) {
+  const cohortRows = await prisma.impactLabParticipant.groupBy({
+    by: ["cohort"],
+    _count: { _all: true },
+  })
+
+  const candidates = cohortRows
+    .map((c) => c.cohort)
+    .filter((cohort) => {
+      if (cohortFilter) return cohort === cohortFilter
+      return cohort !== ACTIVE_COHORT
+    })
+    .sort()
+
+  if (ACTIVE_COHORT && !cohortFilter) {
+    console.log(`Active cohort (skipped): ${ACTIVE_COHORT}`)
+  } else if (!ACTIVE_COHORT) {
+    console.log("No active cohort set (IMPACT_LAB_ACTIVE_COHORT unset).")
+  }
+
+  if (candidates.length === 0) {
+    console.log("No closed cohorts with participants. Nothing to do.")
+    return
+  }
+
+  let totalToClear = 0
+
+  for (const cohort of candidates) {
+    // Only rows that still hold something worth clearing. A row whose phone is
+    // already null and whose blockedTeammates is already empty is left alone so
+    // the report reflects real work rather than padding the count.
+    const rows = await prisma.impactLabParticipant.findMany({
+      where: {
+        cohort,
+        OR: [{ phone: { not: null } }, { blockedTeammates: { isEmpty: false } }],
+      },
+      select: {
+        id: true,
+        email: true,
+        phone: true,
+        blockedTeammates: true,
+      },
+      orderBy: { email: "asc" },
+    })
+
+    console.log(`\n── ${cohort} — ${rows.length} row(s) to clear`)
+    for (const r of rows) {
+      const bits: string[] = []
+      if (r.phone) bits.push("phone")
+      if (r.blockedTeammates.length) {
+        bits.push(`blockedTeammates[${r.blockedTeammates.length}]`)
+      }
+      console.log(`   ${maskEmail(r.email)}  →  clearing ${bits.join(" + ")}`)
+    }
+    totalToClear += rows.length
+
+    if (apply && rows.length > 0) {
+      const result = await prisma.impactLabParticipant.updateMany({
+        where: { id: { in: rows.map((r) => r.id) } },
+        data: { phone: null, blockedTeammates: [] },
+      })
+      console.log(`   ✔ cleared ${result.count} row(s)`)
+    }
+  }
+
+  console.log(
+    `\n${apply ? "Cleared" : "Would clear"} ${totalToClear} row(s) across ${candidates.length} closed cohort(s).`,
+  )
+  if (!apply && totalToClear > 0) {
+    console.log("Dry run — nothing was written. Re-run with --apply to commit.")
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/src/app/api/impact-lab/check-in/route.ts
+++ b/src/app/api/impact-lab/check-in/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
 import { checkMemberAccess } from "@/lib/impact-lab/member"
 
 /**
@@ -14,6 +15,9 @@ import { checkMemberAccess } from "@/lib/impact-lab/member"
 export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
+
+  const closed = guardClosedCohort(DEFAULT_COHORT)
+  if (closed) return closed
 
   const rl = await rateLimit(request, RateLimits.FORM)
   if (!rl.success) {

--- a/src/app/api/impact-lab/profile/route.ts
+++ b/src/app/api/impact-lab/profile/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
 import {
   checkMemberAccess,
   memberProfileSchema,
@@ -36,6 +37,9 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
+
+  const closed = guardClosedCohort(DEFAULT_COHORT)
+  if (closed) return closed
 
   const rl = await rateLimit(request, RateLimits.FORM)
   if (!rl.success) {

--- a/src/app/api/impact-lab/submission/route.ts
+++ b/src/app/api/impact-lab/submission/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   submissionInputSchema,
@@ -108,6 +109,9 @@ export async function GET() {
 export async function PUT(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
+
+  const closed = guardClosedCohort(DEFAULT_COHORT)
+  if (closed) return closed
 
   // FORM (10/min) rather than a daily cap: a submission is edited repeatedly
   // through the night by different teammates, not filed once.

--- a/src/app/api/impact-lab/team/leader/route.ts
+++ b/src/app/api/impact-lab/team/leader/route.ts
@@ -3,6 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { Team } from "@/lib/matching"
 
@@ -22,6 +23,9 @@ import type { Team } from "@/lib/matching"
 export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
+
+  const closed = guardClosedCohort(DEFAULT_COHORT)
+  if (closed) return closed
 
   const rl = await rateLimit(request, RateLimits.FORM)
   if (!rl.success) {

--- a/src/app/api/impact-lab/team/roster/route.ts
+++ b/src/app/api/impact-lab/team/roster/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { Team } from "@/lib/matching"
 
@@ -96,6 +97,9 @@ export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 
+  const closed = guardClosedCohort(DEFAULT_COHORT)
+  if (closed) return closed
+
   const rl = await rateLimit(request, RateLimits.FORM)
   if (!rl.success) {
     return NextResponse.json(
@@ -155,6 +159,9 @@ export async function POST(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
+
+  const closed = guardClosedCohort(DEFAULT_COHORT)
+  if (closed) return closed
 
   const rl = await rateLimit(request, RateLimits.FORM)
   if (!rl.success) {

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -48,7 +48,13 @@ type Phase =
  * spec states from GET /api/impact-lab/profile and GET /api/impact-lab/team:
  * not-registered, profile form, waiting (profile saved, teams pending), reveal.
  */
-export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
+export function ImpactLabClient({
+  sessionEmail,
+  cohortActive,
+}: {
+  sessionEmail: string;
+  cohortActive: boolean;
+}) {
   const [phase, setPhase] = useState<Phase>("loading");
   const [profile, setProfile] = useState<MemberProfile | null>(null);
   const [team, setTeam] = useState<TeamRevealView | null>(null);
@@ -120,7 +126,47 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
   }
 
   if (phase === "revealed" && team) {
-    return <TeamReveal team={team} />;
+    return <TeamReveal team={team} cohortActive={cohortActive} />;
+  }
+
+  // ─── Closed cohort ───────────────────────────────────────────────────────
+  // Past this point every branch invites an action — complete your profile,
+  // wait for teams, contact an organiser before the event. None of that is
+  // true once the cohort closes, so a participant without a team sees the
+  // record and everyone else is told plainly that nothing is running.
+  if (!cohortActive) {
+    return (
+      <section
+        className="rounded-lg border border-border-default bg-bg-secondary p-6"
+        aria-label="Impact Lab archive"
+      >
+        <div className="flex flex-wrap items-start gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-border-default bg-bg-card">
+            <Clock className="h-5 w-5 text-text-dim" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="font-mono text-base font-bold text-text-primary">
+              Impact Lab has wrapped
+            </h2>
+            <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+              {profile
+                ? "Thanks for taking part. Your matching profile is kept as part of the event record and is no longer editable."
+                : "There's no Impact Lab running right now. When the next one opens, this is where your matching profile and team will appear."}
+            </p>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <a
+                href={SOCIAL_LINKS.whatsapp}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 font-mono text-xs font-semibold text-green-primary transition-colors hover:bg-green-primary/20"
+              >
+                Hear about the next one
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+    );
   }
 
   if (phase === "not-registered") {

--- a/src/app/dashboard/impact-lab/TeamReveal.tsx
+++ b/src/app/dashboard/impact-lab/TeamReveal.tsx
@@ -22,7 +22,13 @@ const TEAMMATE_POLL_INTERVAL_MS = 30_000;
  * This is the hero moment of the hackathon dashboard, so it carries a
  * one-time entrance animation (skipped entirely under prefers-reduced-motion).
  */
-export function TeamReveal({ team }: { team: TeamRevealView }) {
+export function TeamReveal({
+  team,
+  cohortActive = true,
+}: {
+  team: TeamRevealView;
+  cohortActive?: boolean;
+}) {
   const prefersReducedMotion = useReducedMotion();
   const router = useRouter();
 
@@ -49,6 +55,10 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
   );
 
   useEffect(() => {
+    // Nobody is arriving at a finished event, so polling for teammate
+    // check-ins would be a background request every 30s, forever, for a
+    // value that can no longer change.
+    if (!cohortActive) return;
     const interval = setInterval(() => {
       fetch("/api/impact-lab/team")
         .then((res) => (res.ok ? (res.json() as Promise<TeamResponse>) : null))
@@ -68,7 +78,7 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
         .catch(() => {});
     }, TEAMMATE_POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, []);
+  }, [cohortActive]);
 
   async function handleCheckIn() {
     setCheckingIn(true);
@@ -136,11 +146,21 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
               {team.teamName}
             </h2>
             <p className="mt-1 text-sm text-text-secondary">
-              {team.members.length} members &middot; see you at the hackathon.
+              {team.members.length} members
+              {cohortActive
+                ? " · see you at the hackathon."
+                : " · this is your record from the event."}
             </p>
           </div>
           <div className="shrink-0">
-            {checkedIn ? (
+            {!cohortActive ? (
+              checkedIn ? (
+                <span className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-3 py-1.5 font-mono text-xs font-semibold text-text-dim">
+                  <UserCheck className="h-3.5 w-3.5" />
+                  Attended
+                </span>
+              ) : null
+            ) : checkedIn ? (
               <span className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-3 py-1.5 font-mono text-xs font-semibold text-green-primary">
                 <UserCheck className="h-3.5 w-3.5" />
                 You&apos;re checked in
@@ -301,17 +321,24 @@ export function TeamReveal({ team }: { team: TeamRevealView }) {
         </ol>
       </motion.section>
 
-      <TeamRoster
-        members={team.members}
-        onChanged={() => {
-          // The roster lives in the server-rendered payload, so a change is
-          // only visible after a refetch — reload rather than patch local
-          // state, so everyone sees the same roster the server now holds.
-          router.refresh();
-        }}
-      />
+      {/* Roster edits and project submission are event-time actions. After the
+          cohort closes the team is a record, not a thing you can still change,
+          so both affordances go rather than sitting there failing on submit. */}
+      {cohortActive && (
+        <>
+          <TeamRoster
+            members={team.members}
+            onChanged={() => {
+              // The roster lives in the server-rendered payload, so a change is
+              // only visible after a refetch — reload rather than patch local
+              // state, so everyone sees the same roster the server now holds.
+              router.refresh();
+            }}
+          />
 
-      <SubmitProject />
+          <SubmitProject />
+        </>
+      )}
     </motion.div>
   );
 }

--- a/src/app/dashboard/impact-lab/page.tsx
+++ b/src/app/dashboard/impact-lab/page.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification";
+import { DEFAULT_COHORT, isCohortActive } from "@/lib/impact-lab/constants";
 import { VerifyEmailBanner } from "../VerifyEmailBanner";
 import { ImpactLabClient } from "./ImpactLabClient";
 
@@ -26,6 +27,8 @@ export default async function ImpactLabPage() {
   });
   if (!user) redirect("/login");
 
+  const cohortActive = isCohortActive(DEFAULT_COHORT);
+
   return (
     <main className="min-h-screen bg-bg-primary pt-24 pb-24">
       <div className="mx-auto max-w-3xl px-4">
@@ -44,7 +47,9 @@ export default async function ImpactLabPage() {
             Impact Lab Hackathon
           </h1>
           <p className="mt-2 font-mono text-sm text-text-dim">
-            Complete your matching profile, then check back here for your team.
+            {cohortActive
+              ? "Complete your matching profile, then check back here for your team."
+              : "The event has wrapped — this is your record of it."}
           </p>
         </header>
 
@@ -53,7 +58,11 @@ export default async function ImpactLabPage() {
             out every account created before the flag flipped, with no way to
             comply — the participant is told to check an inbox nothing was sent
             to. */}
-        {REQUIRE_EMAIL_VERIFICATION && !user.emailVerified ? (
+        {/* The verification gate only exists to protect a live matching
+            profile. With the cohort closed there is nothing left to gate, and
+            asking someone to verify an email to view a finished event's record
+            is a dead end. */}
+        {cohortActive && REQUIRE_EMAIL_VERIFICATION && !user.emailVerified ? (
           <>
             <VerifyEmailBanner />
             <p className="font-mono text-sm text-text-secondary">
@@ -62,7 +71,10 @@ export default async function ImpactLabPage() {
             </p>
           </>
         ) : (
-          <ImpactLabClient sessionEmail={session.user.email} />
+          <ImpactLabClient
+            sessionEmail={session.user.email}
+            cohortActive={cohortActive}
+          />
         )}
       </div>
     </main>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification";
 import { getUpcomingEvents } from "@/lib/data";
 import { SOCIAL_LINKS } from "@/lib/constants";
-import { DEFAULT_COHORT } from "@/lib/impact-lab/constants";
+import { DEFAULT_COHORT, isCohortActive } from "@/lib/impact-lab/constants";
 import { extractFrozenTeams } from "@/lib/impact-lab/member";
 import { Calendar, MessageSquare, BookOpen, Sparkles, Code2, FlaskConical } from "lucide-react";
 import { SignOutButton } from "./SignOutButton";
@@ -84,11 +84,25 @@ export default async function DashboardPage() {
   const nextEvent = upcomingEvents[0];
 
   // Impact Lab hackathon status — mirrors the states on /dashboard/impact-lab.
-  let impactLabStatus: ImpactLabStatus = "verify";
+  // null hides the card entirely: with the cohort closed, someone who never
+  // took part has no reason to see a hackathon card at all, and every live
+  // status ("complete your profile", "teams drop Saturday") would be a lie.
+  const cohortActive = isCohortActive(DEFAULT_COHORT);
+  let impactLabStatus: ImpactLabStatus | null = cohortActive ? "verify" : null;
   // Same flag the API and the Impact Lab page use: with verification off we
   // send no verification mail, so gating on emailVerified alone would strand
   // every pre-flag account on the "verify" card permanently.
-  if (!REQUIRE_EMAIL_VERIFICATION || user.emailVerified) {
+  if (!cohortActive) {
+    // Closed cohort: the card is a link to the record, and only for people who
+    // actually have one.
+    const participant = await prisma.impactLabParticipant.findUnique({
+      where: {
+        cohort_email: { cohort: DEFAULT_COHORT, email: user.email.toLowerCase() },
+      },
+      select: { id: true },
+    });
+    impactLabStatus = participant ? "archived" : null;
+  } else if (!REQUIRE_EMAIL_VERIFICATION || user.emailVerified) {
     // No .catch(() => null) here: swallowing a DB error would show a
     // registered participant the affirmative "Registration not found" copy.
     // A down DB surfaces via the page error boundary, same as the user query.
@@ -153,9 +167,11 @@ export default async function DashboardPage() {
 
         {REQUIRE_EMAIL_VERIFICATION && !user.emailVerified && <VerifyEmailBanner />}
 
-        <section className="mb-8" aria-label="Impact Lab hackathon">
-          <ImpactLabCard status={impactLabStatus} />
-        </section>
+        {impactLabStatus && (
+          <section className="mb-8" aria-label="Impact Lab hackathon">
+            <ImpactLabCard status={impactLabStatus} />
+          </section>
+        )}
 
         <section className="mb-8" aria-label="Profile">
           <ProfileEditor
@@ -328,7 +344,8 @@ type ImpactLabStatus =
   | "profile"
   | "waiting"
   | "revealed"
-  | "unassigned";
+  | "unassigned"
+  | "archived";
 
 const IMPACT_LAB_COPY: Record<
   ImpactLabStatus,
@@ -360,10 +377,40 @@ const IMPACT_LAB_COPY: Record<
     title: "Teams are finalized",
     description: "You weren't placed on a team — contact the organizers.",
   },
+  archived: {
+    title: "Your Impact Lab record",
+    description: "Your team and what you built. Kept as a record of the event.",
+  },
 };
 
 function ImpactLabCard({ status }: { status: ImpactLabStatus }) {
   const copy = IMPACT_LAB_COPY[status];
+
+  // Archived is a record, not a task. Amber reads as "you still need to do
+  // something", which is exactly the wrong signal once the event is over.
+  if (status === "archived") {
+    return (
+      <Link
+        href="/dashboard/impact-lab"
+        className="group flex flex-wrap items-start gap-4 rounded-lg border border-border-default bg-bg-secondary p-6 transition-all hover:border-text-dim"
+      >
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded border border-border-default bg-bg-card">
+          <FlaskConical className="h-6 w-6 text-text-dim" />
+        </div>
+        <div className="flex-1">
+          <p className="mb-1 font-mono text-[11px] uppercase tracking-wider text-text-dim">
+            Impact Lab · archived
+          </p>
+          <h2 className="font-mono text-base font-bold text-text-primary transition-colors group-hover:text-text-secondary">
+            {copy.title}
+          </h2>
+          <p className="mt-1 text-sm text-text-secondary">{copy.description}</p>
+        </div>
+        <span className="font-mono text-sm text-text-dim">View &rarr;</span>
+      </Link>
+    );
+  }
+
   const green = status === "revealed" || status === "waiting";
   const cardClass = green
     ? "group flex flex-wrap items-start gap-4 rounded-lg border border-green-primary/20 bg-bg-secondary p-6 transition-all hover:border-green-primary/40"

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -651,6 +651,49 @@ body::before {
   }
 }
 
+/* ─── Above-the-fold entrance (LCP-safe) ──────────────────────────────────
+ * [data-reveal] above is correct for below-fold content but wrong for the
+ * hero: it holds the element at opacity 0 until a JS observer marks it
+ * in-view, so the largest text on the page could not paint until Framer
+ * Motion had hydrated — an 8.5s LCP on throttled mobile, 95% of it render
+ * delay.
+ *
+ * This runs the same entrance as a pure CSS animation instead. It starts at
+ * first paint rather than at hydration, so the heading is on screen in about
+ * a second regardless of how long the bundle takes. Use it ONLY above the
+ * fold; below-fold content should keep [data-reveal] so it animates on scroll
+ * rather than all at once during load.
+ *
+ * Degrade path matches [data-reveal]: visible by default, animation only
+ * under `.js`, nothing at all under reduced-motion. */
+[data-hero-rise] {
+  opacity: 1;
+}
+.js [data-hero-rise] {
+  animation: hero-rise 0.8s var(--ease-entrance) both;
+  animation-delay: calc(min(var(--i, 0), 4) * 110ms);
+  will-change: opacity, transform;
+}
+
+@keyframes hero-rise {
+  from {
+    opacity: 0;
+    transform: translateY(26px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .js [data-hero-rise] {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* Scroll-drawn progress line (degrade-safe): the parent is the static track;
  * this fill scales from the left on first intersect (same shared observer as
  * [data-reveal]). No JS → full width. Reduced-motion → instant full. */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,12 +48,23 @@
   --ink: #23201B;
   --ink-soft: #5C5349;
   --ink-muted: #6A6155;
-  --ink-faint: #8A7F6E;
+  /* #8A7F6E measured 3.40:1 on --paper — it failed AA in light mode too, not
+   * only in dark. Darkened to 4.58:1. */
+  --ink-faint: #756a5c;
   --clay: #A84E2D;
   --clay-dark: #8F4023;
   --clay-light: #E6906F;
   --sand: #E4DAC8;
   --sand-2: #DDD3C2;
+
+  /* Intentional dark panels (footer, feature cards). Deliberately NOT part of
+   * the light/dark token flip below: these surfaces are meant to read as a
+   * dark slab against the page in both themes. Using --ink for them meant
+   * they inverted to near-white in dark mode while the text sitting on them
+   * stayed light — the footer measured 1.59:1. */
+  --panel-dark: #23201B;
+  --on-panel-dark: #E9E0D2;
+  --on-panel-dark-muted: #B4A997;
   --font-newsreader-stack: var(--font-newsreader), ui-serif, Georgia, serif;
   --font-inter-stack: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
 
@@ -111,6 +122,9 @@
   --color-clay-light: var(--clay-light);
   --color-sand: var(--sand);
   --color-sand-2: var(--sand-2);
+  --color-panel-dark: var(--panel-dark);
+  --color-on-panel-dark: var(--on-panel-dark);
+  --color-on-panel-dark-muted: var(--on-panel-dark-muted);
   --font-newsreader: var(--font-newsreader-stack);
   --font-inter: var(--font-inter-stack);
 }
@@ -802,6 +816,9 @@ body::before {
     --ink: #F4EEE3;
     --ink-soft: #C7BEB0;
     --ink-muted: #9a9082;
+    /* Was missing from this block entirely, so it kept its light-mode value
+     * while the backgrounds around it flipped. 4.91:1 on --paper. */
+    --ink-faint: #8f8574;
     --clay: #d2704a;
     --clay-dark: #A84E2D;
     --clay-light: #E6906F;

--- a/src/app/timer/page.tsx
+++ b/src/app/timer/page.tsx
@@ -7,10 +7,11 @@ import { TimerCountdown } from "./TimerCountdown";
  * Deliberately unlinked from the navigation and excluded from search: this is a
  * room display for one night, not part of the site's information architecture.
  *
- * The deadline defaults to 3:00 PM East Africa Time today and can be overridden
- * per-load with `?at=` (an ISO string, or `HH:MM` for today), so a slipped
- * schedule is a URL change rather than a deploy — which is the difference
- * between fixing the clock in ten seconds and fixing it in ten minutes.
+ * The deadline comes entirely from `?at=` (an ISO string, or `HH:MM` for
+ * today), so a slipped schedule is a URL change rather than a deploy — the
+ * difference between fixing the clock in ten seconds and fixing it in ten
+ * minutes. With no `?at=` the page says there is no session rather than
+ * inventing one.
  */
 export const metadata: Metadata = {
   title: "Time remaining | Impact Lab",
@@ -20,27 +21,31 @@ export const metadata: Metadata = {
 
 /** East Africa Time is UTC+3 year-round — no DST to account for. */
 const EAT_OFFSET = "+03:00";
-const DEFAULT_CLOSE = "15:00";
 
 /**
- * Resolve the deadline to an offset-bearing ISO string. Anything unparseable
- * falls back to the default rather than rendering an invalid clock.
+ * Resolve the deadline to an offset-bearing ISO string, or null when the
+ * caller gave us nothing usable.
+ *
+ * There is deliberately no default. A default of "3pm today" meant this page
+ * rendered a live, authoritative-looking countdown every day forever, counting
+ * down to a time that stopped meaning anything the night the event ended.
+ * A room display with no session to display should say so.
  */
-function resolveDeadline(at: string | undefined): string {
+function resolveDeadline(at: string | undefined): string | null {
+  if (!at) return null;
+
   const today = new Date().toLocaleDateString("en-CA", {
     timeZone: "Africa/Nairobi",
   });
 
-  if (at) {
-    const hhmm = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(at.trim());
-    if (hhmm) {
-      const hh = hhmm[1].padStart(2, "0");
-      return `${today}T${hh}:${hhmm[2]}:00${EAT_OFFSET}`;
-    }
-    if (!Number.isNaN(new Date(at).getTime())) return at;
+  const hhmm = /^([01]?\d|2[0-3]):([0-5]\d)$/.exec(at.trim());
+  if (hhmm) {
+    const hh = hhmm[1].padStart(2, "0");
+    return `${today}T${hh}:${hhmm[2]}:00${EAT_OFFSET}`;
   }
+  if (!Number.isNaN(new Date(at).getTime())) return at;
 
-  return `${today}T${DEFAULT_CLOSE}:00${EAT_OFFSET}`;
+  return null;
 }
 
 export default async function TimerPage({
@@ -54,16 +59,30 @@ export default async function TimerPage({
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-bg-primary px-6 py-16">
       <div className="mb-10 flex items-center gap-3">
-        <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-green-primary" />
+        {deadlineIso && (
+          <span className="h-2.5 w-2.5 animate-pulse rounded-full bg-green-primary" />
+        )}
         <span className="font-mono text-xs uppercase tracking-[0.3em] text-text-dim sm:text-sm">
           Impact Lab · AI Mashinani
         </span>
       </div>
 
-      <TimerCountdown
-        deadlineIso={deadlineIso}
-        label={label?.slice(0, 60) || "Time left to submit"}
-      />
+      {deadlineIso ? (
+        <TimerCountdown
+          deadlineIso={deadlineIso}
+          label={label?.slice(0, 60) || "Time left to submit"}
+        />
+      ) : (
+        <div className="text-center">
+          <p className="font-mono text-2xl font-bold text-text-primary sm:text-4xl">
+            No active session
+          </p>
+          <p className="mx-auto mt-4 max-w-md font-mono text-sm leading-relaxed text-text-dim">
+            Set a deadline to start the clock — <code>?at=15:00</code> for a
+            time today, or <code>?at=</code> a full ISO timestamp.
+          </p>
+        </div>
+      )}
 
       <footer className="mt-16 font-mono text-[11px] uppercase tracking-[0.3em] text-text-dim">
         Claude Community Kenya

--- a/src/components/gallery/PhotoLightbox.tsx
+++ b/src/components/gallery/PhotoLightbox.tsx
@@ -22,6 +22,7 @@ const EASE_OUT = [0.16, 1, 0.3, 1] as const;
  *  - Esc closes
  *  - ← / → navigate
  *  - Tab cycles inside the dialog (focus trap)
+ *  - focus returns to the tile that opened the dialog on close
  *
  * Touch: swipe horizontally on the image to navigate.
  */
@@ -33,6 +34,11 @@ export function PhotoLightbox({
 }: PhotoLightboxProps) {
   const reduce = useReducedMotion();
   const closeBtnRef = useRef<HTMLButtonElement>(null);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  // The element that had focus when the dialog opened — almost always the grid
+  // tile that was clicked. Restoring to it on close is what keeps keyboard
+  // users from being dumped back at the top of the document.
+  const previouslyFocused = useRef<HTMLElement | null>(null);
   const touchStartX = useRef<number | null>(null);
   const open = currentIndex !== null;
   const photo = open ? photos[currentIndex] : null;
@@ -49,24 +55,61 @@ export function PhotoLightbox({
 
   useEffect(() => {
     if (!open) return;
+
+    previouslyFocused.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.preventDefault();
         onClose();
-      } else if (e.key === "ArrowRight") {
+        return;
+      }
+      if (e.key === "ArrowRight") {
         e.preventDefault();
         next();
-      } else if (e.key === "ArrowLeft") {
+        return;
+      }
+      if (e.key === "ArrowLeft") {
         e.preventDefault();
         prev();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      // Focus trap. Without this, Tab walks straight out of the dialog and
+      // into the page behind it — which is still rendered and still
+      // scrollable-to — leaving a keyboard or screen-reader user navigating a
+      // page they cannot see, with no obvious way back.
+      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusables || focusables.length === 0) return;
+
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+
+      if (e.shiftKey && (active === first || !dialogRef.current?.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
       }
     }
+
     window.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     closeBtnRef.current?.focus();
+
     return () => {
       window.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
+      // Guard the node still being in the document: a photo can be removed, or
+      // the grid re-rendered under a filter change, while the dialog is open.
+      const target = previouslyFocused.current;
+      if (target && document.contains(target)) target.focus();
     };
   }, [open, next, prev, onClose]);
 
@@ -88,6 +131,7 @@ export function PhotoLightbox({
       {open && photo && (
         <motion.div
           key="lightbox"
+          ref={dialogRef}
           role="dialog"
           aria-modal="true"
           aria-label={photo.caption ?? "Photo viewer"}

--- a/src/components/karibu/KaribuAbout.tsx
+++ b/src/components/karibu/KaribuAbout.tsx
@@ -112,7 +112,7 @@ export function KaribuAbout({
       {/* Anthropic tie */}
       <section className={`${WRAP} py-8`} aria-label="Anthropic tie">
         <Reveal>
-          <div className="grid items-center gap-6 rounded-2xl bg-ink p-8 text-paper sm:grid-cols-[90px_1fr] sm:p-10">
+          <div className="grid items-center gap-6 rounded-2xl bg-panel-dark p-8 text-on-panel-dark sm:grid-cols-[90px_1fr] sm:p-10">
             <div className="flex h-[90px] w-[90px] items-center justify-center rounded-[14px] bg-paper-alt">
               <Image src="/images/cck-logo.webp" alt="CCK" width={70} height={70} className="h-[70px] w-[70px] rounded-full" />
             </div>
@@ -120,7 +120,7 @@ export function KaribuAbout({
               <div className="mb-2.5 font-inter text-xs font-semibold uppercase tracking-[0.18em] text-clay-light">
                 The Anthropic connection
               </div>
-              <p className="max-w-[660px] font-newsreader text-[21px] leading-[1.4] text-paper sm:text-[23px]">
+              <p className="max-w-[660px] font-newsreader text-[21px] leading-[1.4] text-on-panel-dark sm:text-[23px]">
                 CCK is an independent, volunteer-run community, led by Kenya&apos;s{" "}
                 <span className="italic text-clay-light">Claude Community Ambassador</span> and
                 supported through Anthropic&apos;s Claude Community Ambassadors program —

--- a/src/components/karibu/KaribuFaq.tsx
+++ b/src/components/karibu/KaribuFaq.tsx
@@ -224,8 +224,8 @@ export function KaribuFaq({ faqs, categories }: { faqs: FAQ[]; categories: FaqCa
       {/* Still have questions? */}
       <section className={`${WRAP} py-14`} aria-label="Still have questions">
         <Reveal>
-          <div className="rounded-[18px] bg-ink p-8 text-center text-paper sm:p-12">
-            <h2 className="mb-3 font-newsreader text-[30px] text-paper">Still have questions?</h2>
+          <div className="rounded-[18px] bg-panel-dark p-8 text-center text-on-panel-dark sm:p-12">
+            <h2 className="mb-3 font-newsreader text-[30px] text-on-panel-dark">Still have questions?</h2>
             <p className="mx-auto mb-8 max-w-lg font-inter text-[15px] leading-[1.6] text-[#A79E90]">
               Can&apos;t find what you&apos;re looking for? Reach out to us directly.
             </p>
@@ -240,7 +240,7 @@ export function KaribuFaq({ faqs, categories }: { faqs: FAQ[]; categories: FaqCa
               </a>
               <a
                 href={`mailto:${CONTACT.email}`}
-                className="inline-flex items-center gap-2 rounded-full border border-[#3B352D] px-6 py-3.5 font-inter text-[15px] font-semibold text-paper transition-colors hover:border-clay-light hover:text-clay-light"
+                className="inline-flex items-center gap-2 rounded-full border border-[#3B352D] px-6 py-3.5 font-inter text-[15px] font-semibold text-on-panel-dark transition-colors hover:border-clay-light hover:text-clay-light"
               >
                 Email us <span aria-hidden="true">→</span>
               </a>

--- a/src/components/karibu/KaribuFooter.tsx
+++ b/src/components/karibu/KaribuFooter.tsx
@@ -26,7 +26,7 @@ const COMMUNITY = [
 
 export function KaribuFooter() {
   return (
-    <footer className="bg-ink text-[#E9E0D2]">
+    <footer className="bg-panel-dark text-on-panel-dark">
       <div className="mx-auto grid max-w-[1180px] grid-cols-2 gap-8 px-6 pt-14 md:px-10 lg:grid-cols-[1.6fr_1fr_1fr_1fr]">
         {/* Brand */}
         <div className="col-span-2 lg:col-span-1">
@@ -38,7 +38,7 @@ export function KaribuFooter() {
               height={36}
               className="h-9 w-9 rounded-full"
             />
-            <span className="font-newsreader text-[19px] font-semibold text-paper">
+            <span className="font-newsreader text-[19px] font-semibold text-on-panel-dark">
               Claude Community Kenya
             </span>
           </div>
@@ -58,7 +58,7 @@ export function KaribuFooter() {
 
         <FooterColumn title="Explore">
           {EXPLORE.map((l) => (
-            <Link key={l.href} href={l.href} className="transition-colors hover:text-paper">
+            <Link key={l.href} href={l.href} className="transition-colors hover:text-on-panel-dark">
               {l.label}
             </Link>
           ))}
@@ -71,7 +71,7 @@ export function KaribuFooter() {
               href={l.href}
               target="_blank"
               rel="noopener noreferrer"
-              className="transition-colors hover:text-paper"
+              className="transition-colors hover:text-on-panel-dark"
             >
               {l.label}
             </a>
@@ -85,17 +85,17 @@ export function KaribuFooter() {
       </div>
 
       <div className="mx-auto max-w-[1180px] px-6 pb-9 pt-10 md:px-10">
-        <p className="mb-5 max-w-[780px] font-inter text-[12.5px] leading-relaxed text-ink-faint">
+        <p className="mb-5 max-w-[780px] font-inter text-[12.5px] leading-relaxed text-on-panel-dark-muted">
           Independently operated. Anthropic-supported via the Claude Community
           Ambassadors program (event funding + API credits). Views expressed
           here are community-held, not official Anthropic positions. &ldquo;Claude&rdquo;
           is a trademark of Anthropic PBC.
         </p>
         <div className="flex flex-wrap items-center justify-between gap-4 border-t border-[#3B352D] pt-6">
-          <div className="font-inter text-[13px] text-ink-faint">
+          <div className="font-inter text-[13px] text-on-panel-dark-muted">
             © 2026 Claude Community Kenya · A community, not a product.
           </div>
-          <div className="font-inter text-[13px] text-ink-faint">
+          <div className="font-inter text-[13px] text-on-panel-dark-muted">
             Built by the community, for the community.
           </div>
         </div>
@@ -113,7 +113,7 @@ function FooterColumn({
 }) {
   return (
     <div>
-      <div className="mb-3.5 font-inter text-xs font-bold uppercase tracking-[0.14em] text-ink-faint">
+      <div className="mb-3.5 font-inter text-xs font-bold uppercase tracking-[0.14em] text-on-panel-dark-muted">
         {title}
       </div>
       <div className="flex flex-col gap-2 font-inter text-[14.5px] leading-[2.1] text-[#C7BEB0]">

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -629,7 +629,7 @@ const JOIN_STEPS = [
 function HowToJoin() {
   return (
     <section id="join" className={`${WRAP} py-14`} aria-label="How to join">
-      <Reveal className="relative overflow-hidden rounded-2xl bg-ink p-9 text-paper sm:p-[54px]">
+      <Reveal className="relative overflow-hidden rounded-2xl bg-panel-dark p-9 text-on-panel-dark sm:p-[54px]">
         <div
           className="pointer-events-none absolute inset-0"
           style={{
@@ -664,7 +664,7 @@ function HowToJoin() {
                 href={SOCIAL_LINKS.discord}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 rounded-full border border-[#554E44] px-6 py-[15px] font-inter text-[15.5px] font-semibold text-paper transition-colors hover:border-paper"
+                className="inline-flex items-center gap-2 rounded-full border border-[#554E44] px-6 py-[15px] font-inter text-[15.5px] font-semibold text-on-panel-dark transition-colors hover:border-on-panel-dark"
               >
                 Join Discord
               </a>

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -48,6 +48,31 @@ const TYPE_LABEL: Record<Event["type"], string> = {
   hackathon: "Hackathon",
 };
 
+/**
+ * Today in Nairobi as YYYY-MM-DD — the same shape Event.date already uses, so
+ * the comparison is a plain string compare with no parsing or local-timezone
+ * drift. Pinning the zone on both server and client also keeps SSR and
+ * hydration in agreement for a visitor sitting in another timezone.
+ */
+function todayInNairobi(): string {
+  return new Date().toLocaleDateString("en-CA", { timeZone: "Africa/Nairobi" });
+}
+
+/**
+ * Call-to-action for an event card, derived from when the event is rather than
+ * what kind it is. Type was the wrong signal: it labelled every hackathon
+ * "Register" for as long as the card existed, including months after the
+ * hackathon had been run and judged.
+ */
+function eventCta(ev: Event): string {
+  if (ev.date && ev.date < todayInNairobi()) {
+    return ev.type === "hackathon" ? "See the recap" : "View";
+  }
+  return ev.type === "hackathon" || ev.status === "registration-open"
+    ? "Register"
+    : "RSVP";
+}
+
 export function KaribuHome({
   communityStats,
   upcomingEvents,
@@ -500,10 +525,7 @@ function EventsSection({ events }: { events: Event[] }) {
       <Reveal className={`grid gap-4 ${events.length >= 3 ? "md:grid-cols-3" : events.length === 2 ? "md:grid-cols-2" : ""}`}>
         {events.map((ev, i) => {
           const single = events.length === 1;
-          const cta =
-            ev.type === "hackathon" || ev.status === "registration-open"
-              ? "Register"
-              : "RSVP";
+          const cta = eventCta(ev);
           return (
             <Link
               key={ev.slug}

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -15,7 +15,6 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { motion, useReducedMotion } from "framer-motion";
 import type { Event } from "@/lib/types";
 import type { CommunityStats } from "@/components/sections/HeroTerminal";
 import type { AudienceState } from "@/contexts/AudienceContext";
@@ -125,38 +124,43 @@ function SupportedBy() {
 
 /* ─────────────────────────── Hero ─────────────────────────── */
 
+/**
+ * The hero is the LCP element, so nothing in it may wait for hydration.
+ * Entrance runs via the CSS-only [data-hero-rise] animation in globals.css
+ * (starts at first paint) instead of Framer Motion (starts after ~363KB of JS
+ * has parsed and hydrated). Below-fold sections keep their motion wrappers.
+ */
 function Hero({ nextEvent }: { nextEvent?: Event }) {
-  const reduce = useReducedMotion();
-  const rise = (delay: number) => ({
-    initial: reduce ? false : { opacity: 0, y: 26 },
-    animate: { opacity: 1, y: 0 },
-    transition: { duration: 0.8, ease: [0.2, 0.7, 0.2, 1] as const, delay },
-  });
-
   return (
     <section className={`${WRAP} pb-14 pt-[74px]`} aria-label="Hero">
       <div className="grid items-center gap-14 lg:grid-cols-[1.05fr_0.95fr]">
         <div>
-          <motion.div {...rise(0.1)} className={`${KICKER} mb-6`}>
+          <div data-hero-rise style={{ "--i": 0 } as React.CSSProperties} className={`${KICKER} mb-6`}>
             Karibu · Kenya&apos;s Claude Community
-          </motion.div>
-          <motion.h1
-            {...rise(0.22)}
+          </div>
+          <h1
+            data-hero-rise
+            style={{ "--i": 1 } as React.CSSProperties}
             className="mb-6 font-newsreader text-[44px] font-normal leading-[1.04] tracking-[-0.02em] text-ink sm:text-[54px] lg:text-[62px]"
           >
             A free community for Kenyans{" "}
             <span className="italic text-clay">learning &amp; building</span> with
             Claude.
-          </motion.h1>
-          <motion.p
-            {...rise(0.34)}
+          </h1>
+          <p
+            data-hero-rise
+            style={{ "--i": 2 } as React.CSSProperties}
             className="mb-9 max-w-[480px] font-inter text-[18px] leading-[1.6] text-ink-soft"
           >
             Founder-led, mobile-first, and open to everyone — from first-time
             students to seasoned developers. Meet-ups, hands-on workshops, and a
             warm community growing across Kenya.
-          </motion.p>
-          <motion.div {...rise(0.46)} className="flex flex-wrap items-center gap-3.5">
+          </p>
+          <div
+            data-hero-rise
+            style={{ "--i": 3 } as React.CSSProperties}
+            className="flex flex-wrap items-center gap-3.5"
+          >
             <a
               href={SOCIAL_LINKS.whatsapp}
               target="_blank"
@@ -171,14 +175,14 @@ function Hero({ nextEvent }: { nextEvent?: Event }) {
             >
               See upcoming events →
             </Link>
-          </motion.div>
+          </div>
         </div>
 
-        {/* Hero visual — real CCK meetup photo. */}
-        <motion.div
-          initial={reduce ? false : { opacity: 0, scale: 0.98 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.9, ease: [0.2, 0.7, 0.2, 1] }}
+        {/* Hero visual — real CCK meetup photo. Also above the fold and a
+            competing LCP candidate, so it uses the same CSS entrance. */}
+        <div
+          data-hero-rise
+          style={{ "--i": 1 } as React.CSSProperties}
           className="relative h-[300px] overflow-hidden rounded-2xl border border-sand-2 lg:h-[460px]"
         >
           <Image
@@ -198,7 +202,7 @@ function Hero({ nextEvent }: { nextEvent?: Event }) {
               )}
             </div>
           )}
-        </motion.div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/karibu/KaribuLearn.tsx
+++ b/src/components/karibu/KaribuLearn.tsx
@@ -124,7 +124,7 @@ export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
       {/* Suggested path */}
       <section className={`${WRAP} py-10`} aria-label="A suggested path">
         <Reveal>
-          <div className="rounded-[18px] bg-ink p-8 text-paper sm:p-12">
+          <div className="rounded-[18px] bg-panel-dark p-8 text-on-panel-dark sm:p-12">
             <div className="mb-5 font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay-light">
               A suggested path
             </div>
@@ -132,7 +132,7 @@ export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
               {PATH.map((s, i) => (
                 <Reveal key={s.n} index={i} className="border-t border-[#3B352D] pt-[18px]">
                   <div className="mb-2 font-newsreader text-[30px] text-clay-light">{s.n}</div>
-                  <div className="mb-1.5 font-inter text-base font-semibold text-paper">{s.title}</div>
+                  <div className="mb-1.5 font-inter text-base font-semibold text-on-panel-dark">{s.title}</div>
                   <div className="font-inter text-sm leading-[1.55] text-[#A79E90]">{s.body}</div>
                 </Reveal>
               ))}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -236,9 +236,35 @@ export async function getEventBySlug(slug: string): Promise<Event | null> {
   return row ? mapPrismaEvent(row) : null
 }
 
+/** East Africa Time is UTC+3 year-round — no DST to account for. */
+const EAT_OFFSET_MS = 3 * 60 * 60 * 1000
+
+/**
+ * The instant of midnight-today in Nairobi, as a UTC Date.
+ *
+ * Events store `date` as the day (time lives in the separate `time` string),
+ * so comparing against `now` would drop a same-day event the moment the clock
+ * passed its stored midnight — the site would stop advertising tonight's
+ * meetup on the morning of the meetup. Start-of-day keeps it listed until the
+ * day is genuinely over.
+ */
+function startOfTodayEAT(): Date {
+  const eatNow = new Date(Date.now() + EAT_OFFSET_MS)
+  return new Date(
+    Date.UTC(eatNow.getUTCFullYear(), eatNow.getUTCMonth(), eatNow.getUTCDate()) -
+      EAT_OFFSET_MS,
+  )
+}
+
 export async function getUpcomingEvents(): Promise<Event[]> {
+  // Status alone is not enough: it is set by hand in admin, so a finished event
+  // left as UPCOMING advertises itself forever. Date is the fact that cannot be
+  // forgotten to update.
   const rows = await prisma.event.findMany({
-    where: { status: { in: ["UPCOMING", "REGISTRATION_OPEN"] } },
+    where: {
+      status: { in: ["UPCOMING", "REGISTRATION_OPEN"] },
+      date: { gte: startOfTodayEAT() },
+    },
     orderBy: { date: "asc" },
   })
   return rows.map(mapPrismaEvent)

--- a/src/lib/impact-lab/cohort-guard.ts
+++ b/src/lib/impact-lab/cohort-guard.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server"
+import { isCohortActive } from "./constants"
+
+/**
+ * Refuse member-facing writes once a cohort has closed.
+ *
+ * The dashboard already hides these affordances, but hiding a button is a
+ * presentation choice, not a guarantee — the endpoints stay reachable to
+ * anything holding a session cookie. After an event the participant set,
+ * rosters, check-ins and submissions are the historical record of what
+ * happened, and a late write silently rewrites that record.
+ *
+ * Reads are deliberately untouched: people should still be able to see their
+ * team and what they built.
+ *
+ * Returns a 403 to short-circuit with, or null when the cohort is live.
+ */
+export function guardClosedCohort(cohort: string): NextResponse | null {
+  if (isCohortActive(cohort)) return null
+  return NextResponse.json(
+    {
+      success: false,
+      error:
+        "This Impact Lab has closed. Your team and submission are kept as a record and can no longer be changed.",
+    },
+    { status: 403 },
+  )
+}

--- a/src/lib/impact-lab/constants.ts
+++ b/src/lib/impact-lab/constants.ts
@@ -1,6 +1,26 @@
 /** The default (and, for now, only) Impact Lab cohort. */
 export const DEFAULT_COHORT = "impact-lab-2026-07"
 
+/**
+ * The cohort currently running an event, or null when no Impact Lab is live.
+ *
+ * Env-driven rather than hardcoded so re-opening for the next hackathon is a
+ * Vercel env change, not a deploy. Absent/empty means *no* cohort is active,
+ * which is the correct default the moment an event ends: member-facing
+ * surfaces fall back to a read-only record instead of inviting people to
+ * register for something that already happened.
+ *
+ * Server-only — every importer of this module is a route handler or server
+ * component, so there is no NEXT_PUBLIC_ inlining to worry about.
+ */
+export const ACTIVE_COHORT: string | null =
+  process.env.IMPACT_LAB_ACTIVE_COHORT?.trim() || null
+
+/** True when `cohort` is the one currently running an event. */
+export function isCohortActive(cohort: string): boolean {
+  return ACTIVE_COHORT !== null && cohort === ACTIVE_COHORT
+}
+
 const COHORT_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/i
 
 /**


### PR DESCRIPTION
Post-hackathon hardening, following a full audit of the site now that Impact Lab has run. Nine commits, one logical change each, all verified with `npx tsc --noEmit` and `npm run build`.

This was scoped as fifteen commits. Six of them (the gallery/R2 workstream) are **not** in this PR — see "Deferred" below. Stopping at the last green commit was deliberate.

## Privacy

**`fix(privacy): purge closed-cohort blockedTeammates and phone`**

`blockedTeammates` records who someone did not want to work with. Its own schema comment says it is never shown publicly, and once matching is done it serves no purpose — but it stays in the database, exportable by any admin, and it is the most damaging row on the site if it ever leaks. `phone` is the same shape of problem with a lower ceiling.

Adds `scripts/purge-closed-cohorts.ts`. Rows stay; only those two fields are cleared. Cleared rather than hashed — a hash is only worth keeping if something still needs to compare the value, and nothing does.

> ⚠️ **This has not been run against production.** It is dry-run by default and prints every row it would touch. Edwin runs it himself with `--apply`. Against the local dev database the dry run reported 1 row; production will differ.

Also introduces `IMPACT_LAB_ACTIVE_COHORT`, so reopening for the next hackathon is an env change rather than a deploy. Unset means no cohort is active — the correct default the moment an event ends. The script skips the active cohort unless named explicitly, so running it mid-event cannot wipe numbers organisers are using to reach the room.

## Stale event state

- **`fix(events): filter upcoming events by date, not just status`** — `getUpcomingEvents` filtered on status alone, and status is set by hand, which is how a hackathon dated 2026-04-04 was still rendering as the next event. Compared against start-of-day in Nairobi so tonight's meetup does not vanish on the morning of the meetup.
- **`fix(dashboard): gate Impact Lab to the active cohort`** — the card rendered for every signed-in user, so a brand-new member was told to complete a matching profile for a finished hackathon. Closed cohort now means: no card for people who never took part, an archived record card for those who did, read-only team view, no profile form / roster editing / submission, no check-in polling. Enforced server-side as well — the six member write endpoints return 403. Reads stay open.
- **`fix(timer): require an explicit deadline`** — `/timer` defaulted to 3:00 PM *today*, so it rendered a live countdown every day forever. `?at=` is now required.
- **`fix(home): derive the event CTA from the date, not the type`** — every hackathon card read "Register" because the label keyed off `ev.type`, which never changes.

## Accessibility

- **`fix(a11y): non-inverting dark panel token, and repair --ink-faint`** — two defects behind 18 contrast failures. The dark-mode block inverts `--ink`, so panels built as deliberate dark slabs turned near-white while their text stayed light (footer at **1.59:1** — effectively invisible on a dark-mode phone, which on this audience is most of them). And `--ink-faint` was missing from both dark blocks entirely. Adds a non-inverting `--panel-dark` trio. Every value was measured, not eyeballed: `--ink-faint` also failed in **light** mode at 3.40:1 and is now 4.58:1 there; a first pick of `#857b6c` came out at 4.29:1 and was rejected.
- **`fix(a11y): implement the lightbox focus trap and restore focus`** — the doc comment claimed a focus trap and none existed, so Tab walked out of the dialog into the page behind it. Also restores focus to the tile that opened it.
- **`fix(home): render the LCP hero heading without waiting for hydration`** — the hero `<h1>` shipped as `style="opacity:0"` and only appeared once Framer Motion hydrated. Above-fold entrances now run as a CSS animation starting at first paint.

### Measured outcome — partial, and I want to be straight about it

Production build, mobile, simulated throttling, localhost. Run-to-run variance on this machine was large, so these are the cleanest comparable runs:

| | Before | After |
|---|---|---|
| Performance | 65 | 70–73 |
| LCP | 8.5 s | 5.9–6.1 s |
| FCP | 1.2 s | 1.2 s |
| Contrast failures | 18 | **2** |
| SSR'd `opacity:0` elements | 7 | 2 |

The contrast work did what it claimed. The LCP work **did not fully land**. LCP improved but ~5.4 s of render delay remains, and I verified it is *not* the hero animation: rebuilding with a transform-only entrance (text never invisible at any point) produced an identical render delay of 5287 ms vs 5430 ms. So the residual has a different cause — most likely main-thread blocking (TBT 250–350 ms, 610 ms unused JS) and the two render-blocking stylesheets. That needs its own investigation and is **not** fixed here.

The commit is still worth having: the heading no longer depends on 363 KB of JS to become visible, which matters independently of what Lighthouse scores it.

## Docs

**`docs: correct the stack and design-system facts in CLAUDE.md`** — the file presented Terminal Noir as *the* design system and listed the wrong fonts; neither describes the public site any more. Now documents both systems with their scopes, plus the traps worth knowing (the dead `font-newsreader` utility and which usages are actually dead, the five-family font load, metadata gaps, and the Prisma-client-goes-stale-after-a-pull symptom). Model count corrected 17 → 24.

Note: the audit brief I was working from described this repo as Nuxt/Nitro with a `#080B0F / #7B5CFF / #00D1FF` palette. Neither is true of this codebase and neither appeared in `CLAUDE.md` — flagging it only so nobody goes looking for a Nuxt migration that does not exist.

## Not bundled, deliberately

`AboutClient.tsx:159` says "the first Claude hackathon in Africa" — a **fifth** Africa overclaim, alongside the four already open on your side from the pre-hackathon polish pass (`JoinSwitcher.tsx`, `signup/page.tsx`, `HeroTerminal.tsx`, `ConsoleWelcome.tsx`). It belongs with those four as one copy decision, not scattered into an unrelated hardening PR. Your call, as before.

`Key Facts` in CLAUDE.md still says 2 events hosted, which is stale now Impact Lab has run — but `siteSettings` is its source of truth and inventing a number here would break the no-inflated-stats rule that file sets.

## Deferred

**The gallery / R2 workstream (6 commits)** — storage adapter + `storageKey`, sharp derivatives + per-file alt, presigned PUT uploads, event-grouped routes, pre-generated zip bundles, and the real-photo backfill with takedown route. Not started. It needs three new dependencies (`sharp`, an S3-compatible client, `archiver`) and a Prisma migration, and starting it would have meant either rushing it or leaving a half-finished commit on the branch. The design is settled and it is a clean next branch.

Worth flagging while it waits: **all six photos currently on `/gallery` are Unsplash stock**, under copy reading "Real people, real meetups, real Kenya. Every shot here is from one of our gatherings." That claim is false today, and `next.config.ts:15` still carries the TODO to drop the Unsplash pattern.

**Also deferred to a batch 2:** the font layering (5 families global, 66 dead `font-newsreader` heading usages), 11 public pages with no metadata, canonicals on `/code-of-conduct` and `/resources/links`, the Impact Lab Terminal Noir restyle, and the local-env Prisma staleness. All recorded in `CLAUDE.md` Known Issues so they survive this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
