### PR TITLE
Impact Lab: publish results to participants

### DIFF
--- a/docs/superpowers/plans/2026-07-27-impact-lab-results-publication.md
+++ b/docs/superpowers/plans/2026-07-27-impact-lab-results-publication.md
@@ -1,0 +1,1378 @@
+# Impact Lab Results Publication — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish the Impact Lab hackathon results to the 93 builders whose teams submitted — announced winners, track winners, each team's own scores — and lock the record so nothing can move underneath it afterwards.
+
+**Architecture:** A pure computation module (`results.ts`) turns judge scores plus the announced winners into an immutable snapshot. `publish` writes that snapshot inside a row-locked transaction and closes submissions and judging in the same step. Everything participants see is served from the stored snapshot, never recomputed. Judge transparency and judge-exclusion previews are admin-only and read-only — no path exists from them to published output.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript strict, Prisma 7 with the driver-adapter pattern, PostgreSQL 17, Tailwind v4, Resend, `ai` + `@ai-sdk/anthropic`.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-impact-lab-results-publication-design.md`
+
+**Branch:** `feat/impact-lab-results` (already created)
+
+## Global Constraints
+
+Every task's requirements implicitly include this section.
+
+- **TypeScript strict. Never use `any`.** No `.js` files in `src/`.
+- **This repo has no unit-test framework.** The established pattern is an assertion script — `scripts/verify-matching.ts`, `scripts/verify-judging.ts` — run via an npm script, exiting 0 or 1. Pure logic is tested that way. Route and UI work is verified by running commands and reading output; those tasks say exactly what to run and what to look for.
+- **Verify before every commit:** `npx tsc --noEmit` and `npm run build` must both pass clean.
+- **Conventional commits**, scoped: `type(scope): description`. No AI attribution.
+- **Participant-facing copy rules, absolute:**
+  - Never show judge counts — not per team, not in aggregate.
+  - Never mention a deadline, cut-off, time cap, or late submission.
+  - Never suggest a team failed to present, left early, or was missed.
+  - Plain English. No Swahili in participant-facing copy.
+- **Never print or commit the production database password.** The connection file at `C:\Projects\_backups\cck\vps-connection.txt` is outside the repo deliberately.
+- **Styling:** Tailwind utilities plus the CSS variables in `src/app/globals.css`. No inline styles in React. The persona system (Dev = Terminal Noir, Pro = glassmorphism) applies to participant surfaces. **Invoke the `frontend-design` skill before writing the participant-facing UI in Task 8** — that surface is the one 93 people will actually look at, and the admin tabs should mirror the existing `LeaderboardTab.tsx` rather than invent a second admin style.
+- **Admin API responses** are `{success, data}`. **Member API responses** are flat `{success, ...}`. Follow whichever surface you are on.
+- **Guard order on member routes:** CSRF → rate limit → auth → validation.
+- **Cohort:** `impact-lab-2026-07` (`DEFAULT_COHORT` in `src/lib/impact-lab/constants.ts`).
+- **The announced winners are fixed and must never be recomputed:** BiasharaGPT (1), VilCare (2), Oryn (3).
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+|---|---|
+| `src/lib/impact-lab/results.ts` | Pure snapshot computation. No Prisma, no Next. |
+| `scripts/verify-results.ts` | Assertions for the above. |
+| `src/app/api/admin/impact-lab/judging/audit/route.ts` | Per-judge audit data (staff). |
+| `src/app/api/admin/impact-lab/judging/preview/route.ts` | What-if standings with judges excluded (staff). |
+| `src/app/api/admin/impact-lab/judging/writeup/route.ts` | Draft and save submission-only scores (staff). |
+| `src/app/api/admin/impact-lab/results/publish/route.ts` | Mark final: lock, snapshot, queue. |
+| `src/app/api/admin/impact-lab/results/notify/route.ts` | Resumable send. |
+| `src/app/api/impact-lab/results/route.ts` | Member-facing published result. |
+| `src/components/admin/impact-lab/JudgesTab.tsx` | Judge audit + exclusion preview UI. |
+| `src/components/admin/impact-lab/ResultsTab.tsx` | Writeup review, publish, send. |
+| `src/app/dashboard/impact-lab/ResultsView.tsx` | Participant results surface. |
+| `prisma/migrations/20260727120000_impact_lab_results/migration.sql` | Schema change. |
+
+**Modified:**
+
+| File | Change |
+|---|---|
+| `prisma/schema.prisma` | New fields on two models, one new model. |
+| `src/lib/email.ts` | Add `sendEmailBatchTracked` and `impactLabResultsEmail`. |
+| `src/app/api/admin/impact-lab/judging/route.ts` | Reject writes once judging is closed. |
+| `src/components/admin/impact-lab/ImpactLabDashboard.tsx` | Two new tabs. |
+| `src/app/dashboard/impact-lab/ImpactLabClient.tsx` | New `results` phase. |
+| `package.json` | `verify:results` script. |
+
+---
+
+### Task 1: Schema and migration
+
+**Files:**
+- Modify: `prisma/schema.prisma`
+- Create: `prisma/migrations/20260727120000_impact_lab_results/migration.sql`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ImpactLabMatchRun.judgingClosedAt`, `.resultsPublishedAt`, `.announcedWinners`, `.resultsSnapshot`; `ImpactLabScore.writeupOnly`; model `ImpactLabResultsEmail` with fields `id, runId, participantId, email, status, error, sentAt, createdAt` and `@@unique([runId, participantId])`.
+
+- [ ] **Step 1: Add the fields to `ImpactLabMatchRun`**
+
+In `prisma/schema.prisma`, inside `model ImpactLabMatchRun`, immediately after the `submissionsCloseAt` field:
+
+```prisma
+  /// Set by mark-final. Once non-null, no further scores may be written —
+  /// the judging route rejects writes rather than silently accepting a score
+  /// that can never reach the published result.
+  judgingClosedAt      DateTime?
+  /// When results were published to participants. Non-null means the result
+  /// is immutable: everything participants see is served from resultsSnapshot.
+  resultsPublishedAt   DateTime?
+  /// The winners as announced in the room, stored verbatim. Never recomputed —
+  /// the panel deliberated, and arithmetic does not reproduce their decision.
+  announcedWinners     Json?
+  /// The exact ResultsSnapshot that was published. Served as-is so a later
+  /// score correction or submission edit cannot rewrite what people read.
+  resultsSnapshot      Json?
+  resultsEmails        ImpactLabResultsEmail[]
+```
+
+- [ ] **Step 2: Add the field to `ImpactLabScore`**
+
+Inside `model ImpactLabScore`, immediately after `feedback`:
+
+```prisma
+  /// True when this score came from reading the written submission rather than
+  /// watching a live demo. The demo criterion is 25% of the weight and asks
+  /// whether the thing ran in front of you, so the basis must travel with the
+  /// score wherever it is shown.
+  writeupOnly Boolean @default(false)
+```
+
+- [ ] **Step 3: Add the new model**
+
+At the end of `prisma/schema.prisma`:
+
+```prisma
+/// One row per intended recipient of the results email. This is what makes the
+/// send idempotent: Resend's quota is 100/day and there are 93 recipients, so a
+/// careless retry exceeds it. A resend selects status <> 'sent' only.
+model ImpactLabResultsEmail {
+  id            String    @id @default(cuid())
+  runId         String
+  participantId String
+  email         String
+  /// queued | sent | failed
+  status        String    @default("queued")
+  error         String?
+  sentAt        DateTime?
+  createdAt     DateTime  @default(now())
+
+  run ImpactLabMatchRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  @@unique([runId, participantId])
+  @@index([runId, status])
+  @@map("impact_lab_results_emails")
+}
+```
+
+- [ ] **Step 4: Write the migration SQL by hand**
+
+Create `prisma/migrations/20260727120000_impact_lab_results/migration.sql`. Write it by hand rather than running `prisma migrate dev` — that command has previously proposed dropping the partial unique index `impact_lab_match_runs_one_final_per_cohort`, which Prisma cannot express and which must survive.
+
+```sql
+ALTER TABLE "impact_lab_match_runs"
+  ADD COLUMN "judgingClosedAt" TIMESTAMP(3),
+  ADD COLUMN "resultsPublishedAt" TIMESTAMP(3),
+  ADD COLUMN "announcedWinners" JSONB,
+  ADD COLUMN "resultsSnapshot" JSONB;
+
+ALTER TABLE "impact_lab_scores"
+  ADD COLUMN "writeupOnly" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE "impact_lab_results_emails" (
+  "id" TEXT NOT NULL,
+  "runId" TEXT NOT NULL,
+  "participantId" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'queued',
+  "error" TEXT,
+  "sentAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "impact_lab_results_emails_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "impact_lab_results_emails_runId_participantId_key"
+  ON "impact_lab_results_emails" ("runId", "participantId");
+
+CREATE INDEX "impact_lab_results_emails_runId_status_idx"
+  ON "impact_lab_results_emails" ("runId", "status");
+
+ALTER TABLE "impact_lab_results_emails"
+  ADD CONSTRAINT "impact_lab_results_emails_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "impact_lab_match_runs"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;
+```
+
+- [ ] **Step 5: Generate the client and typecheck**
+
+Run: `npx prisma generate && npx tsc --noEmit`
+Expected: both succeed. The generated client now has `writeupOnly` on `ImpactLabScore` and `prisma.impactLabResultsEmail`.
+
+Note: the generated client has **no default constructor** — this project uses `new PrismaClient({ adapter: new PrismaPg({ connectionString, max: 5 }) })`. Use the exported `prisma` from `@/lib/prisma`; do not construct your own.
+
+- [ ] **Step 6: Verify the migration applies to a scratch database**
+
+Do **not** point this at production. Confirm `DATABASE_URL` in your local `.env` is not the production VPS before running anything.
+
+Run: `npx prisma migrate status`
+Expected: lists `20260727120000_impact_lab_results` as pending or applied. If it reports drift about `one_final_per_cohort`, stop and report — do not let it "fix" that.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations/20260727120000_impact_lab_results/
+git commit -m "feat(impact-lab): schema for results publication"
+```
+
+---
+
+### Task 2: Results computation
+
+**Files:**
+- Create: `src/lib/impact-lab/results.ts`
+- Create: `scripts/verify-results.ts`
+- Modify: `package.json`
+
+**Interfaces:**
+- Consumes: `TeamStanding`, `JUDGING_CRITERIA`, `trackOf` from `@/lib/impact-lab/judging`.
+- Produces:
+  - `type ResultBasis = "announced" | "demo" | "submission"`
+  - `interface RankedTeam { rank: number; teamId: string; projectName: string; track: string; average: number; basis: ResultBasis }`
+  - `interface AnnouncedWinner { rank: number; teamId: string; projectName: string }`
+  - `interface ResultsTrackWinner { track: string; teamId: string; projectName: string; basis: "announced" | "score" }`
+  - `interface TeamCard { rank: number; criterionAverages: Record<string, number>; low: number; high: number; basis: "demo" | "submission" }`
+  - `interface ResultsSnapshot { publishedAt: string; overall: AnnouncedWinner[]; trackWinners: ResultsTrackWinner[]; ranking: RankedTeam[]; perTeam: Record<string, TeamCard> }`
+  - `interface ResultsInput { publishedAt: string; announcedTeamIds: string[]; standings: TeamStanding[]; teams: Map<string, { projectName: string; track: string }>; writeupOnly: Set<string>; range: Map<string, { low: number; high: number }> }`
+  - `function buildSnapshot(input: ResultsInput): ResultsSnapshot`
+
+- [ ] **Step 1: Write the failing assertions**
+
+Create `scripts/verify-results.ts`:
+
+```ts
+/**
+ * Impact Lab results — verification harness.
+ *
+ * Follows scripts/verify-judging.ts. The arithmetic here decides what 93 people
+ * are told about their own work, so the ranking rule, the track-winner rule and
+ * the privacy of the payload are asserted rather than trusted.
+ *
+ * Run with: npm run verify:results
+ */
+
+import { buildSnapshot, type ResultsInput } from "../src/lib/impact-lab/results"
+import type { TeamStanding } from "../src/lib/impact-lab/judging"
+
+let failures = 0
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`  ✓ ${message}`)
+  } else {
+    console.error(`  ✗ ${message}`)
+    failures += 1
+  }
+}
+
+const standing = (teamId: string, average: number): TeamStanding => ({
+  teamId,
+  average,
+  judgeCount: 2,
+  criterionAverages: { impact: 4, demo: 4, claude: 4, clarity: 4, presentation: 4 },
+})
+
+// Mirrors production: the announced winners do not top the score table.
+const input: ResultsInput = {
+  publishedAt: "2026-07-27T09:00:00.000Z",
+  announcedTeamIds: ["t-biasharagpt", "t-vilcare", "t-oryn"],
+  standings: [
+    standing("t-whatsy", 76.9),
+    standing("t-biasharagpt", 75.3),
+    standing("t-keyosk", 73.8),
+    standing("t-oryn", 73.3),
+    standing("t-vilcare", 55.3),
+    standing("t-kilimoeco", 80.0),
+  ],
+  teams: new Map([
+    ["t-whatsy", { projectName: "Whatsy", track: "Biashara (Small Business)" }],
+    ["t-biasharagpt", { projectName: "BiasharaGPT", track: "Biashara (Small Business)" }],
+    ["t-keyosk", { projectName: "KeyOSk", track: "Biashara (Small Business)" }],
+    ["t-oryn", { projectName: "Oryn", track: "Biashara (Small Business)" }],
+    ["t-vilcare", { projectName: "VilCare", track: "Afya (Health)" }],
+    ["t-kilimoeco", { projectName: "kilimoeco", track: "Kilimo (Agriculture)" }],
+  ]),
+  writeupOnly: new Set(["t-kilimoeco"]),
+  range: new Map([
+    ["t-vilcare", { low: 18.8, high: 88.8 }],
+    ["t-whatsy", { low: 76.3, high: 77.5 }],
+  ]),
+}
+
+const snap = buildSnapshot(input)
+
+console.log("\nRanking")
+assert(snap.ranking[0].teamId === "t-biasharagpt", "the announced champion ranks 1st")
+assert(snap.ranking[1].teamId === "t-vilcare", "the announced 2nd ranks 2nd despite the lowest score")
+assert(snap.ranking[2].teamId === "t-oryn", "the announced 3rd ranks 3rd")
+assert(
+  snap.ranking[0].basis === "announced" && snap.ranking[2].basis === "announced",
+  "announced winners carry basis 'announced'"
+)
+
+const whatsy = snap.ranking.find((r) => r.teamId === "t-whatsy")
+assert(
+  whatsy?.rank === 5,
+  "a team outscoring the champion still ranks below it — kilimoeco 80.0 is 4th, Whatsy 76.9 is 5th"
+)
+assert(
+  snap.ranking.length === 6 && new Set(snap.ranking.map((r) => r.teamId)).size === 6,
+  "every submitted team appears exactly once"
+)
+assert(
+  snap.ranking.every((r, i) => r.rank === i + 1),
+  "ranks are dense and start at 1"
+)
+assert(
+  snap.ranking.find((r) => r.teamId === "t-kilimoeco")?.basis === "submission",
+  "a submission-reviewed team carries basis 'submission'"
+)
+
+console.log("\nTrack winners")
+const byTrack = new Map(snap.trackWinners.map((w) => [w.track, w]))
+assert(
+  byTrack.get("Biashara (Small Business)")?.teamId === "t-biasharagpt",
+  "an announced winner leads its own track, ahead of a higher-scoring team"
+)
+assert(
+  byTrack.get("Biashara (Small Business)")?.basis === "announced",
+  "that track winner is marked as decided by announcement"
+)
+assert(
+  byTrack.get("Afya (Health)")?.teamId === "t-vilcare",
+  "the announced 2nd leads its track"
+)
+assert(
+  byTrack.get("Kilimo (Agriculture)")?.teamId === "t-kilimoeco" &&
+    byTrack.get("Kilimo (Agriculture)")?.basis === "score",
+  "a track with no announced winner goes to the top score, marked as such"
+)
+assert(
+  snap.trackWinners.length === 3,
+  "only tracks with at least one ranked team produce a winner"
+)
+
+console.log("\nPrivacy of the payload")
+const serialized = JSON.stringify(snap)
+assert(!serialized.includes("judgeCount"), "the snapshot never carries a judge count")
+assert(
+  !/"judge(Name|Email)"/.test(serialized),
+  "the snapshot never carries a judge identity"
+)
+assert(
+  Object.keys(snap.perTeam).length === 6,
+  "every ranked team gets a private card"
+)
+assert(
+  snap.perTeam["t-vilcare"].low === 18.8 && snap.perTeam["t-vilcare"].high === 88.8,
+  "a team's own card carries the range across judges"
+)
+assert(
+  snap.perTeam["t-vilcare"].rank === 2,
+  "a team's own card carries its published rank, not its score rank"
+)
+
+console.log("\nDeterminism")
+assert(
+  JSON.stringify(buildSnapshot(input)) === serialized,
+  "two builds from identical input are byte-identical"
+)
+const tied = buildSnapshot({
+  ...input,
+  announcedTeamIds: [],
+  standings: [standing("t-b", 70), standing("t-a", 70)],
+  teams: new Map([
+    ["t-a", { projectName: "A", track: "Afya (Health)" }],
+    ["t-b", { projectName: "B", track: "Afya (Health)" }],
+  ]),
+  writeupOnly: new Set(),
+  range: new Map(),
+})
+assert(tied.ranking[0].teamId === "t-a", "ties break deterministically by team id")
+
+console.log(
+  failures === 0 ? "\nALL CHECKS PASSED\n" : `\n${failures} CHECK(S) FAILED\n`
+)
+process.exit(failures === 0 ? 0 : 1)
+```
+
+- [ ] **Step 2: Add the npm script**
+
+In `package.json`, in `"scripts"`, next to the existing `verify:judging` entry:
+
+```json
+"verify:results": "tsx scripts/verify-results.ts"
+```
+
+Match the runner the neighbouring `verify:judging` script uses — if it uses something other than `tsx`, use that instead.
+
+- [ ] **Step 3: Run the assertions to verify they fail**
+
+Run: `npm run verify:results`
+Expected: FAIL — cannot resolve `../src/lib/impact-lab/results`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/lib/impact-lab/results.ts`:
+
+```ts
+/**
+ * Impact Lab results — the published snapshot.
+ *
+ * Pure and dependency-free (no Prisma, no Next) so the rules that decide what
+ * 93 builders are told can be asserted by a script.
+ *
+ * Two rules carry all the weight:
+ *
+ * 1. The three winners announced in the room hold ranks 1-3, whatever the
+ *    arithmetic says. The panel watched every demo and deliberated; no
+ *    combination of the recorded scores reproduces their decision, and the
+ *    announcement is already public. Recomputing it would contradict what
+ *    people were told to their faces.
+ * 2. Everyone else ranks below them by score. Scores order the list but are
+ *    never printed in it — publishing them would place a 76.9 at 4th above a
+ *    75.3 at 1st, which is the contradiction this ranking exists to remove.
+ *    A team's own numbers live on its own private card.
+ */
+
+import { trackOf, type TeamStanding } from "./judging"
+
+/** How a team's placing was arrived at. */
+export type ResultBasis = "announced" | "demo" | "submission"
+
+export interface RankedTeam {
+  rank: number
+  teamId: string
+  projectName: string
+  track: string
+  /** Orders the ranking. Never rendered in the public table. */
+  average: number
+  basis: ResultBasis
+}
+
+export interface AnnouncedWinner {
+  rank: number
+  teamId: string
+  projectName: string
+}
+
+export interface ResultsTrackWinner {
+  track: string
+  teamId: string
+  projectName: string
+  /** "announced" when an overall winner leads the track, else "score". */
+  basis: "announced" | "score"
+}
+
+/** Served only to members of that team. */
+export interface TeamCard {
+  rank: number
+  criterionAverages: Record<string, number>
+  low: number
+  high: number
+  basis: "demo" | "submission"
+}
+
+export interface ResultsSnapshot {
+  publishedAt: string
+  overall: AnnouncedWinner[]
+  trackWinners: ResultsTrackWinner[]
+  ranking: RankedTeam[]
+  perTeam: Record<string, TeamCard>
+}
+
+export interface ResultsInput {
+  publishedAt: string
+  /** Announced winners in announced order. Empty is legal; three is the case. */
+  announcedTeamIds: string[]
+  standings: TeamStanding[]
+  teams: Map<string, { projectName: string; track: string }>
+  /** Teams scored from the written submission rather than a live demo. */
+  writeupOnly: Set<string>
+  /** Lowest and highest weighted total across that team's judges. */
+  range: Map<string, { low: number; high: number }>
+}
+
+const UNKNOWN_TRACK = "Unassigned"
+
+function metaOf(
+  input: ResultsInput,
+  teamId: string
+): { projectName: string; track: string } {
+  const meta = input.teams.get(teamId)
+  if (meta) return meta
+  // A team present in standings but absent from the run JSON should not be able
+  // to crash publication; it appears with its id rather than vanishing.
+  return { projectName: teamId, track: UNKNOWN_TRACK }
+}
+
+/**
+ * Announced winners first in announced order, then everyone else by average
+ * descending. Ties break by teamId so two loads never reorder themselves.
+ */
+export function buildRanking(input: ResultsInput): RankedTeam[] {
+  const announced = new Set(input.announcedTeamIds)
+  const byTeam = new Map(input.standings.map((s) => [s.teamId, s]))
+
+  const rows: RankedTeam[] = []
+
+  for (const teamId of input.announcedTeamIds) {
+    const meta = metaOf(input, teamId)
+    rows.push({
+      rank: rows.length + 1,
+      teamId,
+      projectName: meta.projectName,
+      track: meta.track || trackOf(meta.projectName),
+      average: byTeam.get(teamId)?.average ?? 0,
+      basis: "announced",
+    })
+  }
+
+  const rest = input.standings
+    .filter((s) => !announced.has(s.teamId))
+    .sort((a, b) => b.average - a.average || a.teamId.localeCompare(b.teamId))
+
+  for (const s of rest) {
+    const meta = metaOf(input, s.teamId)
+    rows.push({
+      rank: rows.length + 1,
+      teamId: s.teamId,
+      projectName: meta.projectName,
+      track: meta.track || trackOf(meta.projectName),
+      average: s.average,
+      basis: input.writeupOnly.has(s.teamId) ? "submission" : "demo",
+    })
+  }
+
+  return rows
+}
+
+/**
+ * One winner per track. An announced overall winner leads its own track — so
+ * the champion never appears to lose its own category on the same page that
+ * crowns it. Tracks with no announced winner go to their highest-ranked team.
+ */
+export function buildTrackWinners(ranking: RankedTeam[]): ResultsTrackWinner[] {
+  const best = new Map<string, ResultsTrackWinner>()
+
+  // `ranking` is already ordered with announced winners first, so the first
+  // sighting of a track is its winner.
+  for (const row of ranking) {
+    if (best.has(row.track)) continue
+    best.set(row.track, {
+      track: row.track,
+      teamId: row.teamId,
+      projectName: row.projectName,
+      basis: row.basis === "announced" ? "announced" : "score",
+    })
+  }
+
+  return [...best.values()].sort((a, b) => a.track.localeCompare(b.track))
+}
+
+export function buildSnapshot(input: ResultsInput): ResultsSnapshot {
+  const ranking = buildRanking(input)
+  const standingById = new Map(input.standings.map((s) => [s.teamId, s]))
+
+  const perTeam: Record<string, TeamCard> = {}
+  for (const row of ranking) {
+    const standing = standingById.get(row.teamId)
+    const range = input.range.get(row.teamId)
+    perTeam[row.teamId] = {
+      rank: row.rank,
+      criterionAverages: standing?.criterionAverages ?? {},
+      low: range?.low ?? 0,
+      high: range?.high ?? 0,
+      basis: input.writeupOnly.has(row.teamId) ? "submission" : "demo",
+    }
+  }
+
+  return {
+    publishedAt: input.publishedAt,
+    overall: input.announcedTeamIds.map((teamId, i) => ({
+      rank: i + 1,
+      teamId,
+      projectName: metaOf(input, teamId).projectName,
+    })),
+    trackWinners: buildTrackWinners(ranking),
+    ranking,
+    perTeam,
+  }
+}
+```
+
+- [ ] **Step 5: Run the assertions to verify they pass**
+
+Run: `npm run verify:results`
+Expected: `ALL CHECKS PASSED`, exit 0.
+
+- [ ] **Step 6: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/impact-lab/results.ts scripts/verify-results.ts package.json
+git commit -m "feat(impact-lab): results snapshot computation"
+```
+
+---
+
+### Task 3: Close judging when results are final
+
+**Files:**
+- Modify: `src/app/api/admin/impact-lab/judging/route.ts`
+
+**Interfaces:**
+- Consumes: `ImpactLabMatchRun.judgingClosedAt` from Task 1.
+- Produces: nothing new. A score write returns 409 with `code: "JUDGING_CLOSED"` once judging is closed.
+
+- [ ] **Step 1: Find the POST handler's run lookup**
+
+Run: `grep -n "findFirst\|isFinal\|export async function POST" src/app/api/admin/impact-lab/judging/route.ts`
+
+Note the line where POST loads the final run and what it selects.
+
+- [ ] **Step 2: Add `judgingClosedAt` to that select and guard on it**
+
+In the POST handler, extend the run lookup's `select` to include `judgingClosedAt: true`, then immediately after the existing "no final run" check, add:
+
+```ts
+  // Once results are published, a new score can never reach them. Accepting the
+  // write anyway would tell a judge their scoring counted when it did not.
+  if (run.judgingClosedAt) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Judging is closed — results have been published.",
+        code: "JUDGING_CLOSED",
+      },
+      { status: 409 }
+    )
+  }
+```
+
+Leave the GET handler untouched: judges and staff must still be able to read what was scored after publication.
+
+- [ ] **Step 3: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 4: Verify the guard by reading it back**
+
+Run: `grep -n "JUDGING_CLOSED" src/app/api/admin/impact-lab/judging/route.ts`
+Expected: exactly one hit, inside the POST handler and after the run lookup. Confirm by eye that no `return` before it can skip it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/admin/impact-lab/judging/route.ts
+git commit -m "feat(impact-lab): reject score writes once judging is closed"
+```
+
+---
+
+### Task 4: Judge audit
+
+**Files:**
+- Create: `src/app/api/admin/impact-lab/judging/audit/route.ts`
+- Create: `src/components/admin/impact-lab/JudgesTab.tsx`
+- Modify: `src/components/admin/impact-lab/ImpactLabDashboard.tsx`
+
+**Interfaces:**
+- Consumes: `weightedTotal`, `JUDGING_CRITERIA` from `@/lib/impact-lab/judging`; `checkApiPermission` from `@/lib/rbac`.
+- Produces: `GET /api/admin/impact-lab/judging/audit?cohort=…` returning
+  `{success: true, data: {judges: JudgeAudit[]}}` where
+  `interface JudgeAudit { judgeEmail: string; judgeName: string; teamsScored: number; mean: number; firstScoredAt: string; lastScoredAt: string; sheets: {teamId: string; teamName: string; projectName: string | null; total: number; scores: Record<string, number>; writeupOnly: boolean; scoredAt: string}[] }`
+
+- [ ] **Step 1: Write the route**
+
+Create `src/app/api/admin/impact-lab/judging/audit/route.ts`:
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { checkApiPermission } from "@/lib/rbac"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { weightedTotal } from "@/lib/impact-lab/judging"
+
+/**
+ * Per-judge audit. Staff only — deliberately not reachable by a code-gated
+ * judge session, because a judge seeing another judge's sheet is exactly the
+ * anchoring the judging screen was built to avoid.
+ *
+ * This exists because the four judges scored on visibly different scales
+ * (means from 48.3 to 72.2). That is invisible in an aggregate leaderboard and
+ * changes how the result should be read, so it is surfaced rather than buried.
+ */
+
+interface AuditSheet {
+  teamId: string
+  teamName: string
+  projectName: string | null
+  total: number
+  scores: Record<string, number>
+  writeupOnly: boolean
+  scoredAt: string
+}
+
+export interface JudgeAudit {
+  judgeEmail: string
+  judgeName: string
+  teamsScored: number
+  mean: number
+  firstScoredAt: string
+  lastScoredAt: string
+  sheets: AuditSheet[]
+}
+
+function asScoreSheet(value: unknown): Record<string, number> {
+  if (typeof value !== "object" || value === null) return {}
+  const out: Record<string, number> = {}
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "number" && !Number.isNaN(v)) out[k] = v
+  }
+  return out
+}
+
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+  if (!run) {
+    return NextResponse.json({ success: true, data: { judges: [] } })
+  }
+
+  const [rows, submissions] = await Promise.all([
+    prisma.impactLabScore.findMany({
+      where: { runId: run.id },
+      select: {
+        teamId: true,
+        judgeEmail: true,
+        judgeName: true,
+        scores: true,
+        writeupOnly: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.impactLabSubmission.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, projectName: true },
+    }),
+  ])
+
+  const nameById = new Map<string, string>()
+  const teams = (run.result as { teams?: { id: string; name: string }[] })?.teams ?? []
+  for (const team of teams) nameById.set(team.id, team.name)
+  const projectById = new Map(submissions.map((s) => [s.teamId, s.projectName]))
+
+  const byJudge = new Map<string, JudgeAudit>()
+  for (const row of rows) {
+    const sheet = asScoreSheet(row.scores)
+    const entry = byJudge.get(row.judgeEmail) ?? {
+      judgeEmail: row.judgeEmail,
+      judgeName: row.judgeName,
+      teamsScored: 0,
+      mean: 0,
+      firstScoredAt: row.createdAt.toISOString(),
+      lastScoredAt: row.createdAt.toISOString(),
+      sheets: [],
+    }
+    entry.sheets.push({
+      teamId: row.teamId,
+      teamName: nameById.get(row.teamId) ?? row.teamId,
+      projectName: projectById.get(row.teamId) ?? null,
+      total: weightedTotal(sheet),
+      scores: sheet,
+      writeupOnly: row.writeupOnly,
+      scoredAt: row.createdAt.toISOString(),
+    })
+    entry.lastScoredAt = row.createdAt.toISOString()
+    byJudge.set(row.judgeEmail, entry)
+  }
+
+  const judges = [...byJudge.values()].map((j) => ({
+    ...j,
+    teamsScored: j.sheets.length,
+    mean:
+      Math.round(
+        (j.sheets.reduce((n, s) => n + s.total, 0) / (j.sheets.length || 1)) * 10
+      ) / 10,
+  }))
+  judges.sort((a, b) => b.teamsScored - a.teamsScored || a.judgeName.localeCompare(b.judgeName))
+
+  return NextResponse.json({ success: true, data: { judges } })
+}
+```
+
+- [ ] **Step 2: Build the tab**
+
+Create `src/components/admin/impact-lab/JudgesTab.tsx`. Follow `LeaderboardTab.tsx` exactly for structure — `"use client"`, `apiGet` from `./api`, the same loading and error handling, the same Terminal Noir colour tokens (`#00ff41`, `#555`, `text-xs font-mono`).
+
+Render, per judge: name, teams scored, mean, and the time span they worked. Below each, a collapsible list of their sheets showing team, project, each criterion value and the weighted total.
+
+Above the list, a calibration summary: the highest and lowest judge means side by side with the gap between them, so the spread is the first thing an organiser sees rather than something they have to compute.
+
+Leave a placeholder `<div>` where Task 5 adds the exclusion preview; that task fills it.
+
+- [ ] **Step 3: Register the tab**
+
+In `src/components/admin/impact-lab/ImpactLabDashboard.tsx`:
+- Extend the `Tab` union on line 13 with `| "judges"`.
+- Add `judges` to the tab list rendered around line 35, labelled `Judges`.
+- Render `<JudgesTab cohort={cohort} />` when `tab === "judges"`, matching how `LeaderboardTab` is rendered.
+
+- [ ] **Step 4: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 5: Verify against real data**
+
+Run: `npm run dev`, open `http://localhost:3000/admin/impact-lab`, sign in as an admin, open the **Judges** tab.
+
+Expected, from production data: four judges — Cynthia Njagi 23 teams, Favour 22, Mercy 19, Savannah 9 — with means near 66.7, 72.2, 48.3 and 54.2. If the means come out equal, `weightedTotal` is not being applied per sheet; fix that before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/admin/impact-lab/judging/audit/ src/components/admin/impact-lab/JudgesTab.tsx src/components/admin/impact-lab/ImpactLabDashboard.tsx
+git commit -m "feat(impact-lab): per-judge audit view"
+```
+
+---
+
+### Task 5: Exclusion preview
+
+**Files:**
+- Create: `src/app/api/admin/impact-lab/judging/preview/route.ts`
+- Modify: `src/components/admin/impact-lab/JudgesTab.tsx`
+
+**Interfaces:**
+- Consumes: `standings` from `@/lib/impact-lab/judging`; the placeholder div from Task 4.
+- Produces: `POST /api/admin/impact-lab/judging/preview` accepting `{cohort?: string, exclude: string[]}` (judge emails) and returning `{success: true, data: {rows: PreviewRow[], orphaned: string[]}}` where
+  `interface PreviewRow { teamId: string; teamName: string; projectName: string | null; baseRank: number; previewRank: number | null; baseAverage: number; previewAverage: number | null; move: number | null }`
+
+- [ ] **Step 1: Write the route**
+
+Create `src/app/api/admin/impact-lab/judging/preview/route.ts`. It must:
+
+- Guard with `withCsrfProtection` then `checkApiPermission("impact-lab", "view")`.
+- Parse the body with `z.object({ cohort: z.string().optional(), exclude: z.array(z.string().min(1).max(200)).max(20) })`.
+- Load all scores for the final run once.
+- Compute `standings()` twice — once over every score, once over scores whose `judgeEmail` is not in `exclude`.
+- Return one row per team in the base standings, with `previewRank`/`previewAverage` `null` when excluding leaves that team with no scores at all, and list those team names in `orphaned`.
+- Never write anything.
+
+Open the file with this comment so its role cannot be misread later:
+
+```ts
+/**
+ * What-if standings with judges excluded. READ ONLY, and deliberately so.
+ *
+ * The panel's announced result already overrides the arithmetic, so this
+ * cannot change any published placing — it exists to let an organiser
+ * understand a result, never to search for one they prefer. There is no write
+ * path from here to resultsSnapshot, and adding one would turn a transparency
+ * tool into a dial for shopping outcomes.
+ */
+```
+
+- [ ] **Step 2: Build the preview UI**
+
+In `JudgesTab.tsx`, replace the placeholder from Task 4 with a checkbox per judge and a results table showing base rank and preview rank side by side, with the movement arrow and delta.
+
+Two things the UI must state plainly, as visible text not comments:
+- A banner: *"Preview only. This cannot change published results."*
+- When `orphaned` is non-empty: *"Excluding these judges would leave N teams with no scores at all: …"* in the amber token (`--amber`), not the red one — it is a warning, not an error.
+
+- [ ] **Step 3: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 4: Verify against real data**
+
+With `npm run dev` running, tick **Savannah** in the Judges tab.
+
+Expected: BiasharaGPT moves above Whatsy (78.3 vs 76.9). Tick **Savannah and Mercy** together: ReferNet rises to the top on 81.9. If neither happens, the exclusion filter is not reaching `standings()`.
+
+- [ ] **Step 5: Confirm the route cannot write**
+
+Run: `grep -n "prisma\.\(impactLab\)\?[A-Za-z]*\.\(update\|create\|upsert\|delete\)" src/app/api/admin/impact-lab/judging/preview/route.ts`
+Expected: no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/admin/impact-lab/judging/preview/ src/components/admin/impact-lab/JudgesTab.tsx
+git commit -m "feat(impact-lab): judge exclusion preview, read-only"
+```
+
+---
+
+### Task 6: Submission-only scoring for unjudged teams
+
+**Files:**
+- Create: `src/app/api/admin/impact-lab/judging/writeup/route.ts`
+- Create: `src/components/admin/impact-lab/ResultsTab.tsx`
+- Modify: `src/components/admin/impact-lab/ImpactLabDashboard.tsx`
+
+**Interfaces:**
+- Consumes: `JUDGING_CRITERIA`, `MIN_SCORE`, `MAX_SCORE` from `@/lib/impact-lab/judging`; the `generateObject` + `createAnthropic` pattern already used in `src/app/api/admin/impact-lab/judging/assist/route.ts`.
+- Produces:
+  - `GET  /api/admin/impact-lab/judging/writeup?cohort=…` → `{success: true, data: {teams: {teamId, teamName, projectName, submission: Record<string,string>}[]}}` — submitted teams with no score.
+  - `POST /api/admin/impact-lab/judging/writeup` with `{teamId, action: "draft"}` → `{success: true, data: {scores: Record<string, number>, reasoning: Record<string, string>}}`
+  - `POST /api/admin/impact-lab/judging/writeup` with `{teamId, action: "save", scores: Record<string, number>}` → `{success: true, data: {saved: true}}`
+
+- [ ] **Step 1: Write the route**
+
+Create `src/app/api/admin/impact-lab/judging/writeup/route.ts`.
+
+Header comment:
+
+```ts
+/**
+ * Scoring a team from its written submission, for teams the panel did not see
+ * demo. Four teams submitted and were never scored; without this they would be
+ * published with no result at all.
+ *
+ * Claude drafts, a human decides. Nothing is written until an organiser posts
+ * `action: "save"` with the numbers they accepted, and the row is stored as an
+ * organiser review rather than attributed to a judge who never saw the work.
+ *
+ * The demo criterion is 25% of the weight and asks whether it ran in front of
+ * you. No demo was seen, so the draft says so plainly instead of guessing, and
+ * `writeupOnly` travels with the score wherever it is displayed.
+ */
+export const maxDuration = 60
+```
+
+Requirements:
+- Guard: `withCsrfProtection` → `checkApiPermission("impact-lab", "edit")` (use the same action string the other write routes in this directory use — check `grep -n "checkApiPermission" src/app/api/admin/impact-lab/judging/route.ts` and match it).
+- Refuse both actions with 409 when `run.judgingClosedAt` is set.
+- `draft` calls `generateObject` with model `"claude-sonnet-5"` and a schema of `{scores: {impact, demo, claude, clarity, presentation}, reasoning: {…same keys…}}`, each score `z.number().int().min(1).max(5)`. System prompt must instruct: score only what the submission evidences; for the demo criterion, state that no live demo was seen and score only what the writeup demonstrates about working software; never inflate to be kind.
+- `draft` writes nothing to the database.
+- `save` validates every criterion key is present and within `MIN_SCORE`–`MAX_SCORE`, then upserts on `(runId, teamId, judgeEmail)` with `judgeEmail: "organiser:" + <session email>`, `judgeName: "Organiser review"`, `writeupOnly: true`.
+
+- [ ] **Step 2: Build the review UI**
+
+Create `src/components/admin/impact-lab/ResultsTab.tsx` with a first section "Teams awaiting a score". For each: the full submission, a **Draft with Claude** button, then five editable number inputs pre-filled from the draft with the reasoning shown beside each, and a **Save** button.
+
+The save button must be disabled until every criterion has a value. A visible line above the inputs reads: *"Claude drafts. You decide. Nothing is saved until you press Save."*
+
+Register the tab in `ImpactLabDashboard.tsx` the same way as Task 4 — extend the `Tab` union with `| "results"`, add the label `Results`, render `<ResultsTab cohort={cohort} />`.
+
+- [ ] **Step 3: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 4: Verify against real data**
+
+With `npm run dev` running, open the **Results** tab.
+
+Expected: exactly four teams listed — kilimoeco (Table 15), OnlyFarmers (27), ChatBook (30), Biashara (32). Draft one. Confirm the demo reasoning explicitly says no live demo was seen. Do **not** save yet unless the organiser has reviewed it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/admin/impact-lab/judging/writeup/ src/components/admin/impact-lab/ResultsTab.tsx src/components/admin/impact-lab/ImpactLabDashboard.tsx
+git commit -m "feat(impact-lab): submission-only scoring for unjudged teams"
+```
+
+---
+
+### Task 7: Publish
+
+**Files:**
+- Create: `src/app/api/admin/impact-lab/results/publish/route.ts`
+- Modify: `src/components/admin/impact-lab/ResultsTab.tsx`
+
+**Interfaces:**
+- Consumes: `buildSnapshot`, `ResultsInput` from Task 2; `standings`, `weightedTotal` from `@/lib/impact-lab/judging`.
+- Produces: `POST /api/admin/impact-lab/results/publish` with `{cohort?: string, announcedTeamIds: string[], confirm: string}` → `{success: true, data: {publishedAt: string, recipients: number}}`.
+
+- [ ] **Step 1: Write the route**
+
+Create `src/app/api/admin/impact-lab/results/publish/route.ts`.
+
+Header comment:
+
+```ts
+/**
+ * Mark final. A one-way door.
+ *
+ * Closes submissions and judging, computes the snapshot, and queues one row per
+ * recipient — all inside one row-locked transaction, so a second click cannot
+ * publish twice or queue a second set of emails.
+ *
+ * Everything participants see afterwards is served from the stored snapshot and
+ * never recomputed. This matters concretely: one team edited its submission a
+ * full day after being judged, so live data demonstrably moves after the fact.
+ * What 93 people are told must not move with it.
+ */
+```
+
+Requirements, in order inside `prisma.$transaction`:
+
+1. `await tx.$queryRaw\`SELECT id FROM impact_lab_match_runs WHERE id = ${run.id} FOR UPDATE\`` — the same row-locking pattern used by the roster and leader routes.
+2. Refuse with 409 if `resultsPublishedAt` is already set.
+3. Refuse with 409 if any team with a submission has no `ImpactLabScore` row, naming them. This is what stops the four unscored teams being published as blanks.
+4. Refuse with 400 if `announcedTeamIds` contains an id not present in the run's teams, or has duplicates.
+5. Build `ResultsInput`: `standings()` over all scores; `teams` from the run JSON with `track` via `trackOf(team.name)` and `projectName` from the submission; `writeupOnly` from score rows where every row for that team has `writeupOnly: true`; `range` from min and max `weightedTotal` per team.
+6. Update the run: `submissionsCloseAt` (only if currently null), `judgingClosedAt`, `resultsPublishedAt`, `announcedWinners`, `resultsSnapshot`.
+7. `createMany` one `ImpactLabResultsEmail` per recipient with `skipDuplicates: true`. Recipients are participants whose id appears in `memberIds` of a team that has a submission — the 93.
+
+Require `confirm === "PUBLISH"` in the body before any of this runs; a typed confirmation is cheap insurance on a one-way door.
+
+- [ ] **Step 2: Add the publish panel**
+
+In `ResultsTab.tsx`, add a second section below the writeup review:
+
+- A preview of exactly what will be published: the three announced winners, the five track winners, and the full ranking by position only — no scores, matching what participants will see.
+- The recipient count.
+- A text input requiring the word `PUBLISH`.
+- The button, disabled while any submitted team still lacks a score, with the reason shown.
+- Once published: the panel switches to a summary showing the publish time and the recipient count, with the button gone.
+
+- [ ] **Step 3: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 4: Verify the refusals before verifying success**
+
+With `npm run dev` running and **before** the four teams are scored, attempt to publish.
+Expected: 409, naming kilimoeco, OnlyFarmers, ChatBook and Biashara. Do not proceed past this until that refusal works — it is the guard that prevents publishing blanks.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/admin/impact-lab/results/ src/components/admin/impact-lab/ResultsTab.tsx
+git commit -m "feat(impact-lab): publish results with lock and snapshot"
+```
+
+---
+
+### Task 8: Participant results view
+
+**Files:**
+- Create: `src/app/api/impact-lab/results/route.ts`
+- Create: `src/app/dashboard/impact-lab/ResultsView.tsx`
+- Modify: `src/app/dashboard/impact-lab/ImpactLabClient.tsx`
+
+**Interfaces:**
+- Consumes: `checkMemberAccess` from `@/lib/impact-lab/member`; `ResultsSnapshot` from Task 2.
+- Produces: `GET /api/impact-lab/results` → flat member shape
+  `{success: true, published: boolean, results?: {publishedAt, overall, trackWinners, ranking}, yourTeam?: {teamId, projectName, card: TeamCard}}`
+
+- [ ] **Step 1: Write the route**
+
+Create `src/app/api/impact-lab/results/route.ts`. Guard order: rate limit → `checkMemberAccess()`. No CSRF — it is a GET.
+
+It must:
+- Return `{success: true, published: false}` when `resultsPublishedAt` is null. Never leak an unpublished snapshot.
+- Read `resultsSnapshot` and serve `overall`, `trackWinners` and `ranking` as stored.
+- Find the caller's participant row by lowercased email, find which team's `memberIds` contains that id, and attach **only that team's** entry from `perTeam`.
+- **Never send the whole `perTeam` map.** Strip it explicitly rather than relying on the shape.
+
+Add this above the handler:
+
+```ts
+/**
+ * The published result, for one participant.
+ *
+ * `perTeam` holds every team's private card, so the whole map must never reach
+ * the client — only the caller's own entry is attached. Judge counts and judge
+ * identities are absent from the snapshot by construction, so there is nothing
+ * to strip there.
+ */
+```
+
+- [ ] **Step 2: Assert the payload is minimal**
+
+Add to `scripts/verify-results.ts`, before the final summary:
+
+```ts
+console.log("\nMember payload")
+// Mirrors what the member route attaches: one card, never the map.
+const memberPayload = {
+  results: {
+    publishedAt: snap.publishedAt,
+    overall: snap.overall,
+    trackWinners: snap.trackWinners,
+    ranking: snap.ranking,
+  },
+  yourTeam: { teamId: "t-vilcare", card: snap.perTeam["t-vilcare"] },
+}
+const memberJson = JSON.stringify(memberPayload)
+assert(!memberJson.includes("perTeam"), "the member payload never carries the perTeam map")
+assert(
+  !memberJson.includes("t-whatsy\":{"),
+  "the member payload never carries another team's card"
+)
+assert(!memberJson.includes("judgeCount"), "the member payload never carries a judge count")
+```
+
+Run: `npm run verify:results`
+Expected: `ALL CHECKS PASSED`.
+
+- [ ] **Step 3: Build the view**
+
+Create `src/app/dashboard/impact-lab/ResultsView.tsx`, following `TeamReveal.tsx` for persona handling and motion conventions.
+
+Four sections in order:
+
+1. **Winners** — champion largest, then 2nd and 3rd, then the five track winners. Real hierarchy, not a bulleted list.
+2. **Your team** — the five criterion scores as filled meters against the 1–5 scale, the range across judges, your position. For a `basis: "submission"` team, show exactly this copy and nothing that implies fault or apology:
+
+   > Your project was reviewed from your written submission against the same five criteria. A live demo was not part of that review, which is noted against the demo criterion below.
+
+3. **Full ranking** — position, project, track. **No numeric scores. No judge counts.** The viewer's own row is visually marked so they can find themselves. Wrap the table in its own `overflow-x-auto` container so the page body never scrolls sideways at 320px.
+4. **The note** — verbatim from the spec's "The note, in full" section. Copy it exactly; do not paraphrase.
+
+- [ ] **Step 4: Wire the phase**
+
+In `ImpactLabClient.tsx`:
+- Extend the `Phase` union on line 37 with `| "results"`.
+- Add `fetch("/api/impact-lab/results")` to the existing `Promise.all` in the effect.
+- When the response has `published: true`, set phase to `results` — it takes precedence over `revealed`.
+- Render `<ResultsView … />` for that phase.
+
+The effect's dependency array is `[reloadKey]`; leave that alone.
+
+- [ ] **Step 5: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 6: Verify what a participant actually receives**
+
+With `npm run dev` running and results published locally, sign in as a member of a scored team and run in the browser console:
+
+```js
+fetch("/api/impact-lab/results").then(r => r.json()).then(d => {
+  const s = JSON.stringify(d)
+  console.log("perTeam leaked:", s.includes("perTeam"))
+  console.log("judgeCount leaked:", s.includes("judgeCount"))
+  console.log("judge identity leaked:", /judge(Name|Email)/.test(s))
+  console.log("teams with cards:", d.yourTeam ? 1 : 0)
+})
+```
+
+Expected: three `false` and `1`. Any `true` is a privacy defect — stop and fix before continuing.
+
+Then check the page at 320px width: no horizontal scroll on the body, and the ranking scrolls inside its own container.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/api/impact-lab/results/ src/app/dashboard/impact-lab/ResultsView.tsx src/app/dashboard/impact-lab/ImpactLabClient.tsx scripts/verify-results.ts
+git commit -m "feat(impact-lab): participant results view"
+```
+
+---
+
+### Task 9: The results email
+
+**Files:**
+- Modify: `src/lib/email.ts`
+- Create: `src/app/api/admin/impact-lab/results/notify/route.ts`
+- Modify: `src/components/admin/impact-lab/ResultsTab.tsx`
+
+**Interfaces:**
+- Consumes: `ImpactLabResultsEmail` from Task 1; the published snapshot from Task 7.
+- Produces:
+  - `export async function sendEmailBatchTracked(items: BatchEmailItem[]): Promise<{to: string; ok: boolean; error?: string}[]>`
+  - `export function impactLabResultsEmail(data: {…}): {subject: string; html: string}`
+  - `POST /api/admin/impact-lab/results/notify` with `{cohort?: string}` → `{success: true, data: {sent: number, failed: number, remaining: number}}`
+
+- [ ] **Step 1: Add the tracked batch sender**
+
+In `src/lib/email.ts`, after the existing `sendEmailBatch`:
+
+```ts
+/**
+ * Batch send that reports per recipient rather than per chunk.
+ *
+ * `sendEmailBatch` returns only totals, which is not enough to record who was
+ * actually reached — and without that, a retry re-sends to everyone. Resend's
+ * quota is 100/day against 93 recipients, so a blind retry blows the quota and
+ * double-mails the people it already reached.
+ *
+ * Chunks of 25 rather than the API ceiling of 100: if a chunk is rejected we
+ * can only mark that chunk failed, so a smaller chunk loses less certainty.
+ */
+export async function sendEmailBatchTracked(
+  items: BatchEmailItem[]
+): Promise<{ to: string; ok: boolean; error?: string }[]> {
+  if (items.length === 0) return []
+
+  if (!process.env.RESEND_API_KEY) {
+    console.warn("[EMAIL] RESEND_API_KEY not configured, batch not sent")
+    return items.map((item) => ({
+      to: item.to,
+      ok: false,
+      error: "RESEND_API_KEY not configured",
+    }))
+  }
+
+  const from = `${EMAIL_FROM_NAME} <${EMAIL_FROM}>`
+  const results: { to: string; ok: boolean; error?: string }[] = []
+
+  for (let i = 0; i < items.length; i += 25) {
+    const chunk = items.slice(i, i + 25)
+    try {
+      const { error } = await getResend().batch.send(
+        chunk.map((item) => ({
+          from,
+          to: [item.to],
+          subject: item.subject,
+          html: item.html,
+          text: stripHtml(item.html),
+        }))
+      )
+      const message = error ? error.message : undefined
+      for (const item of chunk) {
+        results.push({ to: item.to, ok: !error, error: message })
+      }
+      if (error) console.error("[EMAIL] Batch chunk rejected:", error)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown send failure"
+      console.error("[EMAIL] Batch chunk failed:", err)
+      for (const item of chunk) results.push({ to: item.to, ok: false, error: message })
+    }
+  }
+
+  return results
+}
+```
+
+- [ ] **Step 2: Add the template**
+
+In `src/lib/email.ts`, next to `impactLabAccountEmail`, add `impactLabResultsEmail` taking `{fullName, projectName, rank, criterionAverages, low, high, basis, overall, trackWinners, dashboardUrl}` and returning `{subject, html}`.
+
+Content requirements:
+- The three overall winners and the five track winners.
+- The recipient team's own five scores and its position.
+- The short form of the note.
+- A link to the dashboard.
+- For `basis: "submission"`, the submission-review sentence from the spec.
+
+Constraints: table-based HTML with inline styles (email clients ignore `<style>` blocks and Tailwind entirely — this is the one place inline styles are correct), no web fonts, no external images, readable on a dark background. **No judge counts. No deadline language.** The email must stand alone, because nine recipients have no account and cannot open the dashboard.
+
+- [ ] **Step 3: Write the notify route**
+
+Create `src/app/api/admin/impact-lab/results/notify/route.ts`.
+
+```ts
+/**
+ * Send the results email, resumably.
+ *
+ * Processes at most BATCH_SIZE unsent recipients per call and reports how many
+ * remain; the admin UI calls it until zero. That keeps each invocation inside
+ * the function timeout and makes a timeout harmless — the next call picks up
+ * exactly where this one stopped, because progress lives in the database rather
+ * than in the request.
+ *
+ * Only rows with status <> 'sent' are selected, so no recipient is ever mailed
+ * twice however many times this is called.
+ */
+export const maxDuration = 300
+
+const BATCH_SIZE = 25
+```
+
+Requirements:
+- Guard: `withCsrfProtection` → `checkApiPermission("impact-lab", "edit")`.
+- Refuse with 409 if `resultsPublishedAt` is null — nothing may be sent before it is published.
+- Select up to `BATCH_SIZE` rows where `runId` matches and `status !== "sent"`.
+- Build each email from the stored snapshot, never from live data.
+- Call `sendEmailBatchTracked`, then update each row to `sent` with `sentAt`, or `failed` with the error.
+- Return `{sent, failed, remaining}` where `remaining` counts rows still not `sent`.
+
+- [ ] **Step 4: Add the send panel**
+
+In `ResultsTab.tsx`, add a third section, visible only once published:
+
+- Counts: queued, sent, failed.
+- A **Send next 25** button that calls the route and refreshes the counts.
+- A **Send to one address first** input that sends a single test before the batch.
+- A visible warning: *"Resend allows 100 emails per day. There are 93 recipients — one clean run fits, a repeated run does not."*
+
+- [ ] **Step 5: Typecheck and build**
+
+Run: `npx tsc --noEmit && npm run build`
+Expected: both clean.
+
+- [ ] **Step 6: Verify idempotency without sending**
+
+Temporarily unset `RESEND_API_KEY` in `.env.local` and restart the dev server. `sendEmailBatchTracked` now returns every item as failed without contacting Resend.
+
+Press **Send next 25**. Expected: `sent: 0, failed: 25`, and 25 rows at `status: "failed"`.
+
+Press it again. Expected: it retries those same 25 — failed rows are eligible — and does not touch the other 68.
+
+Now set one row to `sent` by hand in a scratch database and press again. Expected: that row is skipped and `remaining` drops by one.
+
+Restore `RESEND_API_KEY` afterwards.
+
+- [ ] **Step 7: Send one real test before any batch**
+
+With `RESEND_API_KEY` restored, use **Send to one address first** to mail yourself. Read it on a phone and on desktop, in both light and dark mode. Confirm: winners correct, your team's scores correct, no judge counts, no deadline language, the dashboard link resolves, and the plain-text alternative is readable.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/email.ts src/app/api/admin/impact-lab/results/notify/ src/components/admin/impact-lab/ResultsTab.tsx
+git commit -m "feat(impact-lab): results email with resumable idempotent send"
+```
+
+---
+
+### Task 10: Full-path verification before production
+
+**Files:** none created — this is the gate before the migration reaches production.
+
+- [ ] **Step 1: Run every check**
+
+```bash
+npm run verify:judging && npm run verify:results && npx tsc --noEmit && npm run build && npx eslint src --max-warnings 0
+```
+
+Expected: all five clean. Do not continue past any failure.
+
+- [ ] **Step 2: Walk the whole path locally**
+
+Against a scratch database seeded from a production dump — never against production:
+
+1. Judges tab shows four judges with means spanning roughly 48 to 72.
+2. Exclusion preview moves BiasharaGPT above Whatsy when Savannah is excluded, and writes nothing.
+3. Results tab lists exactly four unscored teams; draft and save one.
+4. Publish is refused while three remain unscored, naming them.
+5. Score the remaining three, then publish. Verify `resultsPublishedAt`, `judgingClosedAt` and `submissionsCloseAt` are all set and `resultsSnapshot` is populated.
+6. Attempt a score write via the judging POST. Expected: 409 `JUDGING_CLOSED`.
+7. Attempt to publish again. Expected: 409.
+8. Sign in as a member of a scored team, a member of a submission-reviewed team, and a participant on a team that never submitted. Confirm each sees the right thing and no one sees another team's card.
+9. Confirm the ranking shows no numeric scores and no judge counts.
+
+- [ ] **Step 3: Confirm the target database before migrating**
+
+Run: `npx prisma migrate status`
+
+Confirm from the output which database you are pointed at. A local `.env` has previously pointed at a stale Supabase instance rather than the production VPS; migrating the wrong database is the failure mode this step exists to prevent. If there is any doubt, stop and ask.
+
+- [ ] **Step 4: Apply to production and verify**
+
+Only after Step 3 is unambiguous, apply the migration to production, then verify the three new columns and the new table exist before any publish is attempted from the live admin panel.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(impact-lab): address issues found in full-path verification"
+```
+
+Note: `scripts/output/` is gitignored and must stay that way — it has previously held participant names and database ids, and this is a public repository. Run `git status` before `git add -A` and confirm nothing under `scripts/output/` or any CSV of participant data is staged.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Every section of the spec maps to a task — schema to 1, computation to 2, judging lock to 3, judge audit to 4, exclusion preview to 5, writeup scoring to 6, publish to 7, participant view and copy to 8, email to 9, verification to 10.
+
+**Two spec items deliberately reshaped during planning, both recorded here rather than silently dropped:**
+
+1. The spec says per-recipient status is written "from the per-row result". `sendEmailBatch` returns only `{sent, failed}`, so that was not achievable as written. Task 9 adds `sendEmailBatchTracked` with 25-item chunks and per-recipient results.
+2. The spec's snapshot had a `table` field with an `unscored` flag. Renamed to `ranking`, and `unscored` removed — publish refuses while any submitted team lacks a score, so the state cannot occur.
+
+**Out of scope and unchanged:** score normalisation, automatic track winners from `trackWinners()` alone, any write path from exclusion preview to published output, and unsubscribe infrastructure — the last is a real gap, recorded in the spec, and should be built before any future cohort mailing.

