### PR TITLE
Fix: /admin/photos crashed on every render

### DIFF
--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -44,13 +44,16 @@ export default async function PhotosAdminPage({
             <p className="text-xs font-mono text-[#555]">{filtered.length} photo{filtered.length !== 1 ? "s" : ""}</p>
             {/* Event filter */}
             <form method="GET" className="flex items-center gap-2">
+              {/*
+                No onChange here. This is a Server Component, and React refuses
+                to serialise an event handler onto a DOM element from one — it
+                throws at render and takes the whole page down, which is what it
+                was doing. The handler was a no-op anyway; the Filter button
+                below submits the form.
+              */}
               <select
                 name="event"
                 defaultValue={eventFilter ?? ""}
-                onChange={(e) => {
-                  // Handled via form submit — this is a server component
-                  void e
-                }}
                 className="bg-[#111] border border-[#1e1e1e] rounded px-2 py-1.5 text-[11px] font-mono text-[#ccc] focus:outline-none focus:border-[#00ff41]/50"
               >
                 <option value="">All events</option>


### PR DESCRIPTION
`/admin/photos` returned a server error on every visit. Not an environment problem — the R2 variables are set correctly and are unrelated.

## Cause

`src/app/admin/photos/page.tsx` passed an `onChange` handler to a `<select>` inside a Server Component. React cannot serialise an event handler across that boundary, so it threw during render and took the page down.

The handler was dead code. Its own comment read *"Handled via form submit — this is a server component"*, and the **Filter** button immediately beside it already submits the form. So it did nothing except crash the page.

Removed rather than replaced — the filter works exactly as before.

## Also checked

Swept every page under `src/app/admin/` for the same pattern (an event handler in a file without `"use client"`). This was the only one.

## Verification

`tsc --noEmit` clean · `npm run build` clean.

@Spidey-Acer