### PR TITLE
Fix: writeup draft returned an opaque HTML 502; drop duplicate chat close button

### DIFF
--- a/src/app/api/admin/impact-lab/judging/writeup/route.ts
+++ b/src/app/api/admin/impact-lab/judging/writeup/route.ts
@@ -29,7 +29,11 @@ import {
  * you. No demo was seen, so the draft says so plainly instead of guessing, and
  * `writeupOnly` travels with the score wherever it is displayed.
  */
-export const maxDuration = 60
+// The platform default is 300s. This route reads a submission, calls a model
+// for ten fields, and may retry — a 60s ceiling turned a slow generation into
+// a killed function, which reaches the browser as an HTML gateway error the
+// route's own error handling never gets to replace.
+export const maxDuration = 300
 
 const MODEL = "claude-sonnet-5"
 const anthropic = createAnthropic()
@@ -165,7 +169,31 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ success: true, data: { teams: awaiting } })
 }
 
+/**
+ * Any unhandled throw here reaches the browser as an HTML gateway page, and
+ * the caller's `res.json()` then fails with "Unexpected token '<'" — which
+ * says nothing about what actually broke. Wrapping the handler means a
+ * failure arrives as readable JSON naming its own cause.
+ */
 export async function POST(request: NextRequest) {
+  try {
+    return await handlePost(request)
+  } catch (error) {
+    console.error("[judging/writeup] unhandled failure", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? `Writeup scoring failed: ${error.message}`
+            : "Writeup scoring failed for an unknown reason.",
+      },
+      { status: 500 }
+    )
+  }
+}
+
+async function handlePost(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 

--- a/src/components/chat/ChatWidget.tsx
+++ b/src/components/chat/ChatWidget.tsx
@@ -9,34 +9,6 @@ import { MessageCircle } from "lucide-react";
 
 const WIDGET_OPEN_KEY = "cck-chat-open";
 
-function DevCloseButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      className="group absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center font-mono text-green-dim transition-all hover:text-red"
-      aria-label="Close chat"
-      title="Close"
-    >
-      <span className="text-xs opacity-60 group-hover:opacity-100">[x]</span>
-    </button>
-  );
-}
-
-function ProCloseButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      onClick={onClick}
-      className="group absolute right-2.5 top-2.5 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-text-dim/20 transition-all hover:bg-red/30"
-      aria-label="Close chat"
-      title="Close"
-    >
-      <svg className="h-2.5 w-2.5 text-text-secondary group-hover:text-red" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-        <path d="M2 2l6 6M8 2l-6 6" />
-      </svg>
-    </button>
-  );
-}
-
 export function ChatWidget() {
   const { skin, isLoaded } = useSkin();
   const [isOpen, setIsOpen] = useState(false);
@@ -81,12 +53,12 @@ export function ChatWidget() {
                 : "rounded-2xl border border-border-default bg-bg-primary/95 backdrop-blur-md"
             )}
           >
-            {isDev ? (
-              <DevCloseButton onClick={() => setIsOpen(false)} />
-            ) : (
-              <ProCloseButton onClick={() => setIsOpen(false)} />
-            )}
-
+            {/*
+              No close button in the panel corner: the floating bubble below
+              already turns into an ✕ while the panel is open, so a second
+              control for the same action sat two inches away from the first
+              and overlapped the panel header.
+            */}
             <ChatPanel />
           </motion.div>
         )}


### PR DESCRIPTION
## The bug

Clicking **Draft with Claude** returned `502` with an HTML body, so the browser's `res.json()` failed with `Unexpected token '<', "<!DOCTYPE"...`. That message says nothing about the cause, and the route's own error handling never ran — the function was killed before it could reply.

Ruled out by testing rather than assumption:
- **Not the schema.** The dynamically-built zod schema constructs and parses fine (zod 4.3.6).
- **Not the model or the key.** The same `generateObject` call with the same schema and model returns in **4.0s** locally, and `ai-explanations.ts` uses `claude-sonnet-5` with the same production key and worked during the event.
- **Not a boot failure.** An unauthenticated POST returns a correct `403` JSON, so the module loads.

That leaves the function being terminated mid-generation. `maxDuration` was pinned at `60`, well under the platform default of 300.

## Changes

- `maxDuration` 60 → 300 on the writeup route.
- The POST handler is wrapped so any unhandled throw returns JSON naming its own cause instead of an HTML gateway page. If this recurs, the next click says what actually broke.
- Removes the chat panel's corner close button. The floating bubble already turns into a close control while the panel is open, so there were two controls for one action inches apart, and the corner one overlapped the panel header.

## Verification

`tsc --noEmit` clean · `npm run build` clean. The one remaining lint error in `ChatWidget.tsx` is pre-existing (`set-state-in-effect` in the localStorage restore), untouched here.

@Spidey-Acer