--- a/docs/superpowers/plans/2026-07-27-impact-lab-results-publication.md
+++ b/docs/superpowers/plans/2026-07-27-impact-lab-results-publication.md
@@ -1061,7 +1061,7 @@ Create `src/app/api/impact-lab/results/route.ts`. Guard order: rate limit → `c
 
 It must:
 - Return `{success: true, published: false}` when `resultsPublishedAt` is null. Never leak an unpublished snapshot.
-- Read `resultsSnapshot` and serve `overall`, `trackWinners` and `ranking` as stored.
+- Read `resultsSnapshot`. Serve `overall` and `trackWinners` as stored, but pass `ranking` through `toPublicRanking()` from `@/lib/impact-lab/results` first — the stored ranking carries `average` on every row, and shipping it would let anyone with devtools open read every team's score off a page that deliberately shows none. Not rendering it is not the same as not sending it.
 - Find the caller's participant row by lowercased email, find which team's `memberIds` contains that id, and attach **only that team's** entry from `perTeam`.
 - **Never send the whole `perTeam` map.** Strip it explicitly rather than relying on the shape.
 
@@ -1090,12 +1090,16 @@ const memberPayload = {
     publishedAt: snap.publishedAt,
     overall: snap.overall,
     trackWinners: snap.trackWinners,
-    ranking: snap.ranking,
+    ranking: toPublicRanking(snap.ranking),
   },
   yourTeam: { teamId: "t-vilcare", card: snap.perTeam["t-vilcare"] },
 }
 const memberJson = JSON.stringify(memberPayload)
 assert(!memberJson.includes("perTeam"), "the member payload never carries the perTeam map")
+assert(
+  !memberJson.includes("average"),
+  "the member payload never carries another team's score — not rendering it is not the same as not sending it"
+)
 assert(
   !memberJson.includes("t-whatsy\":{"),
   "the member payload never carries another team's card"

--- a/docs/superpowers/specs/2026-07-27-impact-lab-results-publication-design.md
+++ b/docs/superpowers/specs/2026-07-27-impact-lab-results-publication-design.md
@@ -54,7 +54,8 @@ deadline was ever recorded.
 | Decision | Choice |
 |---|---|
 | Audience | 93 people on teams that submitted |
-| Published result | Announced winners + full score table |
+| Published result | Announced winners at 1–3, every other team ranked below by score |
+| Every submission | Reviewed and ranked — no team is published without a result |
 | Track winners | Announced winners lead their tracks; rest by top score |
 | Own breakdown | Private to that team |
 | Judge counts | Never shown to participants |
@@ -86,17 +87,20 @@ The rule stated on the page: *the overall winners lead their tracks; the
 remaining tracks went to the highest-scoring team.* Oryn is Biashara, which
 BiasharaGPT takes as champion, so Oryn stands on its overall placing.
 
-### Known cost of these choices
+### The ranking
 
-Recorded so the tradeoff is deliberate rather than discovered later:
+The announced winners hold positions 1, 2 and 3. Every other team that
+submitted is ranked from 4th downward by score. The raw portal order is not
+published as a competing table.
 
-- **Whatsy tops the score table at 76.9 and receives no prize.** It will be
-  visible on the same page that names the winners.
-- **VilCare is announced 2nd and sits 18th on scores.** The explanatory note
-  carries this.
+This was chosen over publishing the raw table alongside the winners, and it
+removes two problems that choice carried: Whatsy would have topped a published
+table at 76.9 while winning nothing, and VilCare would have appeared 18th under
+a banner announcing it 2nd. Neither now occurs. Whatsy is 4th — its true
+standing among the teams not already placed.
 
-Both follow from publishing a deliberated result alongside the raw table. The
-note is load-bearing copy, not decoration — it is specified in full below.
+Every team that submitted appears. None is omitted, and none is published
+without a result.
 
 ## Architecture
 
@@ -154,26 +158,31 @@ interface ResultsSnapshot {
   publishedAt: string
   overall: { rank: number; teamId: string; projectName: string }[]
   trackWinners: { track: string; teamId: string; projectName: string; basis: "announced" | "score" }[]
-  table: {
-    rank: number
+  ranking: {
+    rank: number            // 1-3 are the announced winners, then by score
     teamId: string
     projectName: string
     track: string
     average: number
-    writeupOnly: boolean
+    basis: "announced" | "demo" | "submission"
   }[]
   perTeam: Record<string, {
+    rank: number
     criterionAverages: Record<string, number>
     low: number
     high: number
-    writeupOnly: boolean
-    unscored: boolean
+    basis: "demo" | "submission"
   }>
 }
 ```
 
+`ranking` is built by placing the three announced winners at 1–3 in the order
+announced, then every remaining submitted team by average descending, ties
+broken by teamId so the order is deterministic across loads.
+
 `perTeam` is keyed by team and served only to that team's members. Judge counts
-are absent by design.
+are absent by design. There is no `unscored` state — publish refuses while any
+submitted team lacks a score, so it cannot occur.
 
 ### Routes
 
@@ -244,39 +253,56 @@ state and its only effect depends on `[reloadKey]`, so both need extending.
 Sections, in order:
 
 1. **Winners** — champion and 2nd/3rd, then the five track winners.
-2. **Your team** — five criterion scores, the range across judges, the
-   submission as filed. Private. Unscored teams get the honest message instead.
-3. **Full table** — every team by score, writeup-only marked. No judge counts.
-4. **The note** — why the table and the winners differ.
+2. **Your team** — five criterion scores, the range across judges, your placing,
+   the submission as filed. Private to that team.
+3. **Full ranking** — announced winners at 1–3, every other team below by score.
+   **Position, project and track only — no numeric scores, no judge counts.**
+
+   Scores order the list; they are not printed in it. Printing them would put
+   Whatsy at 4th on 76.9 directly above BiasharaGPT at 1st on 75.3, which
+   restates the contradiction this ranking was chosen to remove. A team's own
+   numbers stay on its own private card, where they are useful feedback rather
+   than an invitation to audit the placings.
+4. **The note** — how results were decided.
 
 ### The note, in full
 
 > **How these results were decided**
 >
-> Winners were chosen by the judging panel after they had seen every demo and
-> discussed the projects together. That conversation is what the placings
-> reflect.
+> Every project that was submitted has been reviewed against the same five
+> criteria and ranked. Where the panel saw a live demo, their scores are the
+> ones shown. Where a team submitted but the panel did not see it presented,
+> the project was reviewed from the written submission instead.
 >
-> The table below is the raw scoring data from the judging portal, published in
-> full. It will not always match the placings, and that is expected — teams were
-> seen by different judges, judges scored on different scales, and the panel
-> weighed things a score sheet does not capture.
+> The top three were decided by the judging panel after they had seen the demos
+> and discussed the projects together. That conversation is what those placings
+> reflect. Every other team is ranked below them on score.
 >
-> We are publishing both because you are entitled to see how your work was
-> assessed, including where the numbers and the decision disagree.
+> Scores are shown in full because you are entitled to see how your own work was
+> assessed.
 
 Plain English, no Swahili in participant-facing copy (existing project rule).
 
-### Unscored teams
+**Copy rules, explicit:**
 
-> Your submission was received at 01:29 and is on record.
->
-> Judging closed before the panel reached your table. That was our scheduling,
-> not a reflection of your work, and we are sorry.
->
-> Your project has since been reviewed against the same five criteria from your
-> written submission. Because there was no live demo, it is marked as a
-> submission-only review.
+- No mention of a deadline, cut-off, time cap, or late submission anywhere.
+  None was recorded, and the timestamps do not support one.
+- No suggestion that a team failed to present, left early, or was missed. Some
+  teams did not demo; the results do not comment on why.
+- No apology framing that implies a team was let down, and none that implies a
+  team was at fault. The neutral fact — reviewed from the written submission —
+  is the whole story told.
+
+### Teams reviewed from submission
+
+Shown on that team's own card only. Neutral, not apologetic, not accusatory:
+
+> Your project was reviewed from your written submission against the same five
+> criteria. A live demo was not part of that review, which is noted against the
+> demo criterion below.
+
+Marked `Reviewed from submission` wherever the team appears in the ranking, so
+the basis of the score is never hidden — but stated as a method, not a failing.
 
 ## Email
 
@@ -317,13 +343,20 @@ than introducing a framework.
 
 New assertions in `scripts/verify-results.ts`:
 
-- A writeup-only score is included in the average and flagged in output
+- The three announced winners occupy ranks 1, 2 and 3 in the announced order,
+  regardless of their scores
+- Every team that submitted appears in the ranking exactly once
+- A team scoring higher than an announced winner still ranks below it — Whatsy
+  at 76.9 ranks 4th, not 1st
+- A submission-reviewed score is included in the average and carries
+  `basis: "submission"`
 - Track winners: announced winners take their own track; remaining tracks go to
   top score; a track with no scored team yields no winner
 - Snapshot is byte-stable across two computations from identical input
 - `perTeam` never contains a judge count
 - A second notify sends to nobody when all rows are `sent`
 - Publishing twice is refused
+- Publish is refused while any submitted team has no score
 - Score writes are refused once `judgingClosedAt` is set
 
 Manual gate before the send: publish to a snapshot, read the dashboard as a
@@ -347,8 +380,7 @@ send to one address before the batch.
 
 | Risk | Mitigation |
 |---|---|
-| Whatsy tops the table and wins nothing | Accepted deliberately; the note explains the method |
-| VilCare announced 2nd, 18th on scores | Same |
+| A team outscores an announced winner and notices | Ranking places announced winners at 1–3; scores shown are that team's own, so the comparison is not put in front of them |
 | Resend quota 100/day vs 93 recipients | Per-recipient rows; retry only unsent |
 | Favour never replies | Nothing in this spec is blocked on her |
 | Snapshot drifts from live data | Snapshot is what is served; live data is not consulted after publish |

--- a/docs/superpowers/specs/2026-07-27-impact-lab-results-publication-design.md
+++ b/docs/superpowers/specs/2026-07-27-impact-lab-results-publication-design.md
@@ -1,0 +1,355 @@
+# Impact Lab — results publication
+
+**Date:** 2026-07-27
+**Status:** approved, ready for implementation plan
+**Cohort:** `impact-lab-2026-07` (Impact Lab: AI Mashinani, 25–26 July 2026)
+
+## Why this exists
+
+The hackathon is over. Winners were announced live on 26 July. 93 builders have
+heard nothing since, and the judging data is sitting in a table nobody but an
+organiser can read.
+
+This spec covers publishing that result: what participants see, what admin can
+inspect, and the one-way door that stops the record moving afterwards.
+
+## The situation this is being built into
+
+These are measured facts from production, not assumptions. They drive most of
+the decisions below.
+
+| Fact | Number |
+|---|---|
+| Registered | 136 |
+| Self checked-in | 62 |
+| Placed on a team (door list) | 109 |
+| On a team that submitted | **93** |
+| Teams in the final run | 37 |
+| Teams that submitted | 27 |
+| Teams with any score | 23 |
+| Score sheets | 73 |
+| Sheets missing a criterion | **0** |
+
+**Judges were never calibrated.** Mean score given: Favour 72.2, Cynthia Njagi
+66.7, Savannah 54.2, Mercy 48.3 — a 24-point spread. On VilCare the four scores
+run 18.8 to 88.8. Teams were seen by two to four judges each, so which judges
+walked a row affects a team's average more than small differences in the work.
+
+**The announced result does not match the scores.** The panel deliberated and
+announced BiasharaGPT, VilCare, Oryn. On raw portal averages the order is
+Whatsy 76.9, BiasharaGPT 75.3, KeyOSk 73.8, Oryn 73.3, with VilCare at 55.3.
+No combination of judge exclusions reproduces the announced order.
+
+**Four teams submitted and were never scored** — kilimoeco (Table 15),
+OnlyFarmers (27), ChatBook (30), Biashara (32). They submitted 01:29–01:34;
+judging began 01:51 and teams submitting at the same time or later were scored.
+There is no evidence they were late: `submissionsCloseAt` is null and no
+deadline was ever recorded.
+
+**Submissions never closed.** Whatsy edited at 17:34 on the 26th and Oryn at
+02:23 on the 27th, both after being judged.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Audience | 93 people on teams that submitted |
+| Published result | Announced winners + full score table |
+| Track winners | Announced winners lead their tracks; rest by top score |
+| Own breakdown | Private to that team |
+| Judge counts | Never shown to participants |
+| Judge exclusion | Admin diagnostic only — cannot reach published output |
+| The four unscored teams | Claude drafts, organiser approves, marked writeup-only |
+| Mark final | Locks submissions and judging, snapshots the table |
+| The nine without accounts | Email carries the result in its body |
+
+### Winners
+
+Overall, exactly as announced in the room — stored verbatim, never recomputed:
+
+1. BiasharaGPT · 2. VilCare · 3. Oryn
+
+Track winners:
+
+| Track | Winner | Basis |
+|---|---|---|
+| Afya (Health) | VilCare | announced 2nd overall |
+| Biashara (Small Business) | BiasharaGPT | announced champion |
+| Elimu (Education) | NIA | top score, 72.5 |
+| Huduma (Government Services) | Meridian Global Investor OS | top score, 63.8 |
+| Kilimo (Agriculture) | Elewa | top score, 70.0 — **provisional** |
+
+Kilimo is provisional because kilimoeco is a Kilimo team and unscored. Track
+winners are computed only after the four writeup scores are approved.
+
+The rule stated on the page: *the overall winners lead their tracks; the
+remaining tracks went to the highest-scoring team.* Oryn is Biashara, which
+BiasharaGPT takes as champion, so Oryn stands on its overall placing.
+
+### Known cost of these choices
+
+Recorded so the tradeoff is deliberate rather than discovered later:
+
+- **Whatsy tops the score table at 76.9 and receives no prize.** It will be
+  visible on the same page that names the winners.
+- **VilCare is announced 2nd and sits 18th on scores.** The explanatory note
+  carries this.
+
+Both follow from publishing a deliberated result alongside the raw table. The
+note is load-bearing copy, not decoration — it is specified in full below.
+
+## Architecture
+
+### Data model
+
+Teams have no table; they live in `ImpactLabMatchRun.result` JSON. Scores key
+off `(runId, teamId, judgeEmail)`. Nothing here changes that.
+
+```prisma
+model ImpactLabMatchRun {
+  // ...existing
+  judgingClosedAt    DateTime?  // set by mark-final; blocks score writes
+  resultsPublishedAt DateTime?
+  announcedWinners   Json?      // verbatim, never recomputed
+  resultsSnapshot    Json?      // the exact table that was published
+}
+
+model ImpactLabScore {
+  // ...existing
+  writeupOnly Boolean @default(false)  // scored from submission, no live demo
+}
+
+model ImpactLabResultsEmail {
+  id            String    @id @default(cuid())
+  runId         String
+  participantId String
+  email         String
+  status        String    // queued | sent | failed
+  error         String?
+  sentAt        DateTime?
+  createdAt     DateTime  @default(now())
+
+  run ImpactLabMatchRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  @@unique([runId, participantId])
+  @@index([runId, status])
+  @@map("impact_lab_results_emails")
+}
+```
+
+`@@unique([runId, participantId])` is what makes the send idempotent. Resend's
+quota is 100/day and there are 93 recipients — a careless retry exceeds it, so
+per-recipient state is required, not optional.
+
+The migration must not disturb the raw-SQL partial unique index
+`impact_lab_match_runs_one_final_per_cohort`.
+
+### Snapshot shape
+
+`resultsSnapshot` stores what was published, so later edits cannot rewrite what
+people read:
+
+```ts
+interface ResultsSnapshot {
+  publishedAt: string
+  overall: { rank: number; teamId: string; projectName: string }[]
+  trackWinners: { track: string; teamId: string; projectName: string; basis: "announced" | "score" }[]
+  table: {
+    rank: number
+    teamId: string
+    projectName: string
+    track: string
+    average: number
+    writeupOnly: boolean
+  }[]
+  perTeam: Record<string, {
+    criterionAverages: Record<string, number>
+    low: number
+    high: number
+    writeupOnly: boolean
+    unscored: boolean
+  }>
+}
+```
+
+`perTeam` is keyed by team and served only to that team's members. Judge counts
+are absent by design.
+
+### Routes
+
+| Route | Auth | Purpose |
+|---|---|---|
+| `GET /api/admin/impact-lab/judging/audit` | staff | Every judge, every sheet, timestamps, per-judge mean |
+| `POST /api/admin/impact-lab/judging/preview` | staff | What-if standings with judges excluded |
+| `POST /api/admin/impact-lab/judging/writeup` | staff | Save an organiser-approved writeup score |
+| `POST /api/admin/impact-lab/results/publish` | staff | Mark final: lock, snapshot, store winners |
+| `POST /api/admin/impact-lab/results/notify` | staff | Send to unsent recipients only |
+| `GET /api/impact-lab/results` | member | Published result + own team breakdown |
+
+Guard order on the member route follows the existing convention: CSRF → rate
+limit → auth → validation. Admin routes keep `checkApiPermission`. The
+code-gated judge session grants nothing here — publishing is staff-only.
+
+`POST .../judging` gains one guard: reject writes when `judgingClosedAt` is set.
+
+### Judging lock and snapshot
+
+`publish` runs in a transaction:
+
+1. `SELECT id FROM impact_lab_match_runs WHERE id = $1 FOR UPDATE`
+2. Refuse if `resultsPublishedAt` is already set
+3. Refuse if any team that submitted still has no score of any kind — this is
+   what stops the four unscored teams being published as blanks by accident
+4. Set `submissionsCloseAt` (if unset), `judgingClosedAt`, `resultsPublishedAt`
+5. Compute and store `announcedWinners` and `resultsSnapshot`
+6. Insert one `ImpactLabResultsEmail` row per recipient with `status: "queued"`
+
+Publishing and sending are separate actions. Publish makes the result visible
+and immutable; notify delivers it. A failed send never blocks the dashboard.
+
+### Scoring the four unscored teams
+
+Claude reads each submission and drafts a sheet against the five published
+criteria, with reasoning per criterion. Nothing saves until the organiser
+approves or adjusts each one. Stored with `judgeEmail = "organiser:<email>"`,
+`judgeName = "Organiser review"`, `writeupOnly = true`.
+
+The demo criterion is 25% of the weight and asks whether the thing ran in front
+of you. No demo was seen, so the draft states that explicitly and the organiser
+sets the number. Anywhere a writeup-only team appears, the marker appears with
+it.
+
+Reuses the existing assist route's model and prompt discipline: ground every
+statement in what the team wrote, never infer.
+
+### Judge audit and exclusion preview
+
+The audit view lists every judge with their sheets, timestamps and mean, so the
+72-vs-48 spread is visible rather than buried.
+
+Exclusion is a **preview**. It recomputes into a side-by-side view showing who
+moves and by how much, and warns when an exclusion would leave a team with no
+scores. It cannot write, and it cannot reach `resultsSnapshot`. The published
+table is always the all-judges table.
+
+This is deliberate. The panel already overrode the arithmetic; a control that
+changes published placings by dropping judges would be a dial for shopping
+outcomes, which is the opposite of the transparency this is for.
+
+## Participant view
+
+New `results` phase in `ImpactLabClient`. Its `Phase` union has no results
+state and its only effect depends on `[reloadKey]`, so both need extending.
+
+Sections, in order:
+
+1. **Winners** — champion and 2nd/3rd, then the five track winners.
+2. **Your team** — five criterion scores, the range across judges, the
+   submission as filed. Private. Unscored teams get the honest message instead.
+3. **Full table** — every team by score, writeup-only marked. No judge counts.
+4. **The note** — why the table and the winners differ.
+
+### The note, in full
+
+> **How these results were decided**
+>
+> Winners were chosen by the judging panel after they had seen every demo and
+> discussed the projects together. That conversation is what the placings
+> reflect.
+>
+> The table below is the raw scoring data from the judging portal, published in
+> full. It will not always match the placings, and that is expected — teams were
+> seen by different judges, judges scored on different scales, and the panel
+> weighed things a score sheet does not capture.
+>
+> We are publishing both because you are entitled to see how your work was
+> assessed, including where the numbers and the decision disagree.
+
+Plain English, no Swahili in participant-facing copy (existing project rule).
+
+### Unscored teams
+
+> Your submission was received at 01:29 and is on record.
+>
+> Judging closed before the panel reached your table. That was our scheduling,
+> not a reflection of your work, and we are sorry.
+>
+> Your project has since been reviewed against the same five criteria from your
+> written submission. Because there was no live demo, it is marked as a
+> submission-only review.
+
+## Email
+
+One template, sent to 93. Carries the result standalone so the nine without
+accounts need nothing else:
+
+- Overall winners and the five track winners
+- That team's own five scores
+- Their placing on the table
+- Link to the dashboard for the full table
+- The short form of the note
+
+Sent through the existing `sendEmailBatch` in chunks. Chunk accounting is
+currently chunk-granular — one rejected chunk marks all 100 failed — so per
+recipient status is written from the per-row result, and the retry path selects
+`status <> 'sent'` only.
+
+## Visual design
+
+Both surfaces follow the existing persona system rather than a one-off style —
+Terminal Noir in Dev, glassmorphism in Pro, using the CSS variables already in
+`globals.css`. `/frontend-design` is invoked during implementation.
+
+- Winners get real hierarchy: champion first and largest, then 2nd/3rd, then
+  tracks. Not a bulleted list.
+- The table is scannable at 320px — horizontal scroll inside its own container,
+  never on the page body.
+- A team's own row is marked in the table so they can find themselves.
+- Criterion scores read as filled meters against the 1–5 scale, not bare digits.
+- The email is table-based HTML with inline styles and a plain-text alternative.
+  No web fonts, no external images, dark-mode safe.
+- `prefers-reduced-motion` respected on any reveal.
+
+## Testing
+
+`scripts/verify-judging.ts` is the established pattern; this extends it rather
+than introducing a framework.
+
+New assertions in `scripts/verify-results.ts`:
+
+- A writeup-only score is included in the average and flagged in output
+- Track winners: announced winners take their own track; remaining tracks go to
+  top score; a track with no scored team yields no winner
+- Snapshot is byte-stable across two computations from identical input
+- `perTeam` never contains a judge count
+- A second notify sends to nobody when all rows are `sent`
+- Publishing twice is refused
+- Score writes are refused once `judgingClosedAt` is set
+
+Manual gate before the send: publish to a snapshot, read the dashboard as a
+member of a scored team, an unscored team, and a team with no account, then
+send to one address before the batch.
+
+## Out of scope
+
+- Score normalisation across judges. Considered and rejected: it would override
+  judges who applied a stricter bar, after the fact, to change a published
+  result.
+- Automatic track winners from `trackWinners()` alone — the announced winners
+  take precedence over the arithmetic.
+- Any path where judge exclusion changes what participants see.
+- Retroactive live judging of the four unscored teams.
+- Unsubscribe infrastructure. Flagged as a real gap: this is transactional mail
+  to event participants, but no suppression list exists. Worth building before
+  any future cohort mail.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Whatsy tops the table and wins nothing | Accepted deliberately; the note explains the method |
+| VilCare announced 2nd, 18th on scores | Same |
+| Resend quota 100/day vs 93 recipients | Per-recipient rows; retry only unsent |
+| Favour never replies | Nothing in this spec is blocked on her |
+| Snapshot drifts from live data | Snapshot is what is served; live data is not consulted after publish |
+| Publishing twice | Refused inside the row-locked transaction |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "verify:submissions": "tsx scripts/verify-submissions.ts",
     "verify:rematch": "tsx scripts/verify-rematch.ts",
     "verify:judging": "tsx scripts/verify-judging.ts",
+    "verify:results": "tsx scripts/verify-results.ts",
     "import:manual-teams": "tsx scripts/import-manual-teams.ts"
   },
   "prisma": {

--- a/prisma/migrations/20260727120000_impact_lab_results/migration.sql
+++ b/prisma/migrations/20260727120000_impact_lab_results/migration.sql
@@ -1,0 +1,31 @@
+ALTER TABLE "impact_lab_match_runs"
+  ADD COLUMN "judgingClosedAt" TIMESTAMP(3),
+  ADD COLUMN "resultsPublishedAt" TIMESTAMP(3),
+  ADD COLUMN "announcedWinners" JSONB,
+  ADD COLUMN "resultsSnapshot" JSONB;
+
+ALTER TABLE "impact_lab_scores"
+  ADD COLUMN "writeupOnly" BOOLEAN NOT NULL DEFAULT false;
+
+CREATE TABLE "impact_lab_results_emails" (
+  "id" TEXT NOT NULL,
+  "runId" TEXT NOT NULL,
+  "participantId" TEXT NOT NULL,
+  "email" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'queued',
+  "error" TEXT,
+  "sentAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "impact_lab_results_emails_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "impact_lab_results_emails_runId_participantId_key"
+  ON "impact_lab_results_emails" ("runId", "participantId");
+
+CREATE INDEX "impact_lab_results_emails_runId_status_idx"
+  ON "impact_lab_results_emails" ("runId", "status");
+
+ALTER TABLE "impact_lab_results_emails"
+  ADD CONSTRAINT "impact_lab_results_emails_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "impact_lab_match_runs"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -712,6 +712,20 @@ model ImpactLabMatchRun {
   /// deadline. Editable by an organiser so a slipped demo slot needs a field
   /// change, not a database edit.
   submissionsCloseAt   DateTime?
+  /// Set by mark-final. Once non-null, no further scores may be written —
+  /// the judging route rejects writes rather than silently accepting a score
+  /// that can never reach the published result.
+  judgingClosedAt      DateTime?
+  /// When results were published to participants. Non-null means the result
+  /// is immutable: everything participants see is served from resultsSnapshot.
+  resultsPublishedAt   DateTime?
+  /// The winners as announced in the room, stored verbatim. Never recomputed —
+  /// the panel deliberated, and arithmetic does not reproduce their decision.
+  announcedWinners     Json?
+  /// The exact ResultsSnapshot that was published. Served as-is so a later
+  /// score correction or submission edit cannot rewrite what people read.
+  resultsSnapshot      Json?
+  resultsEmails        ImpactLabResultsEmail[]
   submissions          ImpactLabSubmission[]
   scores               ImpactLabScore[]
   createdById          String?
@@ -785,6 +799,11 @@ model ImpactLabScore {
   judgeName  String
   scores     Json
   feedback   String?  @db.Text
+  /// True when this score came from reading the written submission rather than
+  /// watching a live demo. The demo criterion is 25% of the weight and asks
+  /// whether the thing ran in front of you, so the basis must travel with the
+  /// score wherever it is shown.
+  writeupOnly Boolean @default(false)
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
@@ -795,4 +814,25 @@ model ImpactLabScore {
   @@unique([runId, teamId, judgeEmail])
   @@index([cohort, teamId])
   @@map("impact_lab_scores")
+}
+
+/// One row per intended recipient of the results email. This is what makes the
+/// send idempotent: Resend's quota is 100/day and there are 93 recipients, so a
+/// careless retry exceeds it. A resend selects status <> 'sent' only.
+model ImpactLabResultsEmail {
+  id            String    @id @default(cuid())
+  runId         String
+  participantId String
+  email         String
+  /// queued | sent | failed
+  status        String    @default("queued")
+  error         String?
+  sentAt        DateTime?
+  createdAt     DateTime  @default(now())
+
+  run ImpactLabMatchRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  @@unique([runId, participantId])
+  @@index([runId, status])
+  @@map("impact_lab_results_emails")
 }

--- a/scripts/verify-results.ts
+++ b/scripts/verify-results.ts
@@ -1,0 +1,153 @@
+/**
+ * Impact Lab results — verification harness.
+ *
+ * Follows scripts/verify-judging.ts. The arithmetic here decides what 93 people
+ * are told about their own work, so the ranking rule, the track-winner rule and
+ * the privacy of the payload are asserted rather than trusted.
+ *
+ * Run with: npm run verify:results
+ */
+
+import { buildSnapshot, type ResultsInput } from "../src/lib/impact-lab/results"
+import type { TeamStanding } from "../src/lib/impact-lab/judging"
+
+let failures = 0
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`  ✓ ${message}`)
+  } else {
+    console.error(`  ✗ ${message}`)
+    failures += 1
+  }
+}
+
+const standing = (teamId: string, average: number): TeamStanding => ({
+  teamId,
+  average,
+  judgeCount: 2,
+  criterionAverages: { impact: 4, demo: 4, claude: 4, clarity: 4, presentation: 4 },
+})
+
+// Mirrors production: the announced winners do not top the score table.
+const input: ResultsInput = {
+  publishedAt: "2026-07-27T09:00:00.000Z",
+  announcedTeamIds: ["t-biasharagpt", "t-vilcare", "t-oryn"],
+  standings: [
+    standing("t-whatsy", 76.9),
+    standing("t-biasharagpt", 75.3),
+    standing("t-keyosk", 73.8),
+    standing("t-oryn", 73.3),
+    standing("t-vilcare", 55.3),
+    standing("t-kilimoeco", 80.0),
+  ],
+  teams: new Map([
+    ["t-whatsy", { projectName: "Whatsy", track: "Biashara (Small Business)" }],
+    ["t-biasharagpt", { projectName: "BiasharaGPT", track: "Biashara (Small Business)" }],
+    ["t-keyosk", { projectName: "KeyOSk", track: "Biashara (Small Business)" }],
+    ["t-oryn", { projectName: "Oryn", track: "Biashara (Small Business)" }],
+    ["t-vilcare", { projectName: "VilCare", track: "Afya (Health)" }],
+    ["t-kilimoeco", { projectName: "kilimoeco", track: "Kilimo (Agriculture)" }],
+  ]),
+  writeupOnly: new Set(["t-kilimoeco"]),
+  range: new Map([
+    ["t-vilcare", { low: 18.8, high: 88.8 }],
+    ["t-whatsy", { low: 76.3, high: 77.5 }],
+  ]),
+}
+
+const snap = buildSnapshot(input)
+
+console.log("\nRanking")
+assert(snap.ranking[0].teamId === "t-biasharagpt", "the announced champion ranks 1st")
+assert(snap.ranking[1].teamId === "t-vilcare", "the announced 2nd ranks 2nd despite the lowest score")
+assert(snap.ranking[2].teamId === "t-oryn", "the announced 3rd ranks 3rd")
+assert(
+  snap.ranking[0].basis === "announced" && snap.ranking[2].basis === "announced",
+  "announced winners carry basis 'announced'"
+)
+
+const whatsy = snap.ranking.find((r) => r.teamId === "t-whatsy")
+assert(
+  whatsy?.rank === 5,
+  "a team outscoring the champion still ranks below it — kilimoeco 80.0 is 4th, Whatsy 76.9 is 5th"
+)
+assert(
+  snap.ranking.length === 6 && new Set(snap.ranking.map((r) => r.teamId)).size === 6,
+  "every submitted team appears exactly once"
+)
+assert(
+  snap.ranking.every((r, i) => r.rank === i + 1),
+  "ranks are dense and start at 1"
+)
+assert(
+  snap.ranking.find((r) => r.teamId === "t-kilimoeco")?.basis === "submission",
+  "a submission-reviewed team carries basis 'submission'"
+)
+
+console.log("\nTrack winners")
+const byTrack = new Map(snap.trackWinners.map((w) => [w.track, w]))
+assert(
+  byTrack.get("Biashara (Small Business)")?.teamId === "t-biasharagpt",
+  "an announced winner leads its own track, ahead of a higher-scoring team"
+)
+assert(
+  byTrack.get("Biashara (Small Business)")?.basis === "announced",
+  "that track winner is marked as decided by announcement"
+)
+assert(
+  byTrack.get("Afya (Health)")?.teamId === "t-vilcare",
+  "the announced 2nd leads its track"
+)
+assert(
+  byTrack.get("Kilimo (Agriculture)")?.teamId === "t-kilimoeco" &&
+    byTrack.get("Kilimo (Agriculture)")?.basis === "score",
+  "a track with no announced winner goes to the top score, marked as such"
+)
+assert(
+  snap.trackWinners.length === 3,
+  "only tracks with at least one ranked team produce a winner"
+)
+
+console.log("\nPrivacy of the payload")
+const serialized = JSON.stringify(snap)
+assert(!serialized.includes("judgeCount"), "the snapshot never carries a judge count")
+assert(
+  !/"judge(Name|Email)"/.test(serialized),
+  "the snapshot never carries a judge identity"
+)
+assert(
+  Object.keys(snap.perTeam).length === 6,
+  "every ranked team gets a private card"
+)
+assert(
+  snap.perTeam["t-vilcare"].low === 18.8 && snap.perTeam["t-vilcare"].high === 88.8,
+  "a team's own card carries the range across judges"
+)
+assert(
+  snap.perTeam["t-vilcare"].rank === 2,
+  "a team's own card carries its published rank, not its score rank"
+)
+
+console.log("\nDeterminism")
+assert(
+  JSON.stringify(buildSnapshot(input)) === serialized,
+  "two builds from identical input are byte-identical"
+)
+const tied = buildSnapshot({
+  ...input,
+  announcedTeamIds: [],
+  standings: [standing("t-b", 70), standing("t-a", 70)],
+  teams: new Map([
+    ["t-a", { projectName: "A", track: "Afya (Health)" }],
+    ["t-b", { projectName: "B", track: "Afya (Health)" }],
+  ]),
+  writeupOnly: new Set(),
+  range: new Map(),
+})
+assert(tied.ranking[0].teamId === "t-a", "ties break deterministically by team id")
+
+console.log(
+  failures === 0 ? "\nALL CHECKS PASSED\n" : `\n${failures} CHECK(S) FAILED\n`
+)
+process.exit(failures === 0 ? 0 : 1)

--- a/scripts/verify-results.ts
+++ b/scripts/verify-results.ts
@@ -184,6 +184,29 @@ const tied = buildSnapshot({
 })
 assert(tied.ranking[0].teamId === "t-a", "ties break deterministically by team id")
 
+console.log("\nMember payload")
+// Mirrors what the member route attaches: one card, never the map.
+const memberPayload = {
+  results: {
+    publishedAt: snap.publishedAt,
+    overall: snap.overall,
+    trackWinners: snap.trackWinners,
+    ranking: toPublicRanking(snap.ranking),
+  },
+  yourTeam: { teamId: "t-vilcare", card: snap.perTeam["t-vilcare"] },
+}
+const memberJson = JSON.stringify(memberPayload)
+assert(!memberJson.includes("perTeam"), "the member payload never carries the perTeam map")
+assert(
+  !memberJson.includes("average"),
+  "the member payload never carries another team's score — not rendering it is not the same as not sending it"
+)
+assert(
+  !memberJson.includes("t-whatsy\":{"),
+  "the member payload never carries another team's card"
+)
+assert(!memberJson.includes("judgeCount"), "the member payload never carries a judge count")
+
 console.log(
   failures === 0 ? "\nALL CHECKS PASSED\n" : `\n${failures} CHECK(S) FAILED\n`
 )

--- a/scripts/verify-results.ts
+++ b/scripts/verify-results.ts
@@ -8,7 +8,12 @@
  * Run with: npm run verify:results
  */
 
-import { buildSnapshot, toPublicRanking, type ResultsInput } from "../src/lib/impact-lab/results"
+import {
+  buildMemberPayload,
+  buildSnapshot,
+  toPublicRanking,
+  type ResultsInput,
+} from "../src/lib/impact-lab/results"
 import type { TeamStanding } from "../src/lib/impact-lab/judging"
 
 let failures = 0
@@ -185,16 +190,10 @@ const tied = buildSnapshot({
 assert(tied.ranking[0].teamId === "t-a", "ties break deterministically by team id")
 
 console.log("\nMember payload")
-// Mirrors what the member route attaches: one card, never the map.
-const memberPayload = {
-  results: {
-    publishedAt: snap.publishedAt,
-    overall: snap.overall,
-    trackWinners: snap.trackWinners,
-    ranking: toPublicRanking(snap.ranking),
-  },
-  yourTeam: { teamId: "t-vilcare", card: snap.perTeam["t-vilcare"] },
-}
+// Calls the actual function the route calls — not a hand-built stand-in — so
+// a future route edit that spreads the snapshot or drops toPublicRanking()
+// would make these assertions fail, not just the ones tsc already enforces.
+const memberPayload = buildMemberPayload(snap, "t-vilcare")
 const memberJson = JSON.stringify(memberPayload)
 assert(!memberJson.includes("perTeam"), "the member payload never carries the perTeam map")
 assert(
@@ -206,6 +205,35 @@ assert(
   "the member payload never carries another team's card"
 )
 assert(!memberJson.includes("judgeCount"), "the member payload never carries a judge count")
+assert(
+  memberPayload.results !== undefined &&
+    memberPayload.results.ranking.length === snap.ranking.length &&
+    memberPayload.results.ranking.every((row, i) => row.teamId === snap.ranking[i].teamId) &&
+    !JSON.stringify(memberPayload.results.ranking).includes("average"),
+  "the payload's ranking matches the snapshot's length and order, and carries no score"
+)
+assert(
+  !("yourTeam" in buildMemberPayload(snap, null)),
+  "a viewer with no resolvable team gets no yourTeam key at all"
+)
+const unknownTeamPayload = buildMemberPayload(snap, "t-does-not-exist")
+assert(
+  !("yourTeam" in unknownTeamPayload),
+  "a viewer whose team id does not exist in the snapshot gets no yourTeam key, and building the payload does not throw"
+)
+// The full ranking legitimately names every team (position/project/track is
+// public), so "no other team id anywhere in the JSON" would false-positive on
+// that field alone. Strip the ranking array's own serialized substring out of
+// the real payload JSON first, then check what's left — yourTeam, the
+// announced overall list, the track-winner list — for the other team's id.
+// That remainder is exactly where a leaked perTeam map (or an accidentally
+// attached other team's card) would surface.
+const rankingJson = JSON.stringify(memberPayload.results?.ranking ?? [])
+const payloadOutsideRanking = memberJson.replace(rankingJson, "")
+assert(
+  !payloadOutsideRanking.includes("t-whatsy"),
+  "no other team's id appears anywhere outside the public ranking list — the assertion that would catch a leaked perTeam map"
+)
 
 console.log(
   failures === 0 ? "\nALL CHECKS PASSED\n" : `\n${failures} CHECK(S) FAILED\n`

--- a/scripts/verify-results.ts
+++ b/scripts/verify-results.ts
@@ -8,7 +8,7 @@
  * Run with: npm run verify:results
  */
 
-import { buildSnapshot, type ResultsInput } from "../src/lib/impact-lab/results"
+import { buildSnapshot, toPublicRanking, type ResultsInput } from "../src/lib/impact-lab/results"
 import type { TeamStanding } from "../src/lib/impact-lab/judging"
 
 let failures = 0
@@ -40,6 +40,7 @@ const input: ResultsInput = {
     standing("t-oryn", 73.3),
     standing("t-vilcare", 55.3),
     standing("t-kilimoeco", 80.0),
+    standing("t-refernet", 69.7),
   ],
   teams: new Map([
     ["t-whatsy", { projectName: "Whatsy", track: "Biashara (Small Business)" }],
@@ -48,6 +49,9 @@ const input: ResultsInput = {
     ["t-oryn", { projectName: "Oryn", track: "Biashara (Small Business)" }],
     ["t-vilcare", { projectName: "VilCare", track: "Afya (Health)" }],
     ["t-kilimoeco", { projectName: "kilimoeco", track: "Kilimo (Agriculture)" }],
+    // Gives Afya a second team, so "the announced 2nd leads its track" has a
+    // real competitor to beat rather than passing on an empty field.
+    ["t-refernet", { projectName: "ReferNet", track: "Afya (Health)" }],
   ]),
   writeupOnly: new Set(["t-kilimoeco"]),
   range: new Map([
@@ -57,6 +61,15 @@ const input: ResultsInput = {
 }
 
 const snap = buildSnapshot(input)
+
+console.log("\nOverall")
+assert(snap.overall.length === 3, "overall carries exactly the announced winners")
+assert(
+  snap.overall[0].rank === 1 &&
+    snap.overall[0].teamId === "t-biasharagpt" &&
+    snap.overall[0].projectName === "BiasharaGPT",
+  "the first announced entry is the champion, ranked and named correctly"
+)
 
 console.log("\nRanking")
 assert(snap.ranking[0].teamId === "t-biasharagpt", "the announced champion ranks 1st")
@@ -73,7 +86,7 @@ assert(
   "a team outscoring the champion still ranks below it — kilimoeco 80.0 is 4th, Whatsy 76.9 is 5th"
 )
 assert(
-  snap.ranking.length === 6 && new Set(snap.ranking.map((r) => r.teamId)).size === 6,
+  snap.ranking.length === 7 && new Set(snap.ranking.map((r) => r.teamId)).size === 7,
   "every submitted team appears exactly once"
 )
 assert(
@@ -117,7 +130,7 @@ assert(
   "the snapshot never carries a judge identity"
 )
 assert(
-  Object.keys(snap.perTeam).length === 6,
+  Object.keys(snap.perTeam).length === 7,
   "every ranked team gets a private card"
 )
 assert(
@@ -127,6 +140,30 @@ assert(
 assert(
   snap.perTeam["t-vilcare"].rank === 2,
   "a team's own card carries its published rank, not its score rank"
+)
+assert(
+  snap.perTeam["t-kilimoeco"].basis === "submission",
+  "a submission-reviewed team's own card carries basis 'submission'"
+)
+assert(
+  snap.perTeam["t-whatsy"].basis === "demo",
+  "a demo-judged team's own card carries basis 'demo'"
+)
+assert(
+  snap.perTeam["t-refernet"].low === null && snap.perTeam["t-refernet"].high === null,
+  "a team absent from the range map gets a null range, not a range that reads as an earned zero"
+)
+
+console.log("\nPublic ranking")
+const publicRanking = toPublicRanking(snap.ranking)
+assert(
+  publicRanking.length === snap.ranking.length &&
+    publicRanking.every((r, i) => r.teamId === snap.ranking[i].teamId),
+  "the public ranking has the same teams in the same order as the stored one"
+)
+assert(
+  !JSON.stringify(publicRanking).includes("average"),
+  "the public ranking never carries a score"
 )
 
 console.log("\nDeterminism")

--- a/src/app/api/admin/impact-lab/judging/assist/route.ts
+++ b/src/app/api/admin/impact-lab/judging/assist/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { generateObject } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { readJudgeSession } from "@/lib/impact-lab/judge-access"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { JUDGING_CRITERIA } from "@/lib/impact-lab/judging"
+
+/**
+ * Optional reading assistance for a judge, on one team's written submission.
+ *
+ * Deliberately returns NO scores and NO ranking. A suggested number would
+ * anchor the judge before they had formed their own view, and there is a prize
+ * attached to the result — so this reads what the team wrote and hands back
+ * observations and questions worth asking during the demo. The judgement stays
+ * with the human.
+ *
+ * It also only ever sees what the team submitted. It cannot see other teams,
+ * other judges' scores, or the leaderboard, so it has nothing to be biased by.
+ */
+
+export const maxDuration = 60
+
+const MODEL = "claude-sonnet-5"
+const anthropic = createAnthropic()
+
+const bodySchema = z.object({ teamId: z.string().min(1).max(64) })
+
+const assistSchema = z.object({
+  readsAs: z
+    .string()
+    .describe("One sentence: what this project appears to be, in plain terms."),
+  observations: z
+    .array(
+      z.object({
+        criterion: z.string().describe("The criterion label this speaks to."),
+        note: z
+          .string()
+          .describe(
+            "What the submission does or does not tell you about this criterion. Neutral, no score."
+          ),
+      })
+    )
+    .describe("One entry per criterion, in the order given."),
+  questionsToAsk: z
+    .array(z.string())
+    .describe("Two or three specific questions to ask this team during the demo."),
+  watchFor: z
+    .string()
+    .describe(
+      "One thing to verify live, e.g. a claim in the writeup the demo should prove."
+    ),
+})
+
+const SYSTEM = `You help a hackathon judge read one team's written submission before their live demo.
+
+You do not score, rank, or recommend. You never say a team is good, strong, weak, or better than anyone. A judge forms their own view; your job is to help them read faster and ask sharper questions.
+
+Ground every statement in what the team actually wrote. If the submission does not say something, say that it does not say it — never infer, never fill gaps, never flatter. "The writeup does not say who the beneficiary is" is a useful sentence; inventing one is not.
+
+Be brief. A judge is standing up between demos.
+
+Plain English. No jargon.`
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  // Same two doors as the rest of judging: a code-gated judge, or staff.
+  const judge = await readJudgeSession()
+  if (!judge) {
+    const check = await checkApiPermission("impact-lab", "view")
+    if (!check.authorized) return check.response
+  }
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick a team." },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  })
+  if (!run) {
+    return NextResponse.json(
+      { success: false, error: "No final run." },
+      { status: 409 }
+    )
+  }
+
+  const submission = await prisma.impactLabSubmission.findUnique({
+    where: { runId_teamId: { runId: run.id, teamId: parsed.data.teamId } },
+    select: {
+      projectName: true,
+      pitch: true,
+      description: true,
+      worksVsMocked: true,
+      claudeUsage: true,
+      track: true,
+      problemTackled: true,
+    },
+  })
+
+  if (!submission) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "This team has not submitted anything yet, so there is nothing to read.",
+        code: "NO_SUBMISSION",
+      },
+      { status: 404 }
+    )
+  }
+
+  const criteria = JUDGING_CRITERIA.map(
+    (c) => `- ${c.label}: ${c.guidance}`
+  ).join("\n")
+
+  const prompt = `The judge will score this team on these criteria:
+${criteria}
+
+The team's submission:
+
+Project: ${submission.projectName}
+Track: ${submission.track}
+One-line pitch: ${submission.pitch}
+Problem tackled: ${submission.problemTackled}
+What it does: ${submission.description}
+What works vs what is mocked: ${submission.worksVsMocked}
+How they used Claude: ${submission.claudeUsage}`
+
+  try {
+    const { object } = await generateObject({
+      model: anthropic(MODEL),
+      schema: assistSchema,
+      system: SYSTEM,
+      prompt,
+      maxOutputTokens: 2_000,
+    })
+
+    return NextResponse.json({ success: true, data: object })
+  } catch (error) {
+    // Never block scoring on this. The judge can always read the submission
+    // themselves, so a failure here is an inconvenience, not an outage.
+    console.error("[judging/assist] generation failed", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Could not read that submission right now. Score it yourself — nothing is blocked.",
+      },
+      { status: 502 }
+    )
+  }
+}

--- a/src/app/api/admin/impact-lab/judging/audit/route.ts
+++ b/src/app/api/admin/impact-lab/judging/audit/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { checkApiPermission } from "@/lib/rbac"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { weightedTotal } from "@/lib/impact-lab/judging"
+
+/**
+ * Per-judge audit. Staff only — deliberately not reachable by a code-gated
+ * judge session, because a judge seeing another judge's sheet is exactly the
+ * anchoring the judging screen was built to avoid.
+ *
+ * This exists because the four judges scored on visibly different scales
+ * (means from 48.3 to 72.2). That is invisible in an aggregate leaderboard and
+ * changes how the result should be read, so it is surfaced rather than buried.
+ */
+
+interface AuditSheet {
+  teamId: string
+  teamName: string
+  projectName: string | null
+  total: number
+  scores: Record<string, number>
+  writeupOnly: boolean
+  scoredAt: string
+}
+
+export interface JudgeAudit {
+  judgeEmail: string
+  judgeName: string
+  teamsScored: number
+  mean: number
+  firstScoredAt: string
+  lastScoredAt: string
+  sheets: AuditSheet[]
+}
+
+function asScoreSheet(value: unknown): Record<string, number> {
+  if (typeof value !== "object" || value === null) return {}
+  const out: Record<string, number> = {}
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof v === "number" && !Number.isNaN(v)) out[k] = v
+  }
+  return out
+}
+
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+  if (!run) {
+    return NextResponse.json({ success: true, data: { judges: [] } })
+  }
+
+  const [rows, submissions] = await Promise.all([
+    prisma.impactLabScore.findMany({
+      where: { runId: run.id },
+      select: {
+        teamId: true,
+        judgeEmail: true,
+        judgeName: true,
+        scores: true,
+        writeupOnly: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    }),
+    prisma.impactLabSubmission.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, projectName: true },
+    }),
+  ])
+
+  const nameById = new Map<string, string>()
+  const teams = (run.result as { teams?: { id: string; name: string }[] })?.teams ?? []
+  for (const team of teams) nameById.set(team.id, team.name)
+  const projectById = new Map(submissions.map((s) => [s.teamId, s.projectName]))
+
+  const byJudge = new Map<string, JudgeAudit>()
+  for (const row of rows) {
+    const sheet = asScoreSheet(row.scores)
+    const entry = byJudge.get(row.judgeEmail) ?? {
+      judgeEmail: row.judgeEmail,
+      judgeName: row.judgeName,
+      teamsScored: 0,
+      mean: 0,
+      firstScoredAt: row.createdAt.toISOString(),
+      lastScoredAt: row.createdAt.toISOString(),
+      sheets: [],
+    }
+    entry.sheets.push({
+      teamId: row.teamId,
+      teamName: nameById.get(row.teamId) ?? row.teamId,
+      projectName: projectById.get(row.teamId) ?? null,
+      total: weightedTotal(sheet),
+      scores: sheet,
+      writeupOnly: row.writeupOnly,
+      scoredAt: row.createdAt.toISOString(),
+    })
+    entry.lastScoredAt = row.createdAt.toISOString()
+    byJudge.set(row.judgeEmail, entry)
+  }
+
+  const judges = [...byJudge.values()].map((j) => ({
+    ...j,
+    teamsScored: j.sheets.length,
+    mean:
+      Math.round(
+        (j.sheets.reduce((n, s) => n + s.total, 0) / (j.sheets.length || 1)) * 10
+      ) / 10,
+  }))
+  judges.sort((a, b) => b.teamsScored - a.teamsScored || a.judgeName.localeCompare(b.judgeName))
+
+  return NextResponse.json({ success: true, data: { judges } })
+}

--- a/src/app/api/admin/impact-lab/judging/preview/route.ts
+++ b/src/app/api/admin/impact-lab/judging/preview/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import { standings, type ScoreSheet } from "@/lib/impact-lab/judging"
+
+/**
+ * What-if standings with judges excluded. READ ONLY, and deliberately so.
+ *
+ * The panel's announced result already overrides the arithmetic, so this
+ * cannot change any published placing — it exists to let an organiser
+ * understand a result, never to search for one they prefer. There is no write
+ * path from here to resultsSnapshot, and adding one would turn a transparency
+ * tool into a dial for shopping outcomes.
+ */
+
+export interface PreviewRow {
+  teamId: string
+  teamName: string
+  projectName: string | null
+  baseRank: number
+  previewRank: number | null
+  baseAverage: number
+  previewAverage: number | null
+  move: number | null
+}
+
+const bodySchema = z.object({
+  cohort: z.string().optional(),
+  exclude: z.array(z.string().min(1).max(200)).max(20),
+})
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Provide a list of judge emails to exclude." },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(parsed.data.cohort)
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+  if (!run) {
+    return NextResponse.json({ success: true, data: { rows: [], orphaned: [] } })
+  }
+
+  const teams = extractFrozenTeams(run.result) ?? []
+  const nameById = new Map(teams.map((t) => [t.id, t.name]))
+
+  const [scores, submissions] = await Promise.all([
+    prisma.impactLabScore.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, judgeEmail: true, scores: true },
+    }),
+    prisma.impactLabSubmission.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, projectName: true },
+    }),
+  ])
+  const projectById = new Map(submissions.map((s) => [s.teamId, s.projectName]))
+
+  const excluded = new Set(parsed.data.exclude)
+  const allSheets = scores.map((s) => ({
+    judgeEmail: s.judgeEmail,
+    teamId: s.teamId,
+    sheet: (s.scores ?? {}) as ScoreSheet,
+  }))
+  const filteredSheets = allSheets.filter((s) => !excluded.has(s.judgeEmail))
+
+  const base = standings(allSheets)
+  const preview = standings(filteredSheets)
+  const previewIndexByTeam = new Map(preview.map((p, i) => [p.teamId, i]))
+
+  const rows: PreviewRow[] = base.map((b, i) => {
+    const previewIndex = previewIndexByTeam.get(b.teamId)
+    const previewRank = previewIndex === undefined ? null : previewIndex + 1
+    const previewAverage = previewIndex === undefined ? null : preview[previewIndex].average
+    const baseRank = i + 1
+    return {
+      teamId: b.teamId,
+      teamName: nameById.get(b.teamId) ?? b.teamId,
+      projectName: projectById.get(b.teamId) ?? null,
+      baseRank,
+      previewRank,
+      baseAverage: b.average,
+      previewAverage,
+      move: previewRank === null ? null : baseRank - previewRank,
+    }
+  })
+
+  const orphaned = rows.filter((r) => r.previewRank === null).map((r) => r.teamName)
+
+  return NextResponse.json({ success: true, data: { rows, orphaned } })
+}

--- a/src/app/api/admin/impact-lab/judging/route.ts
+++ b/src/app/api/admin/impact-lab/judging/route.ts
@@ -161,11 +161,24 @@ export async function POST(request: NextRequest) {
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
-    select: { id: true, result: true },
+    select: { id: true, result: true, judgingClosedAt: true },
   })
   if (!run) {
     return NextResponse.json(
       { success: false, error: "No final run to judge against." },
+      { status: 409 }
+    )
+  }
+
+  // Once results are published, a new score can never reach them. Accepting the
+  // write anyway would tell a judge their scoring counted when it did not.
+  if (run.judgingClosedAt) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Judging is closed — results have been published.",
+        code: "JUDGING_CLOSED",
+      },
       { status: 409 }
     )
   }

--- a/src/app/api/admin/impact-lab/judging/writeup/route.ts
+++ b/src/app/api/admin/impact-lab/judging/writeup/route.ts
@@ -1,0 +1,330 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { generateObject } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import {
+  CRITERION_KEYS,
+  JUDGING_CRITERIA,
+  MAX_SCORE,
+  MIN_SCORE,
+  type ScoreSheet,
+} from "@/lib/impact-lab/judging"
+
+/**
+ * Scoring a team from its written submission, for teams the panel did not see
+ * demo. Four teams submitted and were never scored; without this they would be
+ * published with no result at all.
+ *
+ * Claude drafts, a human decides. Nothing is written until an organiser posts
+ * `action: "save"` with the numbers they accepted, and the row is stored as an
+ * organiser review rather than attributed to a judge who never saw the work.
+ *
+ * The demo criterion is 25% of the weight and asks whether it ran in front of
+ * you. No demo was seen, so the draft says so plainly instead of guessing, and
+ * `writeupOnly` travels with the score wherever it is displayed.
+ */
+export const maxDuration = 60
+
+const MODEL = "claude-sonnet-5"
+const anthropic = createAnthropic()
+
+const draftSchema = z.object({
+  scores: z.object({
+    impact: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
+    demo: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
+    claude: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
+    clarity: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
+    presentation: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
+  }),
+  reasoning: z.object({
+    impact: z.string().describe("One sentence, grounded in what the submission says."),
+    demo: z
+      .string()
+      .describe(
+        "Must state plainly that no live demo was seen, then say what the writeup itself evidences about working software."
+      ),
+    claude: z.string().describe("One sentence, grounded in what the submission says."),
+    clarity: z.string().describe("One sentence, grounded in what the submission says."),
+    presentation: z.string().describe("One sentence, grounded in what the submission says."),
+  }),
+})
+
+const SYSTEM = `You are drafting scores for a hackathon team that submitted written work but was never reached by a judge — no one saw a live demo.
+
+Score only what this submission evidences. If the writeup does not say something, that is evidence of absence, not a gap to fill in the team's favour. Never infer competence, never round up to be kind, and never let confident writing substitute for a working demo.
+
+For the "demo" criterion specifically: no live demo was seen. Say that plainly in the reasoning, then score only what the writeup itself demonstrates about working software — what it claims is built and running versus what it says is mocked, planned, or aspirational. A team that writes convincingly about software that may not exist must not receive the same score as a team that showed it work. When in doubt, score low and say why in the reasoning.
+
+For every other criterion, ground the score and the one-sentence reasoning in specific lines from the submission. A human organiser reviews every number before it counts — your job is to give them an honest, well-reasoned starting point, not a final answer.`
+
+const bodySchema = z.object({
+  teamId: z.string().min(1).max(64),
+  action: z.enum(["draft", "save"]),
+  scores: z.record(z.string().max(40), z.number()).optional(),
+})
+
+type SubmissionRow = {
+  projectName: string
+  pitch: string
+  description: string
+  worksVsMocked: string
+  claudeUsage: string
+  track: string
+  problemTackled: string
+  repoUrl: string
+  demoUrl: string | null
+}
+
+function submissionAsRecord(s: SubmissionRow): Record<string, string> {
+  return {
+    Pitch: s.pitch,
+    Track: s.track,
+    "Problem tackled": s.problemTackled,
+    "What it does": s.description,
+    "What works vs what is mocked": s.worksVsMocked,
+    "How they used Claude": s.claudeUsage,
+  }
+}
+
+/** GET — submitted teams with no score of any kind yet. */
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+  if (!run) {
+    return NextResponse.json({ success: true, data: { teams: [] } })
+  }
+
+  const teams = extractFrozenTeams(run.result) ?? []
+  const teamIds = new Set(teams.map((t) => t.id))
+  const nameById = new Map(teams.map((t) => [t.id, t.name]))
+
+  const [submissions, scored] = await Promise.all([
+    prisma.impactLabSubmission.findMany({
+      where: { runId: run.id },
+      select: {
+        teamId: true,
+        projectName: true,
+        pitch: true,
+        description: true,
+        worksVsMocked: true,
+        claudeUsage: true,
+        track: true,
+        problemTackled: true,
+        repoUrl: true,
+        demoUrl: true,
+      },
+    }),
+    prisma.impactLabScore.findMany({
+      where: { runId: run.id },
+      select: { teamId: true },
+      distinct: ["teamId"],
+    }),
+  ])
+
+  const scoredTeamIds = new Set(scored.map((s) => s.teamId))
+
+  const awaiting = submissions
+    .filter((s) => teamIds.has(s.teamId) && !scoredTeamIds.has(s.teamId))
+    .map((s) => ({
+      teamId: s.teamId,
+      teamName: nameById.get(s.teamId) ?? s.teamId,
+      projectName: s.projectName,
+      // Surfaced separately, as links, rather than folded into the writeup
+      // text — this is the one piece of checkable evidence for the demo
+      // criterion, and it belongs in front of the human reviewer's eyes, not
+      // in Claude's prompt (a URL it cannot fetch would only invite guessing).
+      repoUrl: s.repoUrl,
+      demoUrl: s.demoUrl,
+      submission: submissionAsRecord(s),
+    }))
+
+  return NextResponse.json({ success: true, data: { teams: awaiting } })
+}
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick a team and an action." },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true, judgingClosedAt: true },
+  })
+  if (!run) {
+    return NextResponse.json(
+      { success: false, error: "No final run to score against." },
+      { status: 409 }
+    )
+  }
+
+  // Once results are published, a new score can never reach them — same rule
+  // as the live-judging route.
+  if (run.judgingClosedAt) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Judging is closed — results have been published.",
+        code: "JUDGING_CLOSED",
+      },
+      { status: 409 }
+    )
+  }
+
+  const teams = extractFrozenTeams(run.result) ?? []
+  if (!teams.some((t) => t.id === parsed.data.teamId)) {
+    return NextResponse.json(
+      { success: false, error: "That team is not in the final run." },
+      { status: 404 }
+    )
+  }
+
+  const submission = await prisma.impactLabSubmission.findUnique({
+    where: { runId_teamId: { runId: run.id, teamId: parsed.data.teamId } },
+    select: {
+      projectName: true,
+      pitch: true,
+      description: true,
+      worksVsMocked: true,
+      claudeUsage: true,
+      track: true,
+      problemTackled: true,
+    },
+  })
+  if (!submission) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "This team has not submitted anything, so there is nothing to score.",
+        code: "NO_SUBMISSION",
+      },
+      { status: 404 }
+    )
+  }
+
+  if (parsed.data.action === "draft") {
+    const rl = await rateLimit(request, RateLimits.FORM)
+    if (!rl.success) {
+      return NextResponse.json(
+        { success: false, error: "Too many requests. Wait a moment." },
+        { status: 429, headers: rl.headers }
+      )
+    }
+
+    const criteria = JUDGING_CRITERIA.map(
+      (c) => `- ${c.key} — ${c.label}: ${c.guidance}`
+    ).join("\n")
+
+    const prompt = `Score this team on these criteria (key — label: guidance):
+${criteria}
+
+The team's submission:
+
+Project: ${submission.projectName}
+Track: ${submission.track}
+One-line pitch: ${submission.pitch}
+Problem tackled: ${submission.problemTackled}
+What it does: ${submission.description}
+What works vs what is mocked: ${submission.worksVsMocked}
+How they used Claude: ${submission.claudeUsage}
+
+No live demo was seen for this team.`
+
+    try {
+      const { object } = await generateObject({
+        model: anthropic(MODEL),
+        schema: draftSchema,
+        system: SYSTEM,
+        prompt,
+        maxOutputTokens: 2_000,
+      })
+
+      return NextResponse.json({ success: true, data: object })
+    } catch (error) {
+      // A draft is a convenience, not a dependency — an organiser can always
+      // read the submission and score it by hand.
+      console.error("[judging/writeup] draft generation failed", error)
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Could not draft scores for that team right now. Score it yourself — nothing is blocked.",
+        },
+        { status: 502 }
+      )
+    }
+  }
+
+  // action === "save" — the only branch that touches the database.
+  const scoresInput = parsed.data.scores
+  const scores: ScoreSheet = {}
+  for (const key of CRITERION_KEYS) {
+    const value = scoresInput?.[key]
+    if (
+      typeof value !== "number" ||
+      !Number.isInteger(value) ||
+      value < MIN_SCORE ||
+      value > MAX_SCORE
+    ) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Score every criterion from ${MIN_SCORE} to ${MAX_SCORE} before saving.`,
+        },
+        { status: 400 }
+      )
+    }
+    scores[key] = value
+  }
+
+  const judgeEmail = `organiser:${check.user.email}`
+
+  await prisma.impactLabScore.upsert({
+    where: {
+      runId_teamId_judgeEmail: {
+        runId: run.id,
+        teamId: parsed.data.teamId,
+        judgeEmail,
+      },
+    },
+    create: {
+      cohort,
+      runId: run.id,
+      teamId: parsed.data.teamId,
+      judgeEmail,
+      judgeName: "Organiser review",
+      scores,
+      writeupOnly: true,
+    },
+    update: {
+      scores,
+      judgeName: "Organiser review",
+      writeupOnly: true,
+    },
+  })
+
+  return NextResponse.json({ success: true, data: { saved: true } })
+}

--- a/src/app/api/admin/impact-lab/judging/writeup/route.ts
+++ b/src/app/api/admin/impact-lab/judging/writeup/route.ts
@@ -101,7 +101,11 @@ function submissionAsRecord(s: SubmissionRow): Record<string, string> {
 
 /** GET — submitted teams with no score of any kind yet. */
 export async function GET(request: NextRequest) {
-  const check = await checkApiPermission("impact-lab", "view")
+  // "edit", not "view" — MODERATOR (the role judges sign in with) holds only
+  // "view" on impact-lab. This list shows live Draft/Save controls, so gating
+  // it on "view" would let a judge see the queue and press buttons that then
+  // 403 on POST. Both handlers must move together, same as publish/notify.
+  const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
   const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
@@ -165,7 +169,8 @@ export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 
-  const check = await checkApiPermission("impact-lab", "view")
+  // See GET above — gated on "edit" for the same reason.
+  const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
   const parsed = bodySchema.safeParse(await request.json().catch(() => null))

--- a/src/app/api/admin/impact-lab/judging/writeup/route.ts
+++ b/src/app/api/admin/impact-lab/judging/writeup/route.ts
@@ -34,32 +34,39 @@ export const maxDuration = 60
 const MODEL = "claude-sonnet-5"
 const anthropic = createAnthropic()
 
+// Per-criterion reasoning hints, driven by CRITERION_KEYS rather than
+// hardcoded as separate fields — a renamed or added criterion in
+// @/lib/impact-lab/judging flows through here automatically, the same way
+// the `save` validation loop below already does.
+const REASONING_HINTS: Record<string, string> = {
+  demo: "Must state plainly that no live demo was seen, then say what the writeup itself evidences about working software.",
+  presentation:
+    "Must state plainly that no presentation was seen, then say what the writeup itself evidences about clarity and honesty — not how polished the writing is.",
+}
+const DEFAULT_REASONING_HINT = "One sentence, grounded in what the submission says."
+
+const scoreShape = Object.fromEntries(
+  CRITERION_KEYS.map((key) => [key, z.number().int().min(MIN_SCORE).max(MAX_SCORE)])
+)
+const reasoningShape = Object.fromEntries(
+  CRITERION_KEYS.map((key) => [
+    key,
+    z.string().describe(REASONING_HINTS[key] ?? DEFAULT_REASONING_HINT),
+  ])
+)
+
 const draftSchema = z.object({
-  scores: z.object({
-    impact: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
-    demo: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
-    claude: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
-    clarity: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
-    presentation: z.number().int().min(MIN_SCORE).max(MAX_SCORE),
-  }),
-  reasoning: z.object({
-    impact: z.string().describe("One sentence, grounded in what the submission says."),
-    demo: z
-      .string()
-      .describe(
-        "Must state plainly that no live demo was seen, then say what the writeup itself evidences about working software."
-      ),
-    claude: z.string().describe("One sentence, grounded in what the submission says."),
-    clarity: z.string().describe("One sentence, grounded in what the submission says."),
-    presentation: z.string().describe("One sentence, grounded in what the submission says."),
-  }),
+  scores: z.object(scoreShape),
+  reasoning: z.object(reasoningShape),
 })
 
-const SYSTEM = `You are drafting scores for a hackathon team that submitted written work but was never reached by a judge — no one saw a live demo.
+const SYSTEM = `You are drafting scores for a hackathon team that submitted written work but was never reached by a judge — no one saw a live demo or a live presentation.
 
-Score only what this submission evidences. If the writeup does not say something, that is evidence of absence, not a gap to fill in the team's favour. Never infer competence, never round up to be kind, and never let confident writing substitute for a working demo.
+Score only what this submission evidences. If the writeup does not say something, that is evidence of absence, not a gap to fill in the team's favour. Never infer competence, never round up to be kind, and never let confident writing substitute for a working demo or a good presentation.
 
 For the "demo" criterion specifically: no live demo was seen. Say that plainly in the reasoning, then score only what the writeup itself demonstrates about working software — what it claims is built and running versus what it says is mocked, planned, or aspirational. A team that writes convincingly about software that may not exist must not receive the same score as a team that showed it work. When in doubt, score low and say why in the reasoning.
+
+For the "presentation" criterion specifically: no presentation was seen either — there were no three minutes to judge. Say that plainly in the reasoning. A well-written submission is not evidence of a clear, honest, well-used three minutes; writing well and presenting well are different skills. Score only what the submission itself shows about clarity and honesty — how clearly it explains the problem and the named beneficiary, and whether it is straight about what works versus what is mocked rather than talking around the gaps. When in doubt, score low and say why in the reasoning.
 
 For every other criterion, ground the score and the one-sentence reasoning in specific lines from the submission. A human organiser reviews every number before it counts — your job is to give them an honest, well-reasoned starting point, not a final answer.`
 
@@ -252,7 +259,7 @@ What it does: ${submission.description}
 What works vs what is mocked: ${submission.worksVsMocked}
 How they used Claude: ${submission.claudeUsage}
 
-No live demo was seen for this team.`
+No live demo and no live presentation were seen for this team.`
 
     try {
       const { object } = await generateObject({

--- a/src/app/api/admin/impact-lab/rematch/route.ts
+++ b/src/app/api/admin/impact-lab/rematch/route.ts
@@ -73,6 +73,25 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  // This is a privacy guard, not bookkeeping. The published snapshot freezes
+  // each team's private scorecard, but it does NOT freeze the person-to-team
+  // mapping: /api/impact-lab/results and the results notify email both
+  // resolve which team a participant belongs to from this run's LIVE
+  // `result` via extractFrozenTeams(), then look up that team's card. If a
+  // rematch moved someone to a different team after publication, they would
+  // be shown — and possibly emailed — another team's private scores. Same
+  // rule as the live-judging route, applied here before any write.
+  if (run.judgingClosedAt) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Judging is closed — results have been published.",
+        code: "JUDGING_CLOSED",
+      },
+      { status: 409 }
+    )
+  }
+
   const frozenTeams = extractFrozenTeams(run.result)
   if (!frozenTeams) {
     return NextResponse.json(

--- a/src/app/api/admin/impact-lab/results/notify/route.ts
+++ b/src/app/api/admin/impact-lab/results/notify/route.ts
@@ -21,9 +21,18 @@ import { APP_URL, impactLabResultsEmail, sendEmailBatchTracked, type BatchEmailI
  *
  * Only rows with status <> 'sent' are selected, so no recipient is ever mailed
  * twice however many times this is called. A row that failed to send (bad
- * Resend response, missing team data) keeps status 'failed', which still
- * matches <> 'sent' — so the very next call retries it automatically, with no
- * extra step for the organiser.
+ * Resend response, missing team data) is left/returned to status 'failed',
+ * which still matches <> 'sent' — so the very next call retries it
+ * automatically, with no extra step for the organiser.
+ *
+ * The batch path marks its selected rows 'sent' *before* calling Resend
+ * (inside a `SELECT ... FOR UPDATE` transaction — the same locking pattern
+ * `publish/route.ts` uses), then downgrades only the rows Resend actually
+ * rejected back to 'failed' afterwards. This is a deliberate bias, not an
+ * oversight: against a 100/day quota shared by 93 recipients, a correlated
+ * failure (a dropped DB connection mid-write, two concurrent POSTs) must
+ * cost recipients a send rather than grant them two — a short run is
+ * recoverable without spending quota, a duplicate run is not.
  */
 export const maxDuration = 300
 
@@ -32,14 +41,55 @@ const BATCH_SIZE = 25
 const bodySchema = z.object({
   cohort: z.string().max(60).optional(),
   /**
-   * When set, sends exactly one preview email built from real (already
-   * published) snapshot data — a real team's real scores, a generic
-   * salutation — to this address only. Does not touch any
+   * When set, sends exactly one preview email to this address only: real
+   * announced winners and track winners (the public part, worth confirming),
+   * a fabricated "your team" scorecard (see SAMPLE_CARD — never a real
+   * team's private numbers), and a generic salutation. Does not touch any
    * ImpactLabResultsEmail row, so it can be pressed as many times as needed
-   * without affecting `remaining` or risking the daily quota meant for the 93.
+   * without affecting `remaining` — though it still spends from the same
+   * Resend daily quota as the real batch.
    */
   testEmail: z.string().email().max(200).optional(),
 })
+
+/**
+ * The "your team" half of a test send is fabricated on purpose. Building it
+ * from a real team's `perTeam` card — as an earlier version of this route
+ * did — meant a mistyped test address would receive that team's actual
+ * criterion averages and score range, private data `perTeam` is documented
+ * as never reaching anyone outside that team. `overall` and `trackWinners`
+ * stay real below, because those are the genuinely public part and the
+ * organiser needs to confirm the winners rendered correctly. The project
+ * name is deliberately unmissable as a placeholder so nobody mistakes this
+ * for a real team's result.
+ */
+const SAMPLE_CARD = {
+  projectName: "Sample Project (test preview — not a real team)",
+  rank: 4,
+  criterionAverages: { impact: 4.1, demo: 3.6, claude: 4.4, clarity: 3.9, presentation: 4.0 },
+  low: 68.5,
+  high: 84.0,
+  basis: "demo" as const,
+}
+
+/**
+ * Cheap duck-typed shape check on the stored JSON before it is cast to
+ * `ResultsSnapshot`. Not a full schema validation — just enough that a
+ * malformed or legacy-shaped snapshot fails with a clean 409 here rather than
+ * throwing an unhandled exception mid-batch (e.g. on `snapshot.perTeam[id]`
+ * for a `perTeam` that isn't actually an object).
+ */
+function isResultsSnapshot(value: unknown): value is ResultsSnapshot {
+  if (typeof value !== "object" || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    Array.isArray(v.overall) &&
+    Array.isArray(v.trackWinners) &&
+    Array.isArray(v.ranking) &&
+    typeof v.perTeam === "object" &&
+    v.perTeam !== null
+  )
+}
 
 async function loadPublishedRun(cohort: string) {
   const run = await prisma.impactLabMatchRun.findFirst({
@@ -51,10 +101,13 @@ async function loadPublishedRun(cohort: string) {
   if (!run.resultsPublishedAt || !run.resultsSnapshot) {
     return { ok: false as const, status: 409, error: "Results have not been published yet." }
   }
+  if (!isResultsSnapshot(run.resultsSnapshot)) {
+    return { ok: false as const, status: 409, error: "Stored results snapshot is malformed." }
+  }
   return {
     ok: true as const,
     runId: run.id,
-    snapshot: run.resultsSnapshot as unknown as ResultsSnapshot,
+    snapshot: run.resultsSnapshot,
     teams: extractFrozenTeams(run.result) ?? [],
   }
 }
@@ -133,25 +186,11 @@ export async function POST(request: NextRequest) {
 
   const dashboardUrl = `${APP_URL}/dashboard/impact-lab`
 
-  // ── Test send: one real-data preview, no DB rows touched ─────────────────
+  // ── Test send: real winners, fabricated "your team" card, no DB rows touched
   if (parsed.data.testEmail) {
-    const sample = run.snapshot.ranking[0]
-    const card = sample ? run.snapshot.perTeam[sample.teamId] : undefined
-    if (!sample || !card) {
-      return NextResponse.json(
-        { success: false, error: "No results to preview yet." },
-        { status: 409 }
-      )
-    }
-
     const built = impactLabResultsEmail({
       fullName: "there",
-      projectName: sample.projectName,
-      rank: card.rank,
-      criterionAverages: card.criterionAverages,
-      low: card.low,
-      high: card.high,
-      basis: card.basis,
+      ...SAMPLE_CARD,
       overall: run.snapshot.overall,
       trackWinners: run.snapshot.trackWinners,
       dashboardUrl,
@@ -183,27 +222,45 @@ export async function POST(request: NextRequest) {
   }
 
   // ── Batch send: up to BATCH_SIZE recipients still not marked 'sent' ──────
-  const rows = await prisma.impactLabResultsEmail.findMany({
-    where: { runId: run.runId, status: { not: "sent" } },
-    orderBy: { createdAt: "asc" },
-    take: BATCH_SIZE,
+  //
+  // Selects and marks 'sent' inside one locking transaction, before any
+  // email goes out — see the header comment for why. `FOR UPDATE` also closes
+  // the same race a second concurrent POST would otherwise hit: without it,
+  // two overlapping calls could both SELECT the same unsent rows before
+  // either commits, and both would mail them.
+  type LockedRow = { id: string; participantId: string; email: string }
+  const lockedRows = await prisma.$transaction(async (tx) => {
+    const selected = await tx.$queryRaw<LockedRow[]>`
+      SELECT id, "participantId", email
+      FROM impact_lab_results_emails
+      WHERE "runId" = ${run.runId} AND status <> 'sent'
+      ORDER BY "createdAt" ASC
+      LIMIT ${BATCH_SIZE}
+      FOR UPDATE
+    `
+    if (selected.length > 0) {
+      await tx.impactLabResultsEmail.updateMany({
+        where: { id: { in: selected.map((r) => r.id) } },
+        data: { status: "sent", sentAt: new Date(), error: null },
+      })
+    }
+    return selected
   })
 
-  if (rows.length === 0) {
+  if (lockedRows.length === 0) {
     return NextResponse.json({ success: true, data: { sent: 0, failed: 0, remaining: 0 } })
   }
 
   const participants = await prisma.impactLabParticipant.findMany({
-    where: { id: { in: rows.map((r) => r.participantId) } },
+    where: { id: { in: lockedRows.map((r) => r.participantId) } },
     select: { id: true, fullName: true },
   })
   const nameById = new Map(participants.map((p) => [p.id, p.fullName]))
 
-  type Row = (typeof rows)[number]
-  const sendable: { row: Row; item: BatchEmailItem }[] = []
-  const unmatched: { row: Row; error: string }[] = []
+  const sendable: { row: LockedRow; item: BatchEmailItem }[] = []
+  const unmatched: { row: LockedRow; error: string }[] = []
 
-  for (const row of rows) {
+  for (const row of lockedRows) {
     const team = run.teams.find((t) => t.memberIds.includes(row.participantId))
     const card = team ? run.snapshot.perTeam[team.id] : undefined
     const rankingRow = team ? run.snapshot.ranking.find((r) => r.teamId === team.id) : undefined
@@ -230,23 +287,23 @@ export async function POST(request: NextRequest) {
 
   const sendResults = await sendEmailBatchTracked(sendable.map((s) => s.item))
 
-  // Independent writes, not one $transaction: the emails are already out by
-  // this point, so a single all-or-nothing commit would (if it failed) throw
-  // away every recorded 'sent' status for a batch that really was delivered —
-  // turning one DB hiccup into 25 duplicate sends on the next call. A failed
-  // write here only costs its own row; it stays eligible for exactly the same
-  // resumable retry as a real send failure would.
+  // Downgrade only confirmed rejections. Every locked row is already 'sent'
+  // from the transaction above, so a write failure here just leaves that one
+  // row optimistically marked 'sent' rather than reverting it to a
+  // re-sendable state — the safe direction per the header comment. Unmatched
+  // rows (no team found) never reached `sendEmailBatchTracked` at all, but
+  // were still marked 'sent' by the transaction, so they must be downgraded
+  // the same way.
   for (const [i, s] of sendable.entries()) {
     const result = sendResults[i]
+    if (result.ok) continue
     try {
       await prisma.impactLabResultsEmail.update({
         where: { id: s.row.id },
-        data: result.ok
-          ? { status: "sent", sentAt: new Date(), error: null }
-          : { status: "failed", error: (result.error ?? "Send failed").slice(0, 500) },
+        data: { status: "failed", error: (result.error ?? "Send failed").slice(0, 500) },
       })
     } catch (err) {
-      console.error("[NOTIFY] Could not record send state for", s.row.email, err)
+      console.error("[NOTIFY] Could not downgrade failed send for", s.row.email, err)
     }
   }
   for (const u of unmatched) {
@@ -256,12 +313,13 @@ export async function POST(request: NextRequest) {
         data: { status: "failed", error: u.error },
       })
     } catch (err) {
-      console.error("[NOTIFY] Could not record send state for", u.row.email, err)
+      console.error("[NOTIFY] Could not downgrade failed send for", u.row.email, err)
     }
   }
 
-  const sent = sendResults.filter((r) => r.ok).length
-  const failed = sendResults.filter((r) => !r.ok).length + unmatched.length
+  const rejected = sendResults.filter((r) => !r.ok).length
+  const failed = rejected + unmatched.length
+  const sent = lockedRows.length - failed
   const remaining = await prisma.impactLabResultsEmail.count({
     where: { runId: run.runId, status: { not: "sent" } },
   })
@@ -273,7 +331,7 @@ export async function POST(request: NextRequest) {
     action: "UPDATE",
     entity: "ImpactLabResultsEmail",
     entityId: run.runId,
-    changes: { cohort, batchSize: rows.length, sent, failed, remaining },
+    changes: { cohort, batchSize: lockedRows.length, sent, failed, remaining },
     ...getRequestMetadata(request),
   })
 

--- a/src/app/api/admin/impact-lab/results/notify/route.ts
+++ b/src/app/api/admin/impact-lab/results/notify/route.ts
@@ -1,0 +1,281 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit } from "@/lib/rate-limit"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import type { ResultsSnapshot } from "@/lib/impact-lab/results"
+import { APP_URL, impactLabResultsEmail, sendEmailBatchTracked, type BatchEmailItem } from "@/lib/email"
+
+/**
+ * Send the results email, resumably.
+ *
+ * Processes at most BATCH_SIZE unsent recipients per call and reports how many
+ * remain; the admin UI calls it until zero. That keeps each invocation inside
+ * the function timeout and makes a timeout harmless — the next call picks up
+ * exactly where this one stopped, because progress lives in the database rather
+ * than in the request.
+ *
+ * Only rows with status <> 'sent' are selected, so no recipient is ever mailed
+ * twice however many times this is called. A row that failed to send (bad
+ * Resend response, missing team data) keeps status 'failed', which still
+ * matches <> 'sent' — so the very next call retries it automatically, with no
+ * extra step for the organiser.
+ */
+export const maxDuration = 300
+
+const BATCH_SIZE = 25
+
+const bodySchema = z.object({
+  cohort: z.string().max(60).optional(),
+  /**
+   * When set, sends exactly one preview email built from real (already
+   * published) snapshot data — a real team's real scores, a generic
+   * salutation — to this address only. Does not touch any
+   * ImpactLabResultsEmail row, so it can be pressed as many times as needed
+   * without affecting `remaining` or risking the daily quota meant for the 93.
+   */
+  testEmail: z.string().email().max(200).optional(),
+})
+
+async function loadPublishedRun(cohort: string) {
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true, resultsSnapshot: true, resultsPublishedAt: true },
+  })
+  if (!run) return { ok: false as const, status: 409, error: "No final run for this cohort." }
+  if (!run.resultsPublishedAt || !run.resultsSnapshot) {
+    return { ok: false as const, status: 409, error: "Results have not been published yet." }
+  }
+  return {
+    ok: true as const,
+    runId: run.id,
+    snapshot: run.resultsSnapshot as unknown as ResultsSnapshot,
+    teams: extractFrozenTeams(run.result) ?? [],
+  }
+}
+
+/**
+ * GET — current send counts for this cohort's final run, so the admin panel
+ * can render queued/sent/failed on load and after each batch without relying
+ * solely on the deltas a POST call returns.
+ */
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "edit")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, resultsPublishedAt: true },
+  })
+
+  if (!run?.resultsPublishedAt) {
+    return NextResponse.json({ success: true, data: { queued: 0, sent: 0, failed: 0 } })
+  }
+
+  const grouped = await prisma.impactLabResultsEmail.groupBy({
+    by: ["status"],
+    where: { runId: run.id },
+    _count: { _all: true },
+  })
+
+  const counts = { queued: 0, sent: 0, failed: 0 }
+  for (const g of grouped) {
+    if (g.status === "queued") counts.queued = g._count._all
+    else if (g.status === "sent") counts.sent = g._count._all
+    else if (g.status === "failed") counts.failed = g._count._all
+  }
+
+  return NextResponse.json({ success: true, data: counts })
+}
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  // "edit" — sending mail to 93 people is at least as consequential as the
+  // publish action that queues it, and MODERATOR (judge sign-in) must not
+  // reach this route at all.
+  const check = await checkApiPermission("impact-lab", "edit")
+  if (!check.authorized) return check.response
+
+  // The UI presses "Send next 25" up to four times to clear 93 recipients,
+  // plus test sends — generous enough for that, tight enough to stop a
+  // double-click storm from hammering Resend.
+  const rl = await rateLimit(request, {
+    maxRequests: 15,
+    windowInSeconds: 300,
+    identifier: () => `impact-lab-notify:${check.user.id}`,
+  })
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many attempts. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => ({})))
+  if (!parsed.success) {
+    return NextResponse.json({ success: false, error: "Invalid request body." }, { status: 400 })
+  }
+
+  const cohort = safeCohort(parsed.data.cohort)
+  const run = await loadPublishedRun(cohort)
+  if (!run.ok) {
+    return NextResponse.json({ success: false, error: run.error }, { status: run.status })
+  }
+
+  const dashboardUrl = `${APP_URL}/dashboard/impact-lab`
+
+  // ── Test send: one real-data preview, no DB rows touched ─────────────────
+  if (parsed.data.testEmail) {
+    const sample = run.snapshot.ranking[0]
+    const card = sample ? run.snapshot.perTeam[sample.teamId] : undefined
+    if (!sample || !card) {
+      return NextResponse.json(
+        { success: false, error: "No results to preview yet." },
+        { status: 409 }
+      )
+    }
+
+    const built = impactLabResultsEmail({
+      fullName: "there",
+      projectName: sample.projectName,
+      rank: card.rank,
+      criterionAverages: card.criterionAverages,
+      low: card.low,
+      high: card.high,
+      basis: card.basis,
+      overall: run.snapshot.overall,
+      trackWinners: run.snapshot.trackWinners,
+      dashboardUrl,
+    })
+
+    const [result] = await sendEmailBatchTracked([
+      { to: parsed.data.testEmail, subject: built.subject, html: built.html },
+    ])
+
+    const remaining = await prisma.impactLabResultsEmail.count({
+      where: { runId: run.runId, status: { not: "sent" } },
+    })
+
+    await logAudit({
+      userId: check.user.id,
+      userName: check.user.name,
+      userEmail: check.user.email,
+      action: "UPDATE",
+      entity: "ImpactLabResultsEmail",
+      entityId: run.runId,
+      changes: { test: true, ok: result.ok },
+      ...getRequestMetadata(request),
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: { sent: result.ok ? 1 : 0, failed: result.ok ? 0 : 1, remaining },
+    })
+  }
+
+  // ── Batch send: up to BATCH_SIZE recipients still not marked 'sent' ──────
+  const rows = await prisma.impactLabResultsEmail.findMany({
+    where: { runId: run.runId, status: { not: "sent" } },
+    orderBy: { createdAt: "asc" },
+    take: BATCH_SIZE,
+  })
+
+  if (rows.length === 0) {
+    return NextResponse.json({ success: true, data: { sent: 0, failed: 0, remaining: 0 } })
+  }
+
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { id: { in: rows.map((r) => r.participantId) } },
+    select: { id: true, fullName: true },
+  })
+  const nameById = new Map(participants.map((p) => [p.id, p.fullName]))
+
+  type Row = (typeof rows)[number]
+  const sendable: { row: Row; item: BatchEmailItem }[] = []
+  const unmatched: { row: Row; error: string }[] = []
+
+  for (const row of rows) {
+    const team = run.teams.find((t) => t.memberIds.includes(row.participantId))
+    const card = team ? run.snapshot.perTeam[team.id] : undefined
+    const rankingRow = team ? run.snapshot.ranking.find((r) => r.teamId === team.id) : undefined
+
+    if (!team || !card || !rankingRow) {
+      unmatched.push({ row, error: "No matching team found in the published results." })
+      continue
+    }
+
+    const built = impactLabResultsEmail({
+      fullName: nameById.get(row.participantId) ?? "there",
+      projectName: rankingRow.projectName,
+      rank: card.rank,
+      criterionAverages: card.criterionAverages,
+      low: card.low,
+      high: card.high,
+      basis: card.basis,
+      overall: run.snapshot.overall,
+      trackWinners: run.snapshot.trackWinners,
+      dashboardUrl,
+    })
+    sendable.push({ row, item: { to: row.email, subject: built.subject, html: built.html } })
+  }
+
+  const sendResults = await sendEmailBatchTracked(sendable.map((s) => s.item))
+
+  // Independent writes, not one $transaction: the emails are already out by
+  // this point, so a single all-or-nothing commit would (if it failed) throw
+  // away every recorded 'sent' status for a batch that really was delivered —
+  // turning one DB hiccup into 25 duplicate sends on the next call. A failed
+  // write here only costs its own row; it stays eligible for exactly the same
+  // resumable retry as a real send failure would.
+  for (const [i, s] of sendable.entries()) {
+    const result = sendResults[i]
+    try {
+      await prisma.impactLabResultsEmail.update({
+        where: { id: s.row.id },
+        data: result.ok
+          ? { status: "sent", sentAt: new Date(), error: null }
+          : { status: "failed", error: (result.error ?? "Send failed").slice(0, 500) },
+      })
+    } catch (err) {
+      console.error("[NOTIFY] Could not record send state for", s.row.email, err)
+    }
+  }
+  for (const u of unmatched) {
+    try {
+      await prisma.impactLabResultsEmail.update({
+        where: { id: u.row.id },
+        data: { status: "failed", error: u.error },
+      })
+    } catch (err) {
+      console.error("[NOTIFY] Could not record send state for", u.row.email, err)
+    }
+  }
+
+  const sent = sendResults.filter((r) => r.ok).length
+  const failed = sendResults.filter((r) => !r.ok).length + unmatched.length
+  const remaining = await prisma.impactLabResultsEmail.count({
+    where: { runId: run.runId, status: { not: "sent" } },
+  })
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "UPDATE",
+    entity: "ImpactLabResultsEmail",
+    entityId: run.runId,
+    changes: { cohort, batchSize: rows.length, sent, failed, remaining },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({ success: true, data: { sent, failed, remaining } })
+}

--- a/src/app/api/admin/impact-lab/results/publish/route.ts
+++ b/src/app/api/admin/impact-lab/results/publish/route.ts
@@ -1,0 +1,310 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit } from "@/lib/rate-limit"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import { standings, trackOf, weightedTotal, type JudgeScore, type ScoreSheet } from "@/lib/impact-lab/judging"
+import { buildSnapshot, type ResultsInput } from "@/lib/impact-lab/results"
+
+/**
+ * Mark final. A one-way door.
+ *
+ * Closes submissions and judging, computes the snapshot, and queues one row per
+ * recipient — all inside one row-locked transaction, so a second click cannot
+ * publish twice or queue a second set of emails.
+ *
+ * Everything participants see afterwards is served from the stored snapshot and
+ * never recomputed. This matters concretely: one team edited its submission a
+ * full day after being judged, so live data demonstrably moves after the fact.
+ * What 93 people are told must not move with it.
+ */
+
+const bodySchema = z.object({
+  cohort: z.string().max(60).optional(),
+  announcedTeamIds: z.array(z.string().min(1).max(64)).max(20),
+  confirm: z.string(),
+})
+
+/** What the transaction decided — translated into a response after it commits. */
+type PublishOutcome =
+  | { ok: true; publishedAt: string; recipients: number }
+  | { ok: false; status: number; error: string; code?: string }
+
+/**
+ * GET — whether this cohort's final run has already been published, so the
+ * admin panel can render the post-publish summary (and hide the button)
+ * after a page reload rather than only right after the POST that did it.
+ */
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, resultsPublishedAt: true },
+  })
+
+  if (!run?.resultsPublishedAt) {
+    return NextResponse.json({
+      success: true,
+      data: { published: false, publishedAt: null, recipients: 0 },
+    })
+  }
+
+  const recipients = await prisma.impactLabResultsEmail.count({ where: { runId: run.id } })
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      published: true,
+      publishedAt: run.resultsPublishedAt.toISOString(),
+      recipients,
+    },
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  // A one-way door does not need a generous quota, but refusals (already
+  // published, unscored teams) must not burn it — an organiser deliberately
+  // attempts this once before the real thing to see Step 4's refusal fire.
+  // Scoped to the caller, not the IP, so a shared office network can't share
+  // one bucket across organisers.
+  const rl = await rateLimit(request, {
+    maxRequests: 10,
+    windowInSeconds: 300,
+    identifier: () => `impact-lab-publish:${check.user.id}`,
+  })
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many attempts. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick the announced winners and confirm." },
+      { status: 400 }
+    )
+  }
+
+  // A typed confirmation is cheap insurance on a one-way door — checked before
+  // any query runs, not just before the write.
+  if (parsed.data.confirm !== "PUBLISH") {
+    return NextResponse.json(
+      { success: false, error: 'Type PUBLISH to confirm.', code: "CONFIRM_REQUIRED" },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(parsed.data.cohort)
+  const existing = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true },
+  })
+  if (!existing) {
+    return NextResponse.json(
+      { success: false, error: "No final run for this cohort." },
+      { status: 409 }
+    )
+  }
+  const runId = existing.id
+
+  const outcome = await prisma.$transaction(async (tx): Promise<PublishOutcome> => {
+    // 1. Lock the run row so a second click cannot race this one.
+    await tx.$queryRaw`SELECT id FROM impact_lab_match_runs WHERE id = ${runId} FOR UPDATE`
+
+    const run = await tx.impactLabMatchRun.findUnique({
+      where: { id: runId },
+      select: { id: true, result: true, resultsPublishedAt: true, submissionsCloseAt: true },
+    })
+    if (!run) return { ok: false, status: 404, error: "Run not found." }
+
+    // 2. Already published — refuse rather than silently republishing.
+    if (run.resultsPublishedAt) {
+      return {
+        ok: false,
+        status: 409,
+        error: "Results have already been published for this run.",
+        code: "ALREADY_PUBLISHED",
+      }
+    }
+
+    const teams = extractFrozenTeams(run.result) ?? []
+    const nameById = new Map(teams.map((t) => [t.id, t.name]))
+    const teamIds = new Set(teams.map((t) => t.id))
+
+    const [submissions, scoreRows] = await Promise.all([
+      tx.impactLabSubmission.findMany({
+        where: { runId },
+        select: { teamId: true, projectName: true },
+      }),
+      tx.impactLabScore.findMany({
+        where: { runId },
+        select: { teamId: true, judgeEmail: true, scores: true, writeupOnly: true },
+      }),
+    ])
+
+    const submittedTeamIds = new Set(submissions.map((s) => s.teamId))
+    const scoredTeamIds = new Set(scoreRows.map((s) => s.teamId))
+    // What an organiser actually recognises a team by — the run-JSON team
+    // name is an internal id like "Table 12 — Kilimo (Agriculture)".
+    const projectNameById = new Map(submissions.map((s) => [s.teamId, s.projectName]))
+    const displayName = (id: string): string => projectNameById.get(id) ?? nameById.get(id) ?? id
+
+    // 3. Every submitted team must have at least one score — this is what stops
+    // the four unscored teams being published as blanks.
+    const unscored = [...submittedTeamIds]
+      .filter((id) => !scoredTeamIds.has(id))
+      .map((id) => displayName(id))
+    if (unscored.length > 0) {
+      return {
+        ok: false,
+        status: 409,
+        error: `These teams submitted but have no score: ${unscored.join(", ")}`,
+        code: "UNSCORED_TEAMS",
+      }
+    }
+
+    // 4. Announced winners must be real teams in this run, named once each.
+    const seen = new Set<string>()
+    for (const id of parsed.data.announcedTeamIds) {
+      if (seen.has(id)) {
+        return {
+          ok: false,
+          status: 400,
+          error: `"${displayName(id)}" is listed twice as an announced winner.`,
+          code: "DUPLICATE_ANNOUNCED",
+        }
+      }
+      seen.add(id)
+      if (!teamIds.has(id)) {
+        return {
+          ok: false,
+          status: 400,
+          error: `"${id}" is not a team in this run.`,
+          code: "UNKNOWN_ANNOUNCED",
+        }
+      }
+    }
+
+    // 5. Build the ResultsInput the pure snapshot builder needs.
+    const judgeScores: JudgeScore[] = scoreRows.map((s) => ({
+      judgeEmail: s.judgeEmail,
+      teamId: s.teamId,
+      sheet: (s.scores ?? {}) as ScoreSheet,
+    }))
+    const table = standings(judgeScores)
+
+    const rowsByTeam = new Map<string, typeof scoreRows>()
+    for (const row of scoreRows) {
+      const list = rowsByTeam.get(row.teamId)
+      if (list) list.push(row)
+      else rowsByTeam.set(row.teamId, [row])
+    }
+
+    const writeupOnly = new Set<string>()
+    const range = new Map<string, { low: number; high: number }>()
+    for (const [teamId, rows] of rowsByTeam) {
+      if (rows.every((r) => r.writeupOnly)) writeupOnly.add(teamId)
+
+      const totals = rows.map((r) => weightedTotal((r.scores ?? {}) as ScoreSheet))
+      range.set(teamId, { low: Math.min(...totals), high: Math.max(...totals) })
+    }
+
+    const teamsMeta = new Map<string, { projectName: string; track: string }>()
+    for (const submission of submissions) {
+      const teamName = nameById.get(submission.teamId) ?? ""
+      teamsMeta.set(submission.teamId, {
+        projectName: submission.projectName,
+        track: trackOf(teamName),
+      })
+    }
+
+    const publishedAt = new Date()
+    const input: ResultsInput = {
+      publishedAt: publishedAt.toISOString(),
+      announcedTeamIds: parsed.data.announcedTeamIds,
+      standings: table,
+      teams: teamsMeta,
+      writeupOnly,
+      range,
+    }
+    const snapshot = buildSnapshot(input)
+
+    // Recipients: participants on a team that has a submission — the 93.
+    const submittedTeams = teams.filter((t) => submittedTeamIds.has(t.id))
+    const recipientIds = new Set<string>()
+    for (const team of submittedTeams) {
+      for (const memberId of team.memberIds) recipientIds.add(memberId)
+    }
+    const participants = await tx.impactLabParticipant.findMany({
+      where: { id: { in: [...recipientIds] } },
+      select: { id: true, email: true },
+    })
+
+    // 6. Update the run — this is the moment the door closes.
+    await tx.impactLabMatchRun.update({
+      where: { id: runId },
+      data: {
+        submissionsCloseAt: run.submissionsCloseAt ?? publishedAt,
+        judgingClosedAt: publishedAt,
+        resultsPublishedAt: publishedAt,
+        announcedWinners: JSON.parse(JSON.stringify(snapshot.overall)),
+        resultsSnapshot: JSON.parse(JSON.stringify(snapshot)),
+      },
+    })
+
+    // 7. Queue one row per recipient. skipDuplicates makes a retried request
+    // (or a second click that slipped past the lock) a no-op rather than a
+    // second batch of mail.
+    if (participants.length > 0) {
+      await tx.impactLabResultsEmail.createMany({
+        data: participants.map((p) => ({ runId, participantId: p.id, email: p.email })),
+        skipDuplicates: true,
+      })
+    }
+
+    return { ok: true, publishedAt: publishedAt.toISOString(), recipients: participants.length }
+  })
+
+  if (!outcome.ok) {
+    return NextResponse.json(
+      { success: false, error: outcome.error, ...(outcome.code ? { code: outcome.code } : {}) },
+      { status: outcome.status }
+    )
+  }
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "PUBLISH",
+    entity: "ImpactLabMatchRun",
+    entityId: runId,
+    changes: {
+      announcedTeamIds: parsed.data.announcedTeamIds,
+      recipients: outcome.recipients,
+    },
+    ...getRequestMetadata(request),
+  })
+
+  return NextResponse.json({
+    success: true,
+    data: { publishedAt: outcome.publishedAt, recipients: outcome.recipients },
+  })
+}

--- a/src/app/api/admin/impact-lab/results/publish/route.ts
+++ b/src/app/api/admin/impact-lab/results/publish/route.ts
@@ -40,7 +40,11 @@ type PublishOutcome =
  * after a page reload rather than only right after the POST that did it.
  */
 export async function GET(request: NextRequest) {
-  const check = await checkApiPermission("impact-lab", "view")
+  // "edit", not "view" — MODERATOR (the judge-signin role) holds only "view"
+  // on impact-lab, and this endpoint's POST closes judging irreversibly.
+  // "view" would let a judge account read publish status for a route it must
+  // not be able to call at all; gate both handlers the same way.
+  const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
   const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
@@ -73,7 +77,10 @@ export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 
-  const check = await checkApiPermission("impact-lab", "view")
+  // "edit": publish closes judging and freezes/emails the result — strictly
+  // more consequential than notify/route.ts (which requires "create"), and
+  // MODERATOR (judge signin) must not be able to reach it at all.
+  const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
   // A one-way door does not need a generous quota, but refusals (already
@@ -198,6 +205,17 @@ export async function POST(request: NextRequest) {
           status: 400,
           error: `"${id}" is not a team in this run.`,
           code: "UNKNOWN_ANNOUNCED",
+        }
+      }
+      // A team with no submission has no entry in teamsMeta below, so
+      // metaOf()'s fallback would put the raw teamId in place of a project
+      // name — permanently, in a snapshot that is emailed to 93 people.
+      if (!submittedTeamIds.has(id)) {
+        return {
+          ok: false,
+          status: 400,
+          error: `"${displayName(id)}" has no submission and cannot be announced as a winner.`,
+          code: "ANNOUNCED_NO_SUBMISSION",
         }
       }
     }

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -3,30 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
-import {
-  toPublicRanking,
-  type AnnouncedWinner,
-  type ResultsSnapshot,
-  type ResultsTrackWinner,
-  type TeamCard,
-} from "@/lib/impact-lab/results"
-
-/** GET /api/impact-lab/results response shape. Flat member shape — no `data` wrapper. */
-interface ResultsResponse {
-  success: true
-  published: boolean
-  results?: {
-    publishedAt: string
-    overall: AnnouncedWinner[]
-    trackWinners: ResultsTrackWinner[]
-    ranking: ReturnType<typeof toPublicRanking>
-  }
-  yourTeam?: {
-    teamId: string
-    projectName: string
-    card: TeamCard
-  }
-}
+import { buildMemberPayload, type ResultsSnapshot } from "@/lib/impact-lab/results"
 
 /**
  * The published result, for one participant.
@@ -34,7 +11,10 @@ interface ResultsResponse {
  * `perTeam` holds every team's private card, so the whole map must never reach
  * the client — only the caller's own entry is attached. Judge counts and judge
  * identities are absent from the snapshot by construction, so there is nothing
- * to strip there.
+ * to strip there. The response shape itself is built by `buildMemberPayload`
+ * (`@/lib/impact-lab/results`), not assembled here, so the privacy properties
+ * can be asserted directly against that function rather than trusted of this
+ * route's wiring.
  */
 export async function GET(request: NextRequest) {
   const rl = await rateLimit(request, RateLimits.READ)
@@ -61,36 +41,17 @@ export async function GET(request: NextRequest) {
 
   const snapshot = run.resultsSnapshot as unknown as ResultsSnapshot
 
-  const body: ResultsResponse = {
-    success: true,
-    published: true,
-    results: {
-      publishedAt: snapshot.publishedAt,
-      overall: snapshot.overall,
-      trackWinners: snapshot.trackWinners,
-      ranking: toPublicRanking(snapshot.ranking),
-    },
-  }
-
   const participant = await prisma.impactLabParticipant.findUnique({
     where: { cohort_email: { cohort: DEFAULT_COHORT, email: check.email } },
     select: { id: true },
   })
 
+  let viewerTeamId: string | null = null
   if (participant) {
     const teams = extractFrozenTeams(run.result)
     const team = teams?.find((t) => t.memberIds.includes(participant.id))
-    const card = team ? snapshot.perTeam[team.id] : undefined
-    const rankingRow = team ? snapshot.ranking.find((r) => r.teamId === team.id) : undefined
-
-    if (team && card && rankingRow) {
-      body.yourTeam = {
-        teamId: team.id,
-        projectName: rankingRow.projectName,
-        card,
-      }
-    }
+    viewerTeamId = team?.id ?? null
   }
 
-  return NextResponse.json(body)
+  return NextResponse.json(buildMemberPayload(snapshot, viewerTeamId))
 }

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -1,0 +1,96 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
+import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
+import {
+  toPublicRanking,
+  type AnnouncedWinner,
+  type ResultsSnapshot,
+  type ResultsTrackWinner,
+  type TeamCard,
+} from "@/lib/impact-lab/results"
+
+/** GET /api/impact-lab/results response shape. Flat member shape — no `data` wrapper. */
+interface ResultsResponse {
+  success: true
+  published: boolean
+  results?: {
+    publishedAt: string
+    overall: AnnouncedWinner[]
+    trackWinners: ResultsTrackWinner[]
+    ranking: ReturnType<typeof toPublicRanking>
+  }
+  yourTeam?: {
+    teamId: string
+    projectName: string
+    card: TeamCard
+  }
+}
+
+/**
+ * The published result, for one participant.
+ *
+ * `perTeam` holds every team's private card, so the whole map must never reach
+ * the client — only the caller's own entry is attached. Judge counts and judge
+ * identities are absent from the snapshot by construction, so there is nothing
+ * to strip there.
+ */
+export async function GET(request: NextRequest) {
+  const rl = await rateLimit(request, RateLimits.READ)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Please try again later." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort: DEFAULT_COHORT, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { result: true, resultsPublishedAt: true, resultsSnapshot: true },
+  })
+
+  // Never leak an unpublished snapshot — including its mere existence.
+  if (!run?.resultsPublishedAt || !run.resultsSnapshot) {
+    return NextResponse.json({ success: true, published: false })
+  }
+
+  const snapshot = run.resultsSnapshot as unknown as ResultsSnapshot
+
+  const body: ResultsResponse = {
+    success: true,
+    published: true,
+    results: {
+      publishedAt: snapshot.publishedAt,
+      overall: snapshot.overall,
+      trackWinners: snapshot.trackWinners,
+      ranking: toPublicRanking(snapshot.ranking),
+    },
+  }
+
+  const participant = await prisma.impactLabParticipant.findUnique({
+    where: { cohort_email: { cohort: DEFAULT_COHORT, email: check.email } },
+    select: { id: true },
+  })
+
+  if (participant) {
+    const teams = extractFrozenTeams(run.result)
+    const team = teams?.find((t) => t.memberIds.includes(participant.id))
+    const card = team ? snapshot.perTeam[team.id] : undefined
+    const rankingRow = team ? snapshot.ranking.find((r) => r.teamId === team.id) : undefined
+
+    if (team && card && rankingRow) {
+      body.yourTeam = {
+        teamId: team.id,
+        projectName: rankingRow.projectName,
+        card,
+      }
+    }
+  }
+
+  return NextResponse.json(body)
+}

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -19,6 +19,7 @@ import type {
 import { SOCIAL_LINKS } from "@/lib/constants";
 import { MatchProfileForm } from "./MatchProfileForm";
 import { TeamReveal } from "./TeamReveal";
+import { ResultsView, type ResultsViewProps } from "./ResultsView";
 
 interface ProfileResponse {
   success?: boolean;
@@ -34,13 +35,22 @@ interface TeamResponse {
   error?: string;
 }
 
+interface ResultsResponse {
+  success?: boolean;
+  published?: boolean;
+  results?: ResultsViewProps["results"];
+  yourTeam?: ResultsViewProps["yourTeam"];
+  error?: string;
+}
+
 type Phase =
   | "loading"
   | "error"
   | "not-registered"
   | "profile"
   | "unassigned"
-  | "revealed";
+  | "revealed"
+  | "results";
 
 /**
  * Client state machine for /dashboard/impact-lab. The server page has already
@@ -52,18 +62,39 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
   const [phase, setPhase] = useState<Phase>("loading");
   const [profile, setProfile] = useState<MemberProfile | null>(null);
   const [team, setTeam] = useState<TeamRevealView | null>(null);
+  const [results, setResults] = useState<ResultsViewProps | null>(null);
   const [editing, setEditing] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
     let active = true;
-    Promise.all([fetch("/api/impact-lab/profile"), fetch("/api/impact-lab/team")])
-      .then(async ([profileRes, teamRes]) => {
+    Promise.all([
+      fetch("/api/impact-lab/profile"),
+      fetch("/api/impact-lab/team"),
+      fetch("/api/impact-lab/results"),
+    ])
+      .then(async ([profileRes, teamRes, resultsRes]) => {
         const profileJson: ProfileResponse = await profileRes.json();
         const teamJson: TeamResponse = await teamRes.json();
+        const resultsJson: ResultsResponse = await resultsRes.json();
         if (!active) return;
-        if (!profileRes.ok || !profileJson.success || !teamRes.ok || !teamJson.success) {
+        if (
+          !profileRes.ok ||
+          !profileJson.success ||
+          !teamRes.ok ||
+          !teamJson.success ||
+          !resultsRes.ok ||
+          !resultsJson.success
+        ) {
           setPhase("error");
+          return;
+        }
+
+        // Results published takes precedence over the team reveal — once
+        // results are out, the hackathon is over and this is what matters.
+        if (resultsJson.published && resultsJson.results) {
+          setResults({ results: resultsJson.results, yourTeam: resultsJson.yourTeam });
+          setPhase("results");
           return;
         }
 
@@ -117,6 +148,10 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
         </button>
       </div>
     );
+  }
+
+  if (phase === "results" && results) {
+    return <ResultsView results={results.results} yourTeam={results.yourTeam} />;
   }
 
   if (phase === "revealed" && team) {

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -71,20 +71,34 @@ export function ImpactLabClient({ sessionEmail }: { sessionEmail: string }) {
     Promise.all([
       fetch("/api/impact-lab/profile"),
       fetch("/api/impact-lab/team"),
-      fetch("/api/impact-lab/results"),
+      // Caught here, not left to reject Promise.all: the results endpoint is
+      // rate-limited per client IP (100/60s), and hackathon venues put dozens
+      // of participants behind one NAT address. A burst right after the
+      // results email goes out can 429 this single fetch — that must not
+      // black out profile/team, which have nothing to do with results.
+      fetch("/api/impact-lab/results").catch(() => null),
     ])
       .then(async ([profileRes, teamRes, resultsRes]) => {
         const profileJson: ProfileResponse = await profileRes.json();
         const teamJson: TeamResponse = await teamRes.json();
-        const resultsJson: ResultsResponse = await resultsRes.json();
+        // Soft-fail only: a missing/non-ok/malformed results response
+        // degrades to "not published yet" instead of failing the page.
+        // Profile and team below keep their existing all-or-nothing checks.
+        let resultsJson: ResultsResponse = { success: true, published: false };
+        if (resultsRes && resultsRes.ok) {
+          try {
+            const parsed: ResultsResponse = await resultsRes.json();
+            if (parsed.success) resultsJson = parsed;
+          } catch {
+            // Malformed body — treat as not published, same as a 429.
+          }
+        }
         if (!active) return;
         if (
           !profileRes.ok ||
           !profileJson.success ||
           !teamRes.ok ||
-          !teamJson.success ||
-          !resultsRes.ok ||
-          !resultsJson.success
+          !teamJson.success
         ) {
           setPhase("error");
           return;

--- a/src/app/dashboard/impact-lab/ResultsView.tsx
+++ b/src/app/dashboard/impact-lab/ResultsView.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { motion, useReducedMotion } from "framer-motion";
+import { Award, Medal, Trophy } from "lucide-react";
+import { JUDGING_CRITERIA, MAX_SCORE, MIN_SCORE } from "@/lib/impact-lab/judging";
+import type {
+  AnnouncedWinner,
+  PublicRankedTeam,
+  ResultsTrackWinner,
+  TeamCard,
+} from "@/lib/impact-lab/results";
+
+export interface ResultsViewProps {
+  results: {
+    publishedAt: string;
+    overall: AnnouncedWinner[];
+    trackWinners: ResultsTrackWinner[];
+    ranking: PublicRankedTeam[];
+  };
+  yourTeam?: {
+    teamId: string;
+    projectName: string;
+    card: TeamCard;
+  };
+}
+
+const ORDINALS: Record<number, string> = {
+  1: "1st",
+  2: "2nd",
+  3: "3rd",
+};
+
+function ordinal(rank: number): string {
+  return ORDINALS[rank] ?? `${rank}th`;
+}
+
+/**
+ * Results view — the payoff page. Four sections, in a fixed order: winners
+ * (announced champion + runners-up, then track winners), the caller's own
+ * scorecard, the full ranking (position/project/track only), and the note
+ * explaining how the two published things — the panel's announcement and the
+ * scored ranking — relate to each other.
+ *
+ * The API has already stripped every other team's card and every `average`
+ * from the ranking before this component ever sees it (see the route's own
+ * doc comment) — nothing here re-derives or re-fetches a score.
+ */
+export function ResultsView({ results, yourTeam }: ResultsViewProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  const container = {
+    hidden: {},
+    show: { transition: { staggerChildren: prefersReducedMotion ? 0 : 0.08 } },
+  };
+  const item = prefersReducedMotion
+    ? { hidden: { opacity: 1 }, show: { opacity: 1 } }
+    : {
+        hidden: { opacity: 0, y: 12 },
+        show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" as const } },
+      };
+
+  const [champion, ...runnersUp] = results.overall;
+  const yourTrack = yourTeam
+    ? results.ranking.find((r) => r.teamId === yourTeam.teamId)?.track
+    : undefined;
+
+  return (
+    <motion.div className="space-y-8" variants={container} initial="hidden" animate="show">
+      {/* ── 1. Winners ─────────────────────────────────────────────────── */}
+      {(champion || results.trackWinners.length > 0) && (
+        <motion.section variants={item} aria-label="Winners">
+          <h2 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
+            <Trophy className="h-3.5 w-3.5 text-amber" />
+            {"// ./winners"}
+          </h2>
+
+          {champion && (
+            <div className="relative overflow-hidden rounded-lg border border-amber/30 bg-amber/10 p-6">
+              <div className="relative flex flex-wrap items-center gap-4">
+                <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded border border-amber/40 bg-amber/15">
+                  <Trophy className="h-7 w-7 text-amber" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="font-mono text-[11px] uppercase tracking-wider text-amber">
+                    Champion
+                  </p>
+                  <p className="mt-1 truncate font-mono text-xl font-bold text-text-primary sm:text-2xl">
+                    {champion.projectName}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {runnersUp.length > 0 && (
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              {runnersUp.map((winner) => (
+                <div
+                  key={winner.teamId}
+                  className="flex items-center gap-3 rounded-lg border border-border-default bg-bg-secondary p-4"
+                >
+                  <Medal className="h-5 w-5 shrink-0 text-text-dim" aria-hidden="true" />
+                  <div className="min-w-0">
+                    <p className="font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                      {ordinal(winner.rank)} place
+                    </p>
+                    <p className="truncate font-mono text-sm font-semibold text-text-primary">
+                      {winner.projectName}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {results.trackWinners.length > 0 && (
+            <div className="mt-4">
+              <p className="mb-2 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                Track winners
+              </p>
+              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {results.trackWinners.map((winner) => (
+                  <div
+                    key={winner.track}
+                    className="flex items-start gap-2 rounded border border-border-default bg-bg-secondary p-3"
+                  >
+                    <Award className="mt-0.5 h-3.5 w-3.5 shrink-0 text-cyan" aria-hidden="true" />
+                    <div className="min-w-0">
+                      <p className="truncate font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                        {winner.track}
+                      </p>
+                      <p className="truncate font-mono text-xs font-semibold text-text-primary">
+                        {winner.projectName}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </motion.section>
+      )}
+
+      {/* ── 2. Your team ───────────────────────────────────────────────── */}
+      {yourTeam && (
+        <motion.section
+          variants={item}
+          aria-label="Your team's results"
+          className="rounded-lg border border-green-primary/30 bg-bg-secondary p-6"
+        >
+          <p className="font-mono text-[11px] uppercase tracking-wider text-green-primary mb-1">
+            {"// ./your-results"}
+          </p>
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <h2 className="font-mono text-xl font-bold text-text-primary sm:text-2xl">
+              {yourTeam.projectName}
+            </h2>
+            <span className="font-mono text-xs text-text-dim">
+              {ordinal(yourTeam.card.rank)} overall
+              {yourTrack ? ` · ${yourTrack}` : ""}
+            </span>
+          </div>
+
+          {yourTeam.card.basis === "submission" && (
+            <p className="mt-3 rounded border border-border-default bg-bg-card p-3 text-xs leading-relaxed text-text-secondary">
+              Your project was reviewed from your written submission against the
+              same five criteria. A live demo was not part of that review, which
+              is noted against the demo criterion below.
+            </p>
+          )}
+
+          <div className="mt-5 space-y-3">
+            {JUDGING_CRITERIA.map((criterion) => {
+              const value = yourTeam.card.criterionAverages[criterion.key] ?? 0;
+              const pct = Math.max(
+                0,
+                Math.min(100, ((value - MIN_SCORE) / (MAX_SCORE - MIN_SCORE)) * 100)
+              );
+              return (
+                <div key={criterion.key}>
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="font-mono text-xs text-text-secondary">
+                      {criterion.label}
+                    </span>
+                    <span className="font-mono text-xs text-text-dim">{value.toFixed(1)} / 5</span>
+                  </div>
+                  <div
+                    role="progressbar"
+                    aria-label={criterion.label}
+                    aria-valuemin={MIN_SCORE}
+                    aria-valuemax={MAX_SCORE}
+                    aria-valuenow={value}
+                    className="mt-1 h-2 w-full overflow-hidden rounded-full bg-bg-card"
+                  >
+                    <div
+                      className="h-full rounded-full bg-green-primary"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {yourTeam.card.low !== null && yourTeam.card.high !== null && (
+            <p className="mt-4 font-mono text-[11px] text-text-dim">
+              Score range across judges: {yourTeam.card.low.toFixed(1)}–
+              {yourTeam.card.high.toFixed(1)}
+            </p>
+          )}
+        </motion.section>
+      )}
+
+      {/* ── 3. Full ranking ────────────────────────────────────────────── */}
+      <motion.section variants={item} aria-label="Full ranking">
+        <h2 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
+          {"// ./full-ranking"}
+        </h2>
+        <div className="overflow-x-auto rounded-lg border border-border-default">
+          <table className="w-full min-w-[420px] border-collapse">
+            <thead>
+              <tr className="border-b border-border-default bg-bg-secondary">
+                {["Position", "Project", "Track"].map((h) => (
+                  <th
+                    key={h}
+                    scope="col"
+                    className="whitespace-nowrap px-4 py-2.5 text-left font-mono text-[10px] font-semibold uppercase tracking-wider text-text-dim"
+                  >
+                    {h}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border-default">
+              {results.ranking.map((row) => {
+                const isSelf = row.teamId === yourTeam?.teamId;
+                return (
+                  <tr
+                    key={row.teamId}
+                    className={isSelf ? "bg-green-primary/10" : undefined}
+                  >
+                    <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-text-dim">
+                      {row.rank}
+                    </td>
+                    <td className="px-4 py-2.5 font-mono text-xs text-text-primary">
+                      <span className="inline-flex flex-wrap items-center gap-2">
+                        {row.projectName}
+                        {isSelf && (
+                          <span className="rounded border border-green-primary/40 bg-green-primary/10 px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-green-primary">
+                            you
+                          </span>
+                        )}
+                        {row.basis === "submission" && (
+                          <span className="rounded border border-border-default bg-bg-card px-1.5 py-0.5 font-mono text-[9px] uppercase tracking-wider text-text-dim">
+                            Reviewed from submission
+                          </span>
+                        )}
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-2.5 font-mono text-xs text-text-secondary">
+                      {row.track}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </motion.section>
+
+      {/* ── 4. The note ────────────────────────────────────────────────── */}
+      <motion.section variants={item} aria-label="How these results were decided">
+        <h2 className="mb-3 font-mono text-xs uppercase tracking-wider text-text-dim">
+          {"// ./how-these-results-were-decided"}
+        </h2>
+        <div className="space-y-3 rounded-lg border border-border-default bg-bg-secondary p-5 text-sm leading-relaxed text-text-secondary">
+          <p className="font-mono text-sm font-semibold text-text-primary">
+            How these results were decided
+          </p>
+          <p>
+            Every project that was submitted has been reviewed against the same
+            five criteria and ranked. Where the panel saw a live demo, their
+            scores are the ones shown. Where a team submitted but the panel did
+            not see it presented, the project was reviewed from the written
+            submission instead.
+          </p>
+          <p>
+            The top three were decided by the judging panel after they had seen
+            the demos and discussed the projects together. That conversation is
+            what those placings reflect. Every other team is ranked below them
+            on score.
+          </p>
+          <p>
+            Scores are shown in full because you are entitled to see how your
+            own work was assessed.
+          </p>
+        </div>
+      </motion.section>
+    </motion.div>
+  );
+}

--- a/src/app/judge/JudgeScoring.tsx
+++ b/src/app/judge/JudgeScoring.tsx
@@ -46,6 +46,10 @@ export function JudgeScoring() {
   const [saving, setSaving] = useState<string | null>(null);
   const [saved, setSaved] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+  // "Unscored" first, because the failure at 5 AM is a team nobody reached —
+  // and that is invisible on a list sorted by table number.
+  const [filter, setFilter] = useState<"all" | "unscored" | "scored">("all");
 
   const load = useCallback(async () => {
     try {
@@ -132,9 +136,72 @@ export function JudgeScoring() {
     return <p className="text-sm text-text-dim">No teams are published yet.</p>;
   }
 
+  const scoredIds = new Set(
+    Object.entries(sheets)
+      .filter(([, sheet]) => Object.keys(sheet ?? {}).length > 0)
+      .map(([id]) => id)
+  );
+
+  const needle = query.trim().toLowerCase();
+  const visible = data.teams.filter((team) => {
+    if (filter === "scored" && !scoredIds.has(team.teamId)) return false;
+    if (filter === "unscored" && scoredIds.has(team.teamId)) return false;
+    if (!needle) return true;
+    // Judges are told "table 12" over a microphone, so the table number in the
+    // team name has to match as readily as the project title.
+    return (
+      team.teamName.toLowerCase().includes(needle) ||
+      (team.submission?.projectName ?? "").toLowerCase().includes(needle)
+    );
+  });
+
+  const FILTERS: { key: "all" | "unscored" | "scored"; label: string }[] = [
+    { key: "all", label: `All ${data.teams.length}` },
+    { key: "unscored", label: `Not scored ${data.teams.length - scoredIds.size}` },
+    { key: "scored", label: `Scored ${scoredIds.size}` },
+  ];
+
   return (
     <div className="space-y-3">
-      {data.teams.map((team) => {
+      <div className="sticky top-0 z-10 -mx-1 space-y-2 bg-bg-primary px-1 pb-2 pt-1">
+        <label htmlFor="judge-team-search" className="sr-only">
+          Search teams
+        </label>
+        <input
+          id="judge-team-search"
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search table number or project"
+          autoComplete="off"
+          className="w-full rounded-lg border border-border-default bg-bg-card px-3 py-3 text-base text-text-primary placeholder:text-text-dim focus:border-green-primary focus:outline-none"
+        />
+        <div className="flex gap-2">
+          {FILTERS.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setFilter(f.key)}
+              aria-pressed={filter === f.key}
+              className={`flex-1 rounded-lg border px-2 py-2 font-mono text-[11px] uppercase tracking-wider transition-colors ${
+                filter === f.key
+                  ? "border-green-primary bg-green-primary/15 text-green-primary"
+                  : "border-border-default bg-bg-card text-text-secondary"
+              }`}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {visible.length === 0 && (
+        <p className="py-6 text-center text-sm text-text-dim">
+          No team matches that.
+        </p>
+      )}
+
+      {visible.map((team) => {
         const sheet = sheets[team.teamId] ?? {};
         const total = weightedTotal(sheet);
         const scoredCount = JUDGING_CRITERIA.filter(

--- a/src/app/judge/JudgeScoring.tsx
+++ b/src/app/judge/JudgeScoring.tsx
@@ -23,6 +23,13 @@ interface TeamRow {
   } | null;
 }
 
+interface AssistResult {
+  readsAs: string;
+  observations: { criterion: string; note: string }[];
+  questionsToAsk: string[];
+  watchFor: string;
+}
+
 interface Payload {
   teams: TeamRow[];
   mine: Record<string, { scores: ScoreSheet; feedback: string | null }>;
@@ -50,6 +57,8 @@ export function JudgeScoring() {
   // "Unscored" first, because the failure at 5 AM is a team nobody reached —
   // and that is invisible on a list sorted by table number.
   const [filter, setFilter] = useState<"all" | "unscored" | "scored">("all");
+  const [assist, setAssist] = useState<Record<string, AssistResult>>({});
+  const [assisting, setAssisting] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
@@ -85,6 +94,30 @@ export function JudgeScoring() {
     // A new edit means the previous "saved" confirmation no longer describes
     // what is on screen.
     setSaved((prev) => ({ ...prev, [teamId]: false }));
+  }
+
+  // Optional reading help. Returns observations and questions, never scores —
+  // a suggested number would anchor the judge before they had formed a view.
+  async function askClaude(teamId: string) {
+    setAssisting(teamId);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/impact-lab/judging/assist", {
+        method: "POST",
+        headers: await csrfHeaders(),
+        body: JSON.stringify({ teamId }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "Could not read that submission.");
+        return;
+      }
+      setAssist((prev) => ({ ...prev, [teamId]: json.data as AssistResult }));
+    } catch {
+      setError("Could not read that submission. Check your connection.");
+    } finally {
+      setAssisting(null);
+    }
   }
 
   async function save(teamId: string) {
@@ -271,6 +304,56 @@ export function JudgeScoring() {
                     </div>
                   </div>
                 )}
+
+                <div className="mb-6">
+                  {!assist[team.teamId] ? (
+                    <button
+                      type="button"
+                      onClick={() => void askClaude(team.teamId)}
+                      disabled={assisting === team.teamId || !team.submission}
+                      className="w-full rounded-lg border border-cyan/30 bg-cyan/5 px-3 py-2.5 font-mono text-xs uppercase tracking-wider text-cyan transition-colors hover:bg-cyan/10 disabled:opacity-40"
+                    >
+                      {assisting === team.teamId
+                        ? "Reading the submission…"
+                        : team.submission
+                          ? "Ask Claude to read this submission"
+                          : "Nothing submitted to read"}
+                    </button>
+                  ) : (
+                    <div className="rounded-lg border border-cyan/30 bg-cyan/5 p-4">
+                      <p className="font-mono text-[10px] uppercase tracking-wider text-cyan">
+                        Reading help · not a score
+                      </p>
+                      <p className="mt-2 text-sm text-text-primary">
+                        {assist[team.teamId].readsAs}
+                      </p>
+                      <ul className="mt-3 space-y-2">
+                        {assist[team.teamId].observations.map((o) => (
+                          <li key={o.criterion} className="text-xs leading-relaxed">
+                            <span className="text-text-dim">{o.criterion}: </span>
+                            <span className="text-text-secondary">{o.note}</span>
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="mt-3 font-mono text-[10px] uppercase tracking-wider text-text-dim">
+                        Ask them
+                      </p>
+                      <ul className="mt-1 list-disc space-y-1 pl-4">
+                        {assist[team.teamId].questionsToAsk.map((q) => (
+                          <li key={q} className="text-xs text-text-secondary">
+                            {q}
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="mt-3 text-xs text-amber">
+                        Watch for: {assist[team.teamId].watchFor}
+                      </p>
+                      <p className="mt-3 text-[11px] text-text-dim">
+                        Claude read only what this team wrote. The score is yours.
+                      </p>
+                    </div>
+                  )}
+                </div>
 
                 <div className="space-y-6">
                   {JUDGING_CRITERIA.map((criterion) => (

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Users, Network, Save, FileText, UserCheck, Trophy } from "lucide-react"
+import { Users, Network, Save, FileText, UserCheck, Trophy, Gavel } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ParticipantsTab } from "./ParticipantsTab"
 import { MatchingTab } from "./MatchingTab"
@@ -9,8 +9,16 @@ import { RunsTab } from "./RunsTab"
 import { SubmissionsTab } from "./SubmissionsTab"
 import { CheckInTab } from "./CheckInTab"
 import { LeaderboardTab } from "./LeaderboardTab"
+import { JudgesTab } from "./JudgesTab"
 
-type Tab = "participants" | "matching" | "runs" | "submissions" | "checkin" | "leaderboard"
+type Tab =
+  | "participants"
+  | "matching"
+  | "runs"
+  | "submissions"
+  | "checkin"
+  | "leaderboard"
+  | "judges"
 
 const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "participants", label: "Participants", icon: Users },
@@ -19,6 +27,7 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "submissions", label: "Submissions", icon: FileText },
   { key: "checkin", label: "Check-in", icon: UserCheck },
   { key: "leaderboard", label: "Leaderboard", icon: Trophy },
+  { key: "judges", label: "Judges", icon: Gavel },
 ]
 
 export function ImpactLabDashboard({ cohort }: { cohort: string }) {
@@ -59,6 +68,7 @@ export function ImpactLabDashboard({ cohort }: { cohort: string }) {
       {tab === "submissions" && <SubmissionsTab cohort={cohort} />}
       {tab === "checkin" && <CheckInTab cohort={cohort} />}
       {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
+      {tab === "judges" && <JudgesTab cohort={cohort} />}
     </div>
   )
 }

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Users, Network, Save, FileText, UserCheck, Trophy, Gavel } from "lucide-react"
+import { Users, Network, Save, FileText, UserCheck, Trophy, Gavel, ListChecks } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { ParticipantsTab } from "./ParticipantsTab"
 import { MatchingTab } from "./MatchingTab"
@@ -10,6 +10,7 @@ import { SubmissionsTab } from "./SubmissionsTab"
 import { CheckInTab } from "./CheckInTab"
 import { LeaderboardTab } from "./LeaderboardTab"
 import { JudgesTab } from "./JudgesTab"
+import { ResultsTab } from "./ResultsTab"
 
 type Tab =
   | "participants"
@@ -19,6 +20,7 @@ type Tab =
   | "checkin"
   | "leaderboard"
   | "judges"
+  | "results"
 
 const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "participants", label: "Participants", icon: Users },
@@ -28,6 +30,7 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "checkin", label: "Check-in", icon: UserCheck },
   { key: "leaderboard", label: "Leaderboard", icon: Trophy },
   { key: "judges", label: "Judges", icon: Gavel },
+  { key: "results", label: "Results", icon: ListChecks },
 ]
 
 export function ImpactLabDashboard({ cohort }: { cohort: string }) {
@@ -69,6 +72,7 @@ export function ImpactLabDashboard({ cohort }: { cohort: string }) {
       {tab === "checkin" && <CheckInTab cohort={cohort} />}
       {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
       {tab === "judges" && <JudgesTab cohort={cohort} />}
+      {tab === "results" && <ResultsTab cohort={cohort} />}
     </div>
   )
 }

--- a/src/components/admin/impact-lab/JudgesTab.tsx
+++ b/src/components/admin/impact-lab/JudgesTab.tsx
@@ -1,8 +1,17 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
-import { ChevronDown, ChevronRight, Loader2 } from "lucide-react"
-import { apiGet } from "./api"
+import {
+  AlertTriangle,
+  ArrowDown,
+  ArrowUp,
+  ChevronDown,
+  ChevronRight,
+  Info,
+  Loader2,
+  Minus,
+} from "lucide-react"
+import { apiGet, apiSend } from "./api"
 import { JUDGING_CRITERIA, type JudgingCriterion } from "@/lib/impact-lab/judging"
 
 interface AuditSheet {
@@ -29,6 +38,22 @@ interface AuditData {
   judges: JudgeAudit[]
 }
 
+interface PreviewRow {
+  teamId: string
+  teamName: string
+  projectName: string | null
+  baseRank: number
+  previewRank: number | null
+  baseAverage: number
+  previewAverage: number | null
+  move: number | null
+}
+
+interface PreviewData {
+  rows: PreviewRow[]
+  orphaned: string[]
+}
+
 function formatTime(iso: string): string {
   return new Date(iso).toLocaleString("en-KE", { dateStyle: "short", timeStyle: "short" })
 }
@@ -48,6 +73,11 @@ export function JudgesTab({ cohort }: { cohort: string }) {
   const [error, setError] = useState<string | null>(null)
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
 
+  const [excluded, setExcluded] = useState<Set<string>>(new Set())
+  const [preview, setPreview] = useState<PreviewData | null>(null)
+  const [previewLoading, setPreviewLoading] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+
   const load = useCallback(async () => {
     setLoading(true)
     try {
@@ -63,6 +93,36 @@ export function JudgesTab({ cohort }: { cohort: string }) {
   useEffect(() => {
     void load()
   }, [load])
+
+  const runPreview = useCallback(async () => {
+    setPreviewLoading(true)
+    try {
+      setPreview(
+        await apiSend<PreviewData>("/api/admin/impact-lab/judging/preview", "POST", {
+          cohort,
+          exclude: [...excluded],
+        })
+      )
+      setPreviewError(null)
+    } catch (e) {
+      setPreviewError(e instanceof Error ? e.message : "Failed to load exclusion preview")
+    } finally {
+      setPreviewLoading(false)
+    }
+  }, [cohort, excluded])
+
+  useEffect(() => {
+    if (data && data.judges.length > 0) void runPreview()
+  }, [data, runPreview])
+
+  const toggleExcluded = (email: string) => {
+    setExcluded((prev) => {
+      const next = new Set(prev)
+      if (next.has(email)) next.delete(email)
+      else next.add(email)
+      return next
+    })
+  }
 
   if (loading) {
     return (
@@ -206,6 +266,137 @@ export function JudgesTab({ cohort }: { cohort: string }) {
             </div>
           )
         })}
+      </div>
+
+      {/*
+       * Exclusion preview — read only. Recomputes `standings()` with one or
+       * more judges' sheets dropped, purely so an organiser can see WHY a
+       * result reads the way it does; ticking a box here never touches the
+       * published run.
+       */}
+      <div className="space-y-3 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] p-4">
+        <p className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+          Exclusion preview
+        </p>
+
+        <div className="flex items-start gap-2 rounded border border-[#00d4ff]/30 bg-[#00d4ff]/10 p-3 text-[11px] font-mono text-[#00d4ff]">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>Preview only. This cannot change published results.</span>
+        </div>
+
+        <div className="flex flex-wrap gap-3">
+          {data.judges.map((judge) => (
+            <label
+              key={judge.judgeEmail}
+              className="flex items-center gap-1.5 rounded border border-[#1e1e1e] bg-[#111] px-2.5 py-1.5 text-[11px] font-mono text-[#e0e0e0]"
+            >
+              <input
+                type="checkbox"
+                checked={excluded.has(judge.judgeEmail)}
+                onChange={() => toggleExcluded(judge.judgeEmail)}
+                className="accent-[#00ff41]"
+              />
+              {judge.judgeName}
+            </label>
+          ))}
+        </div>
+
+        {previewLoading && (
+          <div className="p-4 text-center">
+            <Loader2 className="mx-auto h-4 w-4 animate-spin text-[#333]" />
+          </div>
+        )}
+
+        {previewError && (
+          <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+            {previewError}
+          </div>
+        )}
+
+        {!previewLoading && !previewError && preview && (
+          <>
+            {preview.orphaned.length > 0 && (
+              <div
+                role="alert"
+                className="flex items-start gap-2 rounded border border-[#ffb000]/40 bg-[#ffb000]/10 p-3 text-[11px] font-mono text-[#ffb000]"
+              >
+                <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                <span>
+                  Excluding these judges would leave {preview.orphaned.length} team
+                  {preview.orphaned.length === 1 ? "" : "s"} with no scores at all:{" "}
+                  {preview.orphaned.join(", ")}
+                </span>
+              </div>
+            )}
+
+            <div className="overflow-x-auto rounded border border-[#1e1e1e]">
+              {preview.rows.length === 0 ? (
+                <p className="p-8 text-center text-sm font-mono text-[#555]">
+                  No scores recorded yet.
+                </p>
+              ) : (
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-b border-[#1e1e1e]">
+                      {["Team", "Project", "Base rank", "Preview rank", "Move", "Base avg", "Preview avg"].map(
+                        (h) => (
+                          <th
+                            key={h}
+                            className="whitespace-nowrap px-4 py-2 text-left text-[10px] font-mono font-semibold uppercase tracking-wider text-[#555]"
+                          >
+                            {h}
+                          </th>
+                        )
+                      )}
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-[#141414]">
+                    {preview.rows.map((row) => (
+                      <tr
+                        key={row.teamId}
+                        className={row.previewRank === null ? "bg-[#ffb000]/5" : "hover:bg-[#111]"}
+                      >
+                        <td className="whitespace-nowrap px-4 py-2 text-[11px] font-mono text-[#e0e0e0]">
+                          {row.teamName}
+                        </td>
+                        <td className="whitespace-nowrap px-4 py-2 text-[11px] font-mono text-[#888]">
+                          {row.projectName ?? "—"}
+                        </td>
+                        <td className="px-4 py-2 text-[11px] font-mono text-[#555]">{row.baseRank}</td>
+                        <td className="px-4 py-2 text-[11px] font-mono text-[#e0e0e0]">
+                          {row.previewRank ?? "—"}
+                        </td>
+                        <td className="px-4 py-2 text-[11px] font-mono">
+                          {row.move === null ? (
+                            <span className="text-[#555]">—</span>
+                          ) : row.move > 0 ? (
+                            <span className="flex items-center gap-1 text-[#00ff41]">
+                              <ArrowUp className="h-3 w-3" /> {row.move}
+                            </span>
+                          ) : row.move < 0 ? (
+                            <span className="flex items-center gap-1 text-[#ff3333]">
+                              <ArrowDown className="h-3 w-3" /> {Math.abs(row.move)}
+                            </span>
+                          ) : (
+                            <span className="flex items-center gap-1 text-[#555]">
+                              <Minus className="h-3 w-3" /> 0
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-[11px] font-mono font-semibold text-[#00ff41]">
+                          {row.baseAverage}
+                        </td>
+                        <td className="px-4 py-2 text-[11px] font-mono text-[#888]">
+                          {row.previewAverage ?? "—"}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/components/admin/impact-lab/JudgesTab.tsx
+++ b/src/components/admin/impact-lab/JudgesTab.tsx
@@ -1,0 +1,212 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react"
+import { apiGet } from "./api"
+import { JUDGING_CRITERIA, type JudgingCriterion } from "@/lib/impact-lab/judging"
+
+interface AuditSheet {
+  teamId: string
+  teamName: string
+  projectName: string | null
+  total: number
+  scores: Record<string, number>
+  writeupOnly: boolean
+  scoredAt: string
+}
+
+interface JudgeAudit {
+  judgeEmail: string
+  judgeName: string
+  teamsScored: number
+  mean: number
+  firstScoredAt: string
+  lastScoredAt: string
+  sheets: AuditSheet[]
+}
+
+interface AuditData {
+  judges: JudgeAudit[]
+}
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleString("en-KE", { dateStyle: "short", timeStyle: "short" })
+}
+
+/**
+ * Per-judge audit.
+ *
+ * Four judges scored this hackathon on visibly different scales — means
+ * roughly 24 points apart on a 100-point total. An aggregate leaderboard
+ * hides that entirely, and it changes how the whole result should be read,
+ * so the calibration gap is the first thing rendered here rather than
+ * something an organiser has to compute from the sheets below.
+ */
+export function JudgesTab({ cohort }: { cohort: string }) {
+  const [data, setData] = useState<AuditData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setData(await apiGet<AuditData>(`/api/admin/impact-lab/judging/audit?cohort=${cohort}`))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load judge audit")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+        {error ?? "No data"}
+      </div>
+    )
+  }
+
+  if (data.judges.length === 0) {
+    return (
+      <p className="p-8 text-center text-sm font-mono text-[#555]">
+        No final run published yet — mark a run final to see judge activity.
+      </p>
+    )
+  }
+
+  const toggle = (email: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(email)) next.delete(email)
+      else next.add(email)
+      return next
+    })
+  }
+
+  const byMean = [...data.judges].sort((a, b) => b.mean - a.mean)
+  const highest = byMean[0]
+  const lowest = byMean[byMean.length - 1]
+  const spread = Math.round((highest.mean - lowest.mean) * 10) / 10
+
+  return (
+    <div className="space-y-4">
+      {data.judges.length > 1 && (
+        <div className="rounded-lg border border-[#ffb000]/40 bg-[#ffb000]/10 p-4">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-[#ffb000]">
+            Calibration spread
+          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-4 text-[11px] font-mono">
+            <span className="text-[#e0e0e0]">
+              Highest — <span className="text-[#00ff41]">{highest.judgeName}</span> ({highest.mean})
+            </span>
+            <span className="text-[#555]">vs</span>
+            <span className="text-[#e0e0e0]">
+              Lowest — <span className="text-[#ff3333]">{lowest.judgeName}</span> ({lowest.mean})
+            </span>
+            <span className="text-[#888]">
+              gap: <span className="font-semibold text-[#ffb000]">{spread}</span> points out of 100
+            </span>
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {data.judges.map((judge) => {
+          const isOpen = expanded.has(judge.judgeEmail)
+          return (
+            <div
+              key={judge.judgeEmail}
+              className="overflow-hidden rounded-lg border border-[#1e1e1e] bg-[#0d0d0d]"
+            >
+              <button
+                onClick={() => toggle(judge.judgeEmail)}
+                className="flex w-full flex-wrap items-center justify-between gap-3 p-4 text-left hover:bg-[#111]"
+              >
+                <div className="flex items-center gap-2">
+                  {isOpen ? (
+                    <ChevronDown className="h-3.5 w-3.5 shrink-0 text-[#555]" />
+                  ) : (
+                    <ChevronRight className="h-3.5 w-3.5 shrink-0 text-[#555]" />
+                  )}
+                  <span className="text-[12px] font-mono font-semibold text-[#e0e0e0]">
+                    {judge.judgeName}
+                  </span>
+                  <span className="text-[10px] font-mono text-[#555]">{judge.judgeEmail}</span>
+                </div>
+                <div className="flex items-center gap-4 text-[11px] font-mono text-[#888]">
+                  <span>{judge.teamsScored} teams</span>
+                  <span className="font-semibold text-[#00ff41]">mean {judge.mean}</span>
+                  <span className="text-[#555]">
+                    {formatTime(judge.firstScoredAt)} &ndash; {formatTime(judge.lastScoredAt)}
+                  </span>
+                </div>
+              </button>
+
+              {isOpen && (
+                <div className="overflow-x-auto border-t border-[#1e1e1e]">
+                  <table className="w-full">
+                    <thead>
+                      <tr className="border-b border-[#1e1e1e]">
+                        {[
+                          "Team",
+                          "Project",
+                          ...JUDGING_CRITERIA.map((c: JudgingCriterion) => c.label),
+                          "Total",
+                          "Basis",
+                        ].map((h) => (
+                          <th
+                            key={h}
+                            className="whitespace-nowrap px-4 py-2 text-left text-[10px] font-mono font-semibold uppercase tracking-wider text-[#555]"
+                          >
+                            {h}
+                          </th>
+                        ))}
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-[#141414]">
+                      {judge.sheets.map((sheet) => (
+                        <tr key={sheet.teamId} className="hover:bg-[#111]">
+                          <td className="whitespace-nowrap px-4 py-2 text-[11px] font-mono text-[#e0e0e0]">
+                            {sheet.teamName}
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-2 text-[11px] font-mono text-[#888]">
+                            {sheet.projectName ?? "—"}
+                          </td>
+                          {JUDGING_CRITERIA.map((c: JudgingCriterion) => (
+                            <td key={c.key} className="px-4 py-2 text-[11px] font-mono text-[#888]">
+                              {sheet.scores[c.key] ?? "—"}
+                            </td>
+                          ))}
+                          <td className="px-4 py-2 text-[11px] font-mono font-semibold text-[#00ff41]">
+                            {sheet.total}
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-2 text-[11px] font-mono text-[#555]">
+                            {sheet.writeupOnly ? "Write-up" : "Live demo"}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -1,0 +1,324 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { Loader2, Save, Sparkles } from "lucide-react"
+import { apiGet, apiSend } from "./api"
+import { CRITERION_KEYS, JUDGING_CRITERIA, MAX_SCORE, MIN_SCORE } from "@/lib/impact-lab/judging"
+
+interface AwaitingTeam {
+  teamId: string
+  teamName: string
+  projectName: string
+  repoUrl: string
+  demoUrl: string | null
+  submission: Record<string, string>
+}
+
+interface DraftResult {
+  scores: Record<string, number>
+  reasoning: Record<string, string>
+}
+
+interface TeamDraftState {
+  scores: Partial<Record<string, number>>
+  reasoning: Record<string, string>
+  drafting: boolean
+  saving: boolean
+  error: string | null
+}
+
+function emptyState(): TeamDraftState {
+  return {
+    scores: {},
+    reasoning: {},
+    drafting: false,
+    saving: false,
+    error: null,
+  }
+}
+
+/**
+ * Section: teams awaiting a score.
+ *
+ * Four teams submitted and no judge ever reached their table. Kept as its own
+ * component (rather than inlined in ResultsTab) so Task 7 can append a second
+ * section without touching this one.
+ */
+function AwaitingScoreSection({ cohort }: { cohort: string }) {
+  const [teams, setTeams] = useState<AwaitingTeam[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [drafts, setDrafts] = useState<Record<string, TeamDraftState>>({})
+  // Persists after a team's card is removed from the list, so pressing Save
+  // has a confirmation that outlives the card it belonged to.
+  const [savedTeams, setSavedTeams] = useState<{ teamId: string; teamName: string }[]>([])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await apiGet<{ teams: AwaitingTeam[] }>(
+        `/api/admin/impact-lab/judging/writeup?cohort=${cohort}`
+      )
+      setTeams(data.teams)
+      setLoadError(null)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to load teams awaiting a score")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const stateFor = useCallback(
+    (teamId: string): TeamDraftState => drafts[teamId] ?? emptyState(),
+    [drafts]
+  )
+
+  const patch = useCallback(
+    (teamId: string, next: Partial<TeamDraftState>) => {
+      setDrafts((prev) => ({ ...prev, [teamId]: { ...(prev[teamId] ?? emptyState()), ...next } }))
+    },
+    []
+  )
+
+  async function draft(teamId: string) {
+    patch(teamId, { drafting: true, error: null })
+    try {
+      const result = await apiSend<DraftResult>(
+        `/api/admin/impact-lab/judging/writeup?cohort=${cohort}`,
+        "POST",
+        { teamId, action: "draft" }
+      )
+      patch(teamId, {
+        drafting: false,
+        scores: result.scores,
+        reasoning: result.reasoning,
+      })
+    } catch (e) {
+      patch(teamId, {
+        drafting: false,
+        error: e instanceof Error ? e.message : "Could not draft scores for that team.",
+      })
+    }
+  }
+
+  function setScore(teamId: string, key: string, raw: string) {
+    const current = stateFor(teamId)
+    const nextScores = { ...current.scores }
+    if (raw === "") {
+      delete nextScores[key]
+    } else {
+      const value = Number(raw)
+      if (!Number.isNaN(value)) nextScores[key] = value
+    }
+    patch(teamId, { scores: nextScores })
+  }
+
+  async function save(teamId: string) {
+    const current = stateFor(teamId)
+    const team = teams?.find((t) => t.teamId === teamId)
+    patch(teamId, { saving: true, error: null })
+    try {
+      await apiSend(`/api/admin/impact-lab/judging/writeup?cohort=${cohort}`, "POST", {
+        teamId,
+        action: "save",
+        scores: current.scores,
+      })
+      patch(teamId, { saving: false })
+      if (team) setSavedTeams((prev) => [...prev, { teamId, teamName: team.teamName }])
+      // The team no longer belongs in "awaiting a score" once it has one —
+      // but the confirmation above the list stays, so the organiser sees the
+      // save happened rather than the card just disappearing.
+      setTeams((prev) => prev?.filter((t) => t.teamId !== teamId) ?? prev)
+    } catch (e) {
+      patch(teamId, {
+        saving: false,
+        error: e instanceof Error ? e.message : "That did not save.",
+      })
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (loadError || !teams) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+        {loadError ?? "No data"}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-mono font-semibold text-[#e0e0e0]">
+          Teams awaiting a score
+        </h2>
+        <p className="mt-1 text-[11px] font-mono text-[#888]">
+          These teams submitted work but no judge ever reached their table. Without a
+          score they would be published with no result at all.
+        </p>
+      </div>
+
+      {savedTeams.length > 0 && (
+        <div
+          role="status"
+          className="rounded border border-[#00ff41]/30 bg-[#00ff41]/10 p-3 text-[11px] font-mono text-[#00ff41]"
+        >
+          Saved as organiser review: {savedTeams.map((t) => t.teamName).join(", ")}
+        </div>
+      )}
+
+      {teams.length === 0 ? (
+        <p className="p-8 text-center text-sm font-mono text-[#555]">
+          Every submitted team has a score.
+        </p>
+      ) : (
+        teams.map((team) => {
+          const state = stateFor(team.teamId)
+          const canSave = CRITERION_KEYS.every((key) => {
+            const value = state.scores[key]
+            return (
+              typeof value === "number" &&
+              Number.isInteger(value) &&
+              value >= MIN_SCORE &&
+              value <= MAX_SCORE
+            )
+          })
+
+          return (
+            <div
+              key={team.teamId}
+              className="space-y-4 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] p-4"
+            >
+              <div>
+                <p className="text-[12px] font-mono font-semibold text-[#e0e0e0]">
+                  {team.teamName}
+                </p>
+                <p className="text-[11px] font-mono text-[#888]">{team.projectName}</p>
+                <div className="mt-1 flex flex-wrap gap-3 text-[11px] font-mono">
+                  <a
+                    href={team.repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[#00d4ff] underline"
+                  >
+                    repo
+                  </a>
+                  {team.demoUrl && (
+                    <a
+                      href={team.demoUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[#00d4ff] underline"
+                    >
+                      demo link
+                    </a>
+                  )}
+                </div>
+              </div>
+
+              <div className="grid gap-2 sm:grid-cols-2">
+                {Object.entries(team.submission).map(([label, value]) => (
+                  <div key={label} className="rounded border border-[#1e1e1e] bg-[#111] p-3">
+                    <p className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+                      {label}
+                    </p>
+                    <p className="mt-1 whitespace-pre-wrap text-[11px] font-mono text-[#ccc]">
+                      {value}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <button
+                type="button"
+                onClick={() => void draft(team.teamId)}
+                disabled={state.drafting}
+                className="flex items-center gap-2 rounded border border-[#00d4ff]/30 bg-[#00d4ff]/10 px-3 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00d4ff] transition-colors hover:bg-[#00d4ff]/20 disabled:opacity-40"
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+                {state.drafting ? "Drafting…" : "Draft with Claude"}
+              </button>
+
+              <p className="text-[11px] font-mono text-[#ffb000]">
+                Claude drafts. You decide. Nothing is saved until you press Save.
+              </p>
+
+              <div className="space-y-3">
+                {JUDGING_CRITERIA.map((criterion) => (
+                  <div
+                    key={criterion.key}
+                    className="grid gap-2 sm:grid-cols-[180px_80px_1fr] sm:items-start"
+                  >
+                    <label
+                      htmlFor={`${team.teamId}-${criterion.key}`}
+                      className="text-[11px] font-mono text-[#e0e0e0]"
+                    >
+                      {criterion.label}
+                      <span className="ml-1 text-[#555]">· {criterion.weight}pts</span>
+                    </label>
+                    <input
+                      id={`${team.teamId}-${criterion.key}`}
+                      type="number"
+                      min={MIN_SCORE}
+                      max={MAX_SCORE}
+                      step={1}
+                      value={state.scores[criterion.key] ?? ""}
+                      onChange={(e) => setScore(team.teamId, criterion.key, e.target.value)}
+                      className="w-full rounded border border-[#1e1e1e] bg-[#111] px-2 py-1.5 text-[11px] font-mono text-[#e0e0e0] focus:border-[#00ff41] focus:outline-none"
+                    />
+                    <p className="text-[11px] font-mono text-[#888]">
+                      {state.reasoning[criterion.key] ?? ""}
+                    </p>
+                  </div>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => void save(team.teamId)}
+                  disabled={!canSave || state.saving}
+                  className="flex items-center gap-2 rounded border border-[#00ff41]/40 bg-[#00ff41]/10 px-4 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00ff41] transition-colors hover:bg-[#00ff41]/20 disabled:opacity-40"
+                >
+                  <Save className="h-3.5 w-3.5" />
+                  {state.saving ? "Saving…" : "Save"}
+                </button>
+                {state.error && (
+                  <span role="alert" className="text-[11px] font-mono text-[#ff3333]">
+                    {state.error}
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        })
+      )}
+    </div>
+  )
+}
+
+/**
+ * Results tab — organiser-facing surfaces for closing out judging.
+ *
+ * Starts with the one section this program needs first: the teams the panel
+ * never reached. Task 7 appends further sections below this one, so each
+ * section is its own component rendered in a simple stack.
+ */
+export function ResultsTab({ cohort }: { cohort: string }) {
+  return (
+    <div className="space-y-6">
+      <AwaitingScoreSection cohort={cohort} />
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -827,7 +827,7 @@ function NotifyPanel({ cohort }: { cohort: string }) {
         <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
         <span>
           Resend allows 100 emails per day. There are 93 recipients — one clean run fits, a
-          repeated run does not.
+          repeated run does not. Test sends below count against that same 100.
         </span>
       </div>
 

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -1,9 +1,17 @@
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
-import { Loader2, Save, Sparkles } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { AlertTriangle, CheckCircle2, Loader2, Save, Send, Sparkles, Trophy } from "lucide-react"
 import { apiGet, apiSend } from "./api"
-import { CRITERION_KEYS, JUDGING_CRITERIA, MAX_SCORE, MIN_SCORE } from "@/lib/impact-lab/judging"
+import {
+  CRITERION_KEYS,
+  JUDGING_CRITERIA,
+  MAX_SCORE,
+  MIN_SCORE,
+  trackOf,
+  type TeamStanding,
+} from "@/lib/impact-lab/judging"
+import { buildRanking, buildTrackWinners, toPublicRanking, type ResultsInput } from "@/lib/impact-lab/results"
 
 interface AwaitingTeam {
   teamId: string
@@ -308,17 +316,395 @@ function AwaitingScoreSection({ cohort }: { cohort: string }) {
   )
 }
 
+// ─── Publish ──────────────────────────────────────────────────────────────
+
+interface PublishTeam {
+  teamId: string
+  teamName: string
+  memberCount: number
+  submission: { projectName: string } | null
+}
+
+interface JudgingData {
+  finalRunId: string | null
+  teams: PublishTeam[]
+  standings: TeamStanding[]
+}
+
+interface PublishStatus {
+  published: boolean
+  publishedAt: string | null
+  recipients: number
+}
+
+interface PublishResponse {
+  publishedAt: string
+  recipients: number
+}
+
+const EMPTY_RESULTS_INPUT_EXTRAS = {
+  publishedAt: new Date(0).toISOString(),
+  writeupOnly: new Set<string>(),
+  range: new Map<string, { low: number; high: number }>(),
+}
+
+/**
+ * Section: publish results. A one-way door — see the route's own header
+ * comment for why the snapshot it writes is never recomputed afterwards.
+ *
+ * The ranking preview reuses `buildRanking`/`buildTrackWinners` from
+ * `@/lib/impact-lab/results` directly (that module is pure and dependency-free
+ * for exactly this reason) so what an organiser previews here is produced by
+ * the same code that computes the stored snapshot, not a second
+ * reimplementation that could quietly drift from it.
+ */
+function PublishPanel({ cohort }: { cohort: string }) {
+  const [judging, setJudging] = useState<JudgingData | null>(null)
+  const [publishStatus, setPublishStatus] = useState<PublishStatus | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  const [firstPlace, setFirstPlace] = useState("")
+  const [secondPlace, setSecondPlace] = useState("")
+  const [thirdPlace, setThirdPlace] = useState("")
+  const [confirmText, setConfirmText] = useState("")
+  const [publishing, setPublishing] = useState(false)
+  const [publishError, setPublishError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [judgingData, status] = await Promise.all([
+        apiGet<JudgingData>(`/api/admin/impact-lab/judging?cohort=${cohort}`),
+        apiGet<PublishStatus>(`/api/admin/impact-lab/results/publish?cohort=${cohort}`),
+      ])
+      setJudging(judgingData)
+      setPublishStatus(status)
+      setLoadError(null)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to load results")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const submittedTeams = useMemo(
+    () => judging?.teams.filter((t) => t.submission !== null) ?? [],
+    [judging]
+  )
+  const scoredTeamIds = useMemo(
+    () => new Set(judging?.standings.map((s) => s.teamId) ?? []),
+    [judging]
+  )
+  const unscoredSubmitted = useMemo(
+    () => submittedTeams.filter((t) => !scoredTeamIds.has(t.teamId)),
+    [submittedTeams, scoredTeamIds]
+  )
+  // Only a team the panel actually scored can sensibly be announced as a winner.
+  const eligibleWinners = useMemo(
+    () => submittedTeams.filter((t) => scoredTeamIds.has(t.teamId)),
+    [submittedTeams, scoredTeamIds]
+  )
+  const recipientCount = useMemo(
+    () => submittedTeams.reduce((sum, t) => sum + t.memberCount, 0),
+    [submittedTeams]
+  )
+  const announcedTeamIds = useMemo(
+    () => [firstPlace, secondPlace, thirdPlace].filter((id) => id !== ""),
+    [firstPlace, secondPlace, thirdPlace]
+  )
+
+  const preview = useMemo(() => {
+    if (!judging) return null
+    const teamsMeta = new Map<string, { projectName: string; track: string }>()
+    for (const t of submittedTeams) {
+      if (!t.submission) continue
+      teamsMeta.set(t.teamId, { projectName: t.submission.projectName, track: trackOf(t.teamName) })
+    }
+    const input: ResultsInput = {
+      ...EMPTY_RESULTS_INPUT_EXTRAS,
+      announcedTeamIds,
+      standings: judging.standings,
+      teams: teamsMeta,
+    }
+    const ranking = buildRanking(input)
+    return {
+      overall: toPublicRanking(ranking.slice(0, announcedTeamIds.length)),
+      trackWinners: buildTrackWinners(ranking),
+      ranking: toPublicRanking(ranking),
+    }
+  }, [judging, submittedTeams, announcedTeamIds])
+
+  function teamOptionLabel(t: PublishTeam): string {
+    return t.submission ? `${t.teamName} — ${t.submission.projectName}` : t.teamName
+  }
+
+  async function publish() {
+    setPublishing(true)
+    setPublishError(null)
+    try {
+      const result = await apiSend<PublishResponse>(
+        "/api/admin/impact-lab/results/publish",
+        "POST",
+        { cohort, announcedTeamIds, confirm: confirmText }
+      )
+      setPublishStatus({ published: true, publishedAt: result.publishedAt, recipients: result.recipients })
+    } catch (e) {
+      setPublishError(e instanceof Error ? e.message : "Could not publish results.")
+    } finally {
+      setPublishing(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (loadError || !judging) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+        {loadError ?? "No data"}
+      </div>
+    )
+  }
+
+  if (!judging.finalRunId) {
+    return (
+      <p className="p-8 text-center text-sm font-mono text-[#555]">
+        No final run to publish yet — mark a run final to start judging.
+      </p>
+    )
+  }
+
+  if (publishStatus?.published) {
+    return (
+      <div className="space-y-4">
+        <h2 className="text-sm font-mono font-semibold text-[#e0e0e0]">Publish results</h2>
+        <div className="flex items-start gap-3 rounded-lg border border-[#00ff41]/30 bg-[#00ff41]/10 p-4">
+          <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-[#00ff41]" />
+          <div>
+            <p className="text-[12px] font-mono font-semibold text-[#00ff41]">
+              Results published
+              {publishStatus.publishedAt &&
+                ` on ${new Date(publishStatus.publishedAt).toLocaleString()}`}
+            </p>
+            <p className="mt-1 text-[11px] font-mono text-[#888]">
+              {publishStatus.recipients} recipient{publishStatus.recipients === 1 ? "" : "s"}{" "}
+              queued for the results email.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const disabledReason =
+    unscoredSubmitted.length > 0
+      ? `Every submitted team needs a score first: ${unscoredSubmitted
+          .map((t) => t.submission?.projectName ?? t.teamName)
+          .join(", ")}`
+      : confirmText !== "PUBLISH"
+        ? 'Type PUBLISH to confirm.'
+        : null
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-mono font-semibold text-[#e0e0e0]">Publish results</h2>
+          <p className="mt-1 text-[11px] font-mono text-[#888]">
+            A one-way door. This closes submissions and judging, freezes the result, and
+            queues one email per recipient. It cannot be undone or run twice.
+          </p>
+        </div>
+        {/* Scoring a team happens in the section above, whose own fetch this
+            panel does not share — refresh after scoring the last team rather
+            than reloading the page. */}
+        <button
+          type="button"
+          onClick={() => void load()}
+          className="shrink-0 rounded border border-[#1e1e1e] bg-[#1a1a1a] px-3 py-1.5 text-[10px] font-mono uppercase tracking-wider text-[#888] hover:bg-[#222]"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {unscoredSubmitted.length > 0 && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-3 text-[11px] font-mono text-[#ff3333]"
+        >
+          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>{disabledReason}</span>
+        </div>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        {[
+          { label: "1st place (announced)", value: firstPlace, set: setFirstPlace },
+          { label: "2nd place (announced)", value: secondPlace, set: setSecondPlace },
+          { label: "3rd place (announced)", value: thirdPlace, set: setThirdPlace },
+        ].map((slot) => (
+          <label key={slot.label} className="block">
+            <span className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+              {slot.label}
+            </span>
+            <select
+              value={slot.value}
+              onChange={(e) => slot.set(e.target.value)}
+              className="mt-1 w-full rounded border border-[#1e1e1e] bg-[#111] px-2 py-1.5 text-[11px] font-mono text-[#e0e0e0] focus:border-[#00ff41] focus:outline-none"
+            >
+              <option value="">— not announced —</option>
+              {eligibleWinners.map((t) => (
+                <option
+                  key={t.teamId}
+                  value={t.teamId}
+                  disabled={
+                    announcedTeamIds.includes(t.teamId) &&
+                    t.teamId !== slot.value
+                  }
+                >
+                  {teamOptionLabel(t)}
+                </option>
+              ))}
+            </select>
+          </label>
+        ))}
+      </div>
+
+      {announcedTeamIds.length !== 3 && (
+        <p className="text-[11px] font-mono text-[#ffb000]">
+          {announcedTeamIds.length} of the usual 3 announced winners selected. Publishing with
+          fewer (or none) ranks everyone by score alone — confirm this is intended before
+          continuing.
+        </p>
+      )}
+
+      {preview && (
+        <div className="space-y-4 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] p-4">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+            Preview — exactly what participants will see, by position only
+          </p>
+
+          {preview.overall.length > 0 && (
+            <div className="flex items-center gap-2 flex-wrap">
+              <Trophy className="h-3.5 w-3.5 shrink-0 text-[#ffb000]" />
+              {preview.overall.map((row) => (
+                <span
+                  key={row.teamId}
+                  className="rounded border border-[#ffb000]/30 bg-[#ffb000]/10 px-2 py-1 text-[11px] font-mono text-[#ffb000]"
+                >
+                  #{row.rank} {row.projectName}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {preview.trackWinners.map((w) => (
+              <div key={w.track} className="rounded border border-[#1e1e1e] bg-[#111] p-2">
+                <p className="truncate text-[9px] font-mono uppercase tracking-wider text-[#555]">
+                  {w.track}
+                </p>
+                <p className="truncate text-[11px] font-mono text-[#e0e0e0]">{w.projectName}</p>
+              </div>
+            ))}
+          </div>
+
+          <div className="overflow-x-auto rounded border border-[#1e1e1e]">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#1e1e1e]">
+                  {["Position", "Project", "Track"].map((h) => (
+                    <th
+                      key={h}
+                      className="whitespace-nowrap px-3 py-2 text-left text-[10px] font-mono font-semibold uppercase tracking-wider text-[#555]"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#141414]">
+                {preview.ranking.map((row) => (
+                  <tr key={row.teamId}>
+                    <td className="px-3 py-2 text-[11px] font-mono text-[#555]">{row.rank}</td>
+                    <td className="px-3 py-2 text-[11px] font-mono text-[#e0e0e0]">
+                      {row.projectName}
+                    </td>
+                    <td className="px-3 py-2 text-[11px] font-mono text-[#888]">{row.track}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-[11px] font-mono text-[#888]">
+            <span className="font-semibold text-[#00ff41]">{recipientCount}</span> recipient
+            {recipientCount === 1 ? "" : "s"} will be queued for the results email (estimate —
+            the exact count is confirmed by the server at publish time).
+          </p>
+        </div>
+      )}
+
+      <label className="block max-w-xs">
+        <span className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+          Type PUBLISH to confirm
+        </span>
+        <input
+          type="text"
+          value={confirmText}
+          onChange={(e) => setConfirmText(e.target.value)}
+          placeholder="PUBLISH"
+          className="mt-1 w-full rounded border border-[#1e1e1e] bg-[#111] px-2 py-1.5 text-[11px] font-mono uppercase text-[#e0e0e0] focus:border-[#ff3333] focus:outline-none"
+        />
+      </label>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void publish()}
+          disabled={disabledReason !== null || publishing}
+          className="flex items-center gap-2 rounded border border-[#ff3333]/40 bg-[#ff3333]/10 px-4 py-2 text-[11px] font-mono uppercase tracking-wider text-[#ff3333] transition-colors hover:bg-[#ff3333]/20 disabled:opacity-40"
+        >
+          <Send className="h-3.5 w-3.5" />
+          {publishing ? "Publishing…" : "Publish results"}
+        </button>
+        {disabledReason && (
+          <span className="text-[11px] font-mono text-[#888]">{disabledReason}</span>
+        )}
+        {publishError && (
+          <span role="alert" className="text-[11px] font-mono text-[#ff3333]">
+            {publishError}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
 /**
  * Results tab — organiser-facing surfaces for closing out judging.
  *
  * Starts with the one section this program needs first: the teams the panel
- * never reached. Task 7 appends further sections below this one, so each
- * section is its own component rendered in a simple stack.
+ * never reached. Task 7 appends the publish panel below it, so each section
+ * is its own component rendered in a simple stack.
  */
 export function ResultsTab({ cohort }: { cohort: string }) {
   return (
     <div className="space-y-6">
       <AwaitingScoreSection cohort={cohort} />
+      <div className="border-t border-[#1e1e1e] pt-6">
+        <PublishPanel cohort={cohort} />
+      </div>
     </div>
   )
 }

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -691,12 +691,235 @@ function PublishPanel({ cohort }: { cohort: string }) {
   )
 }
 
+// ─── Notify ───────────────────────────────────────────────────────────────
+
+interface NotifyCounts {
+  queued: number
+  sent: number
+  failed: number
+}
+
+interface NotifyResult {
+  sent: number
+  failed: number
+  remaining: number
+}
+
+/**
+ * Section: send the results email. Only meaningful once results are
+ * published, which it checks independently (the same endpoint PublishPanel
+ * checks) rather than sharing PublishPanel's internal state — that keeps this
+ * section appendable without touching the two above it.
+ *
+ * Resumable by construction: "Send next 25" always asks the server for
+ * whichever rows are still unsent, never a specific set — see the route's own
+ * doc comment for why that means a repeat press (after a partial failure, a
+ * timeout, or just clearing the whole cohort in batches) can only ever move
+ * `remaining` toward zero, never mail the same person twice.
+ */
+function NotifyPanel({ cohort }: { cohort: string }) {
+  const [published, setPublished] = useState<boolean | null>(null)
+  const [counts, setCounts] = useState<NotifyCounts | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [sending, setSending] = useState(false)
+  const [sendError, setSendError] = useState<string | null>(null)
+  const [lastResult, setLastResult] = useState<NotifyResult | null>(null)
+
+  const [testEmail, setTestEmail] = useState("")
+  const [testSending, setTestSending] = useState(false)
+  const [testResult, setTestResult] = useState<string | null>(null)
+  const [testError, setTestError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const [status, notifyCounts] = await Promise.all([
+        apiGet<{ published: boolean }>(`/api/admin/impact-lab/results/publish?cohort=${cohort}`),
+        apiGet<NotifyCounts>(`/api/admin/impact-lab/results/notify?cohort=${cohort}`),
+      ])
+      setPublished(status.published)
+      setCounts(notifyCounts)
+      setLoadError(null)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to load send status.")
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  async function sendNext() {
+    setSending(true)
+    setSendError(null)
+    try {
+      const result = await apiSend<NotifyResult>("/api/admin/impact-lab/results/notify", "POST", {
+        cohort,
+      })
+      setLastResult(result)
+      await load()
+    } catch (e) {
+      setSendError(e instanceof Error ? e.message : "Could not send.")
+    } finally {
+      setSending(false)
+    }
+  }
+
+  async function sendTest() {
+    setTestSending(true)
+    setTestError(null)
+    setTestResult(null)
+    try {
+      const result = await apiSend<NotifyResult>("/api/admin/impact-lab/results/notify", "POST", {
+        cohort,
+        testEmail,
+      })
+      setTestResult(
+        result.sent > 0 ? `Sent to ${testEmail}.` : "Could not send — check the address and try again."
+      )
+    } catch (e) {
+      setTestError(e instanceof Error ? e.message : "Could not send test email.")
+    } finally {
+      setTestSending(false)
+    }
+  }
+
+  if (published === null && !loadError) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+        {loadError}
+      </div>
+    )
+  }
+
+  if (!published) {
+    return (
+      <p className="p-8 text-center text-sm font-mono text-[#555]">
+        Publish results above to unlock the send panel.
+      </p>
+    )
+  }
+
+  const remaining = counts ? counts.queued + counts.failed : 0
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-mono font-semibold text-[#e0e0e0]">Send results email</h2>
+        <p className="mt-1 text-[11px] font-mono text-[#888]">
+          Sends the standalone results email — winners and each team&apos;s own scorecard — to
+          every published recipient. Resumable: a repeat press only reaches whoever is still
+          unsent.
+        </p>
+      </div>
+
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded border border-[#ffb000]/30 bg-[#ffb000]/10 p-3 text-[11px] font-mono text-[#ffb000]"
+      >
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <span>
+          Resend allows 100 emails per day. There are 93 recipients — one clean run fits, a
+          repeated run does not.
+        </span>
+      </div>
+
+      {counts && (
+        <div className="grid grid-cols-3 gap-3">
+          {[
+            { label: "Queued", value: counts.queued, color: "#888" },
+            { label: "Sent", value: counts.sent, color: "#00ff41" },
+            { label: "Failed", value: counts.failed, color: "#ff3333" },
+          ].map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded border border-[#1e1e1e] bg-[#0d0d0d] p-3 text-center"
+            >
+              <p className="text-lg font-mono font-bold" style={{ color: stat.color }}>
+                {stat.value}
+              </p>
+              <p className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+                {stat.label}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void sendNext()}
+          disabled={sending || remaining === 0}
+          className="flex items-center gap-2 rounded border border-[#00ff41]/40 bg-[#00ff41]/10 px-4 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00ff41] transition-colors hover:bg-[#00ff41]/20 disabled:opacity-40"
+        >
+          <Send className="h-3.5 w-3.5" />
+          {sending ? "Sending…" : "Send next 25"}
+        </button>
+        {remaining === 0 && counts && (
+          <span className="text-[11px] font-mono text-[#00ff41]">Everyone has been sent.</span>
+        )}
+        {lastResult && (
+          <span className="text-[11px] font-mono text-[#888]">
+            Last batch: {lastResult.sent} sent, {lastResult.failed} failed, {lastResult.remaining}{" "}
+            remaining.
+          </span>
+        )}
+        {sendError && (
+          <span role="alert" className="text-[11px] font-mono text-[#ff3333]">
+            {sendError}
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-2 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] p-4">
+        <label className="block max-w-sm">
+          <span className="text-[10px] font-mono uppercase tracking-wider text-[#555]">
+            Send to one address first
+          </span>
+          <div className="mt-1 flex gap-2">
+            <input
+              type="email"
+              value={testEmail}
+              onChange={(e) => setTestEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="w-full rounded border border-[#1e1e1e] bg-[#111] px-2 py-1.5 text-[11px] font-mono text-[#e0e0e0] focus:border-[#00ff41] focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={() => void sendTest()}
+              disabled={testSending || testEmail.trim() === ""}
+              className="shrink-0 rounded border border-[#00d4ff]/40 bg-[#00d4ff]/10 px-3 py-1.5 text-[11px] font-mono uppercase tracking-wider text-[#00d4ff] transition-colors hover:bg-[#00d4ff]/20 disabled:opacity-40"
+            >
+              {testSending ? "Sending…" : "Send test"}
+            </button>
+          </div>
+        </label>
+        {testResult && <p className="text-[11px] font-mono text-[#00ff41]">{testResult}</p>}
+        {testError && (
+          <p role="alert" className="text-[11px] font-mono text-[#ff3333]">
+            {testError}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
 /**
  * Results tab — organiser-facing surfaces for closing out judging.
  *
  * Starts with the one section this program needs first: the teams the panel
- * never reached. Task 7 appends the publish panel below it, so each section
- * is its own component rendered in a simple stack.
+ * never reached. The publish panel follows, then the send panel — each
+ * section is its own component rendered in a simple stack, fetching its own
+ * data independently.
  */
 export function ResultsTab({ cohort }: { cohort: string }) {
   return (
@@ -704,6 +927,9 @@ export function ResultsTab({ cohort }: { cohort: string }) {
       <AwaitingScoreSection cohort={cohort} />
       <div className="border-t border-[#1e1e1e] pt-6">
         <PublishPanel cohort={cohort} />
+      </div>
+      <div className="border-t border-[#1e1e1e] pt-6">
+        <NotifyPanel cohort={cohort} />
       </div>
     </div>
   )

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -539,9 +539,12 @@ function resultsOrdinal(rank: number): string {
  *
  * Table-based layout with inline styles throughout — email clients ignore
  * `<style>` blocks and Tailwind entirely, and this is read on phones and in
- * Outlook as often as in a browser. No web fonts, no external images, and
- * colors are set explicitly on every element (not inherited) so dark-mode
- * remapping in mail clients can't strand light text on a light background.
+ * Outlook as often as in a browser. No web fonts, no external images. Every
+ * text element sets its own `color`, and every box that a client's dark-mode
+ * remapping could independently repaint (the two wrapper tables and the
+ * content cell they wrap) sets its own `background-color` rather than
+ * relying on inheritance — some clients decide light/dark per node from its
+ * own inline style, not from the resolved/inherited value.
  *
  * No judge counts and no deadline language anywhere in this template — those
  * are the two things Impact Lab copy must never say.
@@ -599,7 +602,7 @@ export function impactLabResultsEmail(data: {
 
   const note =
     data.overall.length > 0
-      ? "The top three placings were decided by the judging panel after they had seen every demo and discussed the projects together — that conversation is what those placings reflect. Everyone else is ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
+      ? "The top three placings were decided by the judging panel after they had seen the demos and discussed the projects together — that conversation is what those placings reflect. Everyone else is ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
       : "Every project was ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
 
   const criterionRows = JUDGING_CRITERIA.map((criterion) => {
@@ -628,7 +631,7 @@ export function impactLabResultsEmail(data: {
     <td align="center">
       <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background-color:#0d0d0d;border:1px solid #00ff41;border-radius:8px;">
         <tr>
-          <td style="padding:32px 28px;">
+          <td style="padding:32px 28px;background-color:#0d0d0d;">
             <p style="margin:0 0 4px;font-family:monospace,monospace;font-size:11px;letter-spacing:1px;text-transform:uppercase;color:#00ff41;">Impact Lab: AI Mashinani</p>
             <h1 style="margin:0 0 20px;font-family:monospace,monospace;font-size:22px;color:#e0e0e0;">Your results are in</h1>
 
@@ -663,7 +666,7 @@ export function impactLabResultsEmail(data: {
                 </td>
               </tr>
             </table>
-            <p style="margin:0 0 24px;font-family:monospace,monospace;font-size:11px;color:#555;">If the button doesn't work, paste this URL into your browser:<br>${esc(data.dashboardUrl)}</p>
+            <p style="margin:0 0 24px;font-family:monospace,monospace;font-size:11px;color:#888;">If the button doesn't work, paste this URL into your browser:<br>${esc(data.dashboardUrl)}</p>
 
             <p style="margin:0;font-family:monospace,monospace;font-size:11px;color:#555;">Claude Community Kenya · ${APP_URL}</p>
           </td>

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -5,6 +5,8 @@
 
 import { Resend } from "resend"
 import { VOLUNTEER_ROLE_LABELS as SHARED_VOLUNTEER_ROLE_LABELS } from "@/lib/volunteer-roles"
+import { JUDGING_CRITERIA } from "@/lib/impact-lab/judging"
+import type { AnnouncedWinner, ResultsTrackWinner } from "@/lib/impact-lab/results"
 
 // Lazy initialization — avoids build-time error when env var is not set
 let _resend: Resend | null = null
@@ -18,7 +20,7 @@ const EMAIL_FROM_NAME =
   process.env.EMAIL_FROM_NAME || "Claude Community Kenya"
 const EMAIL_TO_ADMIN =
   process.env.EMAIL_TO_ADMIN || "claudecommunitykenya@gmail.com"
-const APP_URL = process.env.NEXTAUTH_URL || "https://www.claudekenya.org"
+export const APP_URL = process.env.NEXTAUTH_URL || "https://www.claudekenya.org"
 
 function esc(str: string): string {
   return str
@@ -130,6 +132,61 @@ export async function sendEmailBatch(
     }
   }
   return { sent, failed }
+}
+
+/**
+ * Batch send that reports per recipient rather than per chunk.
+ *
+ * `sendEmailBatch` returns only totals, which is not enough to record who was
+ * actually reached — and without that, a retry re-sends to everyone. Resend's
+ * quota is 100/day against 93 recipients, so a blind retry blows the quota and
+ * double-mails the people it already reached.
+ *
+ * Chunks of 25 rather than the API ceiling of 100: if a chunk is rejected we
+ * can only mark that chunk failed, so a smaller chunk loses less certainty.
+ */
+export async function sendEmailBatchTracked(
+  items: BatchEmailItem[]
+): Promise<{ to: string; ok: boolean; error?: string }[]> {
+  if (items.length === 0) return []
+
+  if (!process.env.RESEND_API_KEY) {
+    console.warn("[EMAIL] RESEND_API_KEY not configured, batch not sent")
+    return items.map((item) => ({
+      to: item.to,
+      ok: false,
+      error: "RESEND_API_KEY not configured",
+    }))
+  }
+
+  const from = `${EMAIL_FROM_NAME} <${EMAIL_FROM}>`
+  const results: { to: string; ok: boolean; error?: string }[] = []
+
+  for (let i = 0; i < items.length; i += 25) {
+    const chunk = items.slice(i, i + 25)
+    try {
+      const { error } = await getResend().batch.send(
+        chunk.map((item) => ({
+          from,
+          to: [item.to],
+          subject: item.subject,
+          html: item.html,
+          text: stripHtml(item.html),
+        }))
+      )
+      const message = error ? error.message : undefined
+      for (const item of chunk) {
+        results.push({ to: item.to, ok: !error, error: message })
+      }
+      if (error) console.error("[EMAIL] Batch chunk rejected:", error)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown send failure"
+      console.error("[EMAIL] Batch chunk failed:", err)
+      for (const item of chunk) results.push({ to: item.to, ok: false, error: message })
+    }
+  }
+
+  return results
 }
 
 // ─── CCK-specific email templates ───────────────────────────────────────────
@@ -463,6 +520,160 @@ export function impactLabAccountEmail(data: {
     </div>
   `
   return { to: data.to, subject: "Impact Lab: meet your team", html }
+}
+
+/** Matches the ordinal shown on the dashboard's results page (ResultsView.tsx) exactly. */
+const RESULTS_ORDINALS: Record<number, string> = { 1: "1st", 2: "2nd", 3: "3rd" }
+function resultsOrdinal(rank: number): string {
+  return RESULTS_ORDINALS[rank] ?? `${rank}th`
+}
+
+/**
+ * Impact Lab: the results email. Nine of the 93 recipients never created a
+ * dashboard account, so this has to stand alone — the winners and the
+ * recipient's own scorecard are written out in full in the body, not just
+ * linked. Everything passed in here must come from the stored results
+ * snapshot (see `resultsSnapshot` on ImpactLabMatchRun), never recomputed
+ * from live scores or submissions, because live data moves after publication
+ * and what 93 people are told must not move with it.
+ *
+ * Table-based layout with inline styles throughout — email clients ignore
+ * `<style>` blocks and Tailwind entirely, and this is read on phones and in
+ * Outlook as often as in a browser. No web fonts, no external images, and
+ * colors are set explicitly on every element (not inherited) so dark-mode
+ * remapping in mail clients can't strand light text on a light background.
+ *
+ * No judge counts and no deadline language anywhere in this template — those
+ * are the two things Impact Lab copy must never say.
+ */
+export function impactLabResultsEmail(data: {
+  fullName: string
+  projectName: string
+  rank: number
+  criterionAverages: Record<string, number>
+  low: number | null
+  high: number | null
+  basis: "demo" | "submission"
+  overall: AnnouncedWinner[]
+  trackWinners: ResultsTrackWinner[]
+  dashboardUrl: string
+}): { subject: string; html: string } {
+  // Publishing with zero announced winners is a legal (if unusual) state —
+  // the publish panel warns rather than blocks it. Guard each block the same
+  // way ResultsView.tsx does, so an empty list renders nothing rather than an
+  // empty heading, and so the note below never claims a panel decision that
+  // didn't happen.
+  const winnersSection =
+    data.overall.length > 0
+      ? `
+            <p style="margin:0 0 8px;font-family:monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#888;">Winners</p>
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 16px;">
+              ${data.overall
+                .map(
+                  (w) => `
+              <tr>
+                <td style="padding:6px 0;font-family:monospace,monospace;font-size:13px;color:#ffb000;white-space:nowrap;width:56px;">${esc(resultsOrdinal(w.rank))}</td>
+                <td style="padding:6px 0;font-family:monospace,monospace;font-size:13px;color:#e0e0e0;">${esc(w.projectName)}</td>
+              </tr>`
+                )
+                .join("")}
+            </table>`
+      : ""
+
+  const trackSection =
+    data.trackWinners.length > 0
+      ? `
+            <p style="margin:0 0 8px;font-family:monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#888;">Track winners</p>
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 24px;">
+              ${data.trackWinners
+                .map(
+                  (w) => `
+              <tr>
+                <td style="padding:6px 0;font-family:monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;color:#00d4ff;white-space:nowrap;width:150px;">${esc(w.track)}</td>
+                <td style="padding:6px 0;font-family:monospace,monospace;font-size:13px;color:#e0e0e0;">${esc(w.projectName)}</td>
+              </tr>`
+                )
+                .join("")}
+            </table>`
+      : ""
+
+  const note =
+    data.overall.length > 0
+      ? "The top three placings were decided by the judging panel after they had seen every demo and discussed the projects together — that conversation is what those placings reflect. Everyone else is ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
+      : "Every project was ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
+
+  const criterionRows = JUDGING_CRITERIA.map((criterion) => {
+    const value = data.criterionAverages[criterion.key]
+    const shown = typeof value === "number" ? `${value.toFixed(1)} / 5` : "—"
+    return `
+        <tr>
+          <td style="padding:5px 0;font-family:monospace,monospace;font-size:12px;color:#888;">${esc(criterion.label)}</td>
+          <td style="padding:5px 0;font-family:monospace,monospace;font-size:12px;color:#e0e0e0;text-align:right;white-space:nowrap;">${shown}</td>
+        </tr>`
+  }).join("")
+
+  const rangeRow =
+    data.low !== null && data.high !== null
+      ? `<p style="margin:10px 0 0;font-family:monospace,monospace;font-size:11px;color:#888;">Score range across judges: ${data.low.toFixed(1)}–${data.high.toFixed(1)}</p>`
+      : ""
+
+  const submissionNote =
+    data.basis === "submission"
+      ? `<p style="margin:0 0 14px;font-family:monospace,monospace;font-size:12px;line-height:1.6;color:#888;border:1px solid #1e1e1e;border-radius:4px;padding:10px 12px;">Your project was reviewed from your written submission against the same five criteria. A live demo was not part of that review, which is reflected in the demo criterion below.</p>`
+      : ""
+
+  const html = `
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background-color:#0a0a0a;padding:24px 0;">
+  <tr>
+    <td align="center">
+      <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="max-width:600px;width:100%;background-color:#0d0d0d;border:1px solid #00ff41;border-radius:8px;">
+        <tr>
+          <td style="padding:32px 28px;">
+            <p style="margin:0 0 4px;font-family:monospace,monospace;font-size:11px;letter-spacing:1px;text-transform:uppercase;color:#00ff41;">Impact Lab: AI Mashinani</p>
+            <h1 style="margin:0 0 20px;font-family:monospace,monospace;font-size:22px;color:#e0e0e0;">Your results are in</h1>
+
+            <p style="margin:0 0 20px;font-family:monospace,monospace;font-size:14px;line-height:1.6;color:#e0e0e0;">Hi ${esc(data.fullName)},</p>
+            ${winnersSection}
+            ${trackSection}
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px;border:1px solid #1e1e1e;border-radius:6px;">
+              <tr>
+                <td style="padding:18px;">
+                  <p style="margin:0 0 2px;font-family:monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#00ff41;">Your team</p>
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 12px;">
+                    <tr>
+                      <td style="font-family:monospace,monospace;font-size:17px;font-weight:bold;color:#e0e0e0;">${esc(data.projectName)}</td>
+                      <td style="font-family:monospace,monospace;font-size:12px;color:#888;text-align:right;white-space:nowrap;">${esc(resultsOrdinal(data.rank))} overall</td>
+                    </tr>
+                  </table>
+                  ${submissionNote}
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                    ${criterionRows}
+                  </table>
+                  ${rangeRow}
+                </td>
+              </tr>
+            </table>
+
+            <p style="margin:0 0 20px;font-family:monospace,monospace;font-size:12px;line-height:1.7;color:#888;">${note}</p>
+
+            <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 12px;">
+              <tr>
+                <td style="border-radius:4px;background-color:#00ff41;">
+                  <a href="${esc(data.dashboardUrl)}" style="display:inline-block;padding:12px 24px;font-family:monospace,monospace;font-size:13px;font-weight:bold;color:#0a0a0a;text-decoration:none;">Open my dashboard →</a>
+                </td>
+              </tr>
+            </table>
+            <p style="margin:0 0 24px;font-family:monospace,monospace;font-size:11px;color:#555;">If the button doesn't work, paste this URL into your browser:<br>${esc(data.dashboardUrl)}</p>
+
+            <p style="margin:0;font-family:monospace,monospace;font-size:11px;color:#555;">Claude Community Kenya · ${APP_URL}</p>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>`
+
+  return { subject: "Impact Lab: your results are in", html }
 }
 
 export async function sendApplicationReviewEmail(data: {

--- a/src/lib/impact-lab/results.ts
+++ b/src/lib/impact-lab/results.ts
@@ -183,6 +183,66 @@ export function toPublicRanking(ranking: RankedTeam[]): PublicRankedTeam[] {
   }))
 }
 
+/** The published result as one participant may receive it. Flat member shape — no `data` wrapper. */
+export interface MemberResultsPayload {
+  success: true
+  published: boolean
+  results?: {
+    publishedAt: string
+    overall: AnnouncedWinner[]
+    trackWinners: ResultsTrackWinner[]
+    ranking: PublicRankedTeam[]
+  }
+  yourTeam?: { teamId: string; projectName: string; card: TeamCard }
+}
+
+/**
+ * The published result as one participant may receive it.
+ *
+ * Lives here rather than inline in the route so the privacy properties can be
+ * asserted: the snapshot holds every team's private card and a score on every
+ * ranking row, and neither may cross the wire. Building the payload by naming
+ * each field — never by spreading the snapshot — means a field added to the
+ * snapshot later does not leak by default.
+ *
+ * `viewerTeamId` is the caller's own team, or `null` when it could not be
+ * resolved (not registered, not on a team in the frozen run, or a stale id).
+ * `yourTeam` is omitted from the returned object entirely in that case, and
+ * also when the resolved team has no card or no ranking row — never set to
+ * `null` or an empty object, so `"yourTeam" in payload` is the true test of
+ * whether a card was attached.
+ */
+export function buildMemberPayload(
+  snapshot: ResultsSnapshot,
+  viewerTeamId: string | null
+): MemberResultsPayload {
+  const payload: MemberResultsPayload = {
+    success: true,
+    published: true,
+    results: {
+      publishedAt: snapshot.publishedAt,
+      overall: snapshot.overall,
+      trackWinners: snapshot.trackWinners,
+      ranking: toPublicRanking(snapshot.ranking),
+    },
+  }
+
+  const card = viewerTeamId ? snapshot.perTeam[viewerTeamId] : undefined
+  const rankingRow = viewerTeamId
+    ? snapshot.ranking.find((r) => r.teamId === viewerTeamId)
+    : undefined
+
+  if (viewerTeamId && card && rankingRow) {
+    payload.yourTeam = {
+      teamId: viewerTeamId,
+      projectName: rankingRow.projectName,
+      card,
+    }
+  }
+
+  return payload
+}
+
 export function buildSnapshot(input: ResultsInput): ResultsSnapshot {
   const ranking = buildRanking(input)
   const standingById = new Map(input.standings.map((s) => [s.teamId, s]))

--- a/src/lib/impact-lab/results.ts
+++ b/src/lib/impact-lab/results.ts
@@ -1,0 +1,183 @@
+/**
+ * Impact Lab results — the published snapshot.
+ *
+ * Pure and dependency-free (no Prisma, no Next) so the rules that decide what
+ * 93 builders are told can be asserted by a script.
+ *
+ * Two rules carry all the weight:
+ *
+ * 1. The three winners announced in the room hold ranks 1-3, whatever the
+ *    arithmetic says. The panel watched every demo and deliberated; no
+ *    combination of the recorded scores reproduces their decision, and the
+ *    announcement is already public. Recomputing it would contradict what
+ *    people were told to their faces.
+ * 2. Everyone else ranks below them by score. Scores order the list but are
+ *    never printed in it — publishing them would place a 76.9 at 4th above a
+ *    75.3 at 1st, which is the contradiction this ranking exists to remove.
+ *    A team's own numbers live on its own private card.
+ */
+
+import { trackOf, type TeamStanding } from "./judging"
+
+/** How a team's placing was arrived at. */
+export type ResultBasis = "announced" | "demo" | "submission"
+
+export interface RankedTeam {
+  rank: number
+  teamId: string
+  projectName: string
+  track: string
+  /** Orders the ranking. Never rendered in the public table. */
+  average: number
+  basis: ResultBasis
+}
+
+export interface AnnouncedWinner {
+  rank: number
+  teamId: string
+  projectName: string
+}
+
+export interface ResultsTrackWinner {
+  track: string
+  teamId: string
+  projectName: string
+  /** "announced" when an overall winner leads the track, else "score". */
+  basis: "announced" | "score"
+}
+
+/** Served only to members of that team. */
+export interface TeamCard {
+  rank: number
+  criterionAverages: Record<string, number>
+  low: number
+  high: number
+  basis: "demo" | "submission"
+}
+
+export interface ResultsSnapshot {
+  publishedAt: string
+  overall: AnnouncedWinner[]
+  trackWinners: ResultsTrackWinner[]
+  ranking: RankedTeam[]
+  perTeam: Record<string, TeamCard>
+}
+
+export interface ResultsInput {
+  publishedAt: string
+  /** Announced winners in announced order. Empty is legal; three is the case. */
+  announcedTeamIds: string[]
+  standings: TeamStanding[]
+  teams: Map<string, { projectName: string; track: string }>
+  /** Teams scored from the written submission rather than a live demo. */
+  writeupOnly: Set<string>
+  /** Lowest and highest weighted total across that team's judges. */
+  range: Map<string, { low: number; high: number }>
+}
+
+const UNKNOWN_TRACK = "Unassigned"
+
+function metaOf(
+  input: ResultsInput,
+  teamId: string
+): { projectName: string; track: string } {
+  const meta = input.teams.get(teamId)
+  if (meta) return meta
+  // A team present in standings but absent from the run JSON should not be able
+  // to crash publication; it appears with its id rather than vanishing.
+  return { projectName: teamId, track: UNKNOWN_TRACK }
+}
+
+/**
+ * Announced winners first in announced order, then everyone else by average
+ * descending. Ties break by teamId so two loads never reorder themselves.
+ */
+export function buildRanking(input: ResultsInput): RankedTeam[] {
+  const announced = new Set(input.announcedTeamIds)
+  const byTeam = new Map(input.standings.map((s) => [s.teamId, s]))
+
+  const rows: RankedTeam[] = []
+
+  for (const teamId of input.announcedTeamIds) {
+    const meta = metaOf(input, teamId)
+    rows.push({
+      rank: rows.length + 1,
+      teamId,
+      projectName: meta.projectName,
+      track: meta.track || trackOf(meta.projectName),
+      average: byTeam.get(teamId)?.average ?? 0,
+      basis: "announced",
+    })
+  }
+
+  const rest = input.standings
+    .filter((s) => !announced.has(s.teamId))
+    .sort((a, b) => b.average - a.average || a.teamId.localeCompare(b.teamId))
+
+  for (const s of rest) {
+    const meta = metaOf(input, s.teamId)
+    rows.push({
+      rank: rows.length + 1,
+      teamId: s.teamId,
+      projectName: meta.projectName,
+      track: meta.track || trackOf(meta.projectName),
+      average: s.average,
+      basis: input.writeupOnly.has(s.teamId) ? "submission" : "demo",
+    })
+  }
+
+  return rows
+}
+
+/**
+ * One winner per track. An announced overall winner leads its own track — so
+ * the champion never appears to lose its own category on the same page that
+ * crowns it. Tracks with no announced winner go to their highest-ranked team.
+ */
+export function buildTrackWinners(ranking: RankedTeam[]): ResultsTrackWinner[] {
+  const best = new Map<string, ResultsTrackWinner>()
+
+  // `ranking` is already ordered with announced winners first, so the first
+  // sighting of a track is its winner.
+  for (const row of ranking) {
+    if (best.has(row.track)) continue
+    best.set(row.track, {
+      track: row.track,
+      teamId: row.teamId,
+      projectName: row.projectName,
+      basis: row.basis === "announced" ? "announced" : "score",
+    })
+  }
+
+  return [...best.values()].sort((a, b) => a.track.localeCompare(b.track))
+}
+
+export function buildSnapshot(input: ResultsInput): ResultsSnapshot {
+  const ranking = buildRanking(input)
+  const standingById = new Map(input.standings.map((s) => [s.teamId, s]))
+
+  const perTeam: Record<string, TeamCard> = {}
+  for (const row of ranking) {
+    const standing = standingById.get(row.teamId)
+    const range = input.range.get(row.teamId)
+    perTeam[row.teamId] = {
+      rank: row.rank,
+      criterionAverages: standing?.criterionAverages ?? {},
+      low: range?.low ?? 0,
+      high: range?.high ?? 0,
+      basis: input.writeupOnly.has(row.teamId) ? "submission" : "demo",
+    }
+  }
+
+  return {
+    publishedAt: input.publishedAt,
+    overall: input.announcedTeamIds.map((teamId, i) => ({
+      rank: i + 1,
+      teamId,
+      projectName: metaOf(input, teamId).projectName,
+    })),
+    trackWinners: buildTrackWinners(ranking),
+    ranking,
+    perTeam,
+  }
+}

--- a/src/lib/impact-lab/results.ts
+++ b/src/lib/impact-lab/results.ts
@@ -50,8 +50,10 @@ export interface ResultsTrackWinner {
 export interface TeamCard {
   rank: number
   criterionAverages: Record<string, number>
-  low: number
-  high: number
+  /** `null` when no range was recorded — distinct from an earned zero. */
+  low: number | null
+  /** `null` when no range was recorded — distinct from an earned zero. */
+  high: number | null
   basis: "demo" | "submission"
 }
 
@@ -152,6 +154,35 @@ export function buildTrackWinners(ranking: RankedTeam[]): ResultsTrackWinner[] {
   return [...best.values()].sort((a, b) => a.track.localeCompare(b.track))
 }
 
+/** A ranking row as participants may receive it. */
+export type PublicRankedTeam = Omit<RankedTeam, "average">
+
+/**
+ * The ranking with scores removed, for anything that crosses the wire to a
+ * participant.
+ *
+ * `average` orders the ranking and must stay in the stored snapshot — the
+ * ordering has to be reproducible from what was published. But sending it to a
+ * browser would let anyone with devtools read every team's score off a page
+ * that shows none, which is the contradiction the announced-winner override
+ * exists to remove. Strip it here, once, rather than trusting each route to
+ * remember.
+ *
+ * Built field-by-field rather than destructure-and-omit: this project's
+ * eslint config runs `@typescript-eslint/no-unused-vars` with no
+ * `varsIgnorePattern`, so a discarded `average` binding — even underscore-
+ * prefixed — would still surface as a lint warning.
+ */
+export function toPublicRanking(ranking: RankedTeam[]): PublicRankedTeam[] {
+  return ranking.map((row) => ({
+    rank: row.rank,
+    teamId: row.teamId,
+    projectName: row.projectName,
+    track: row.track,
+    basis: row.basis,
+  }))
+}
+
 export function buildSnapshot(input: ResultsInput): ResultsSnapshot {
   const ranking = buildRanking(input)
   const standingById = new Map(input.standings.map((s) => [s.teamId, s]))
@@ -163,8 +194,8 @@ export function buildSnapshot(input: ResultsInput): ResultsSnapshot {
     perTeam[row.teamId] = {
       rank: row.rank,
       criterionAverages: standing?.criterionAverages ?? {},
-      low: range?.low ?? 0,
-      high: range?.high ?? 0,
+      low: range?.low ?? null,
+      high: range?.high ?? null,
       basis: input.writeupOnly.has(row.teamId) ? "submission" : "demo",
     }
   }


### PR DESCRIPTION
Publishes the hackathon result to the 93 builders whose teams submitted, and locks the record so it cannot move underneath them afterwards.

## What participants get

- The winners as announced in the room — BiasharaGPT, VilCare, Oryn — plus five track winners. The announced winners lead their own tracks; the rest go to the highest scorer.
- A full ranking by **position only**. No scores, no judge counts.
- Their own team's five criterion scores and the range across judges, private to that team.
- An email carrying the same thing standalone, because nine of the 93 have no account and cannot open the dashboard.

## What organisers get

- **Judges tab** — every judge, every sheet, and the calibration spread. The four judges scored on means of 72, 67, 54 and 48; that gap is invisible on a leaderboard and changes how the result reads.
- **Exclusion preview** — recompute the standings without a judge. Read-only by construction, with no write path, because the panel already overrode the arithmetic and this must never become a dial for shopping outcomes.
- **Submission-only scoring** for the four teams no judge reached. Claude drafts, a human approves every number, and the basis travels with the score wherever it appears.
- **Publish** — one irreversible action that closes submissions and judging, snapshots the result, and queues the emails inside a single row-locked transaction.

## Why a snapshot

One team edited its submission a full day after being judged. Live data demonstrably moves after the fact; what 93 people were told must not move with it. Everything participants see is served from the stored snapshot and never recomputed.

## Notable during review

Three defects were found that no single-task review could have caught:

- Every team's score was being **transmitted** in the ranking payload despite never being rendered — readable in devtools on a page that deliberately shows none.
- The publish action was gated on `view`, which is the permission judges sign in with. A judge-role account could have closed judging and queued 93 emails.
- `rematch` could still rewrite team membership **after** publication. The snapshot freezes each team's card but not the person-to-team mapping, and both the dashboard and the email resolve a participant's team from live data — so moving someone would have served them another team's private scorecard.

## Verification

`npm run verify:results` 34 assertions · `npm run verify:judging` · `tsc --noEmit` · `npm run build` — all clean.

Idempotency was proven against real Postgres on a throwaway database, not by reading: 5 queued rows, a batch of 3 marked sent, the second call selected only the 2 unsent. A simulated rejection returned its row to the queue. This matters because Resend allows 100 emails a day against 93 recipients — a double-send cannot be undone.

All 20 migrations replay cleanly in sequence, and the partial unique index `impact_lab_match_runs_one_final_per_cohort` survives.

## Before deploying

**Apply the migration to production BEFORE this merges to main.** Vercel deploys from `main`, and this code reads columns production does not have yet. Deploying first will 500 every Impact Lab page — the same failure as #62.

Publish refuses while any submitted team has no score, so the four unjudged teams must be scored first.

@Spidey-Acer