### PR TITLE
Fix: homepage hero is the Mombasa photo — credit it as such

### DIFF
--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -27,7 +27,7 @@ import { Reveal } from "@/components/karibu/motion/Reveal";
 import { CountUp } from "@/components/ui/CountUp";
 import { KaribuTestimonials } from "@/components/karibu/KaribuTestimonials";
 import { KaribuProjects } from "@/components/karibu/KaribuProjects";
-import { HERO_PHOTO, GALLERY_PHOTOS, eventCover } from "@/components/karibu/photos";
+import { HERO_PHOTO, HERO_PHOTO_CREDIT, GALLERY_PHOTOS, eventCover } from "@/components/karibu/photos";
 import { EventCoverPlaceholder } from "@/components/karibu/EventCoverPlaceholder";
 
 interface KaribuHomeProps {
@@ -184,13 +184,21 @@ function Hero({ nextEvent }: { nextEvent?: Event }) {
         >
           <Image
             src={HERO_PHOTO}
-            alt="Claude Community Kenya members at a Nairobi meetup"
+            alt={`Claude Community Kenya members at the ${HERO_PHOTO_CREDIT}`}
             fill
             priority
             sizes="(max-width: 1024px) 100vw, 560px"
             className="object-cover"
           />
           <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-scrim/45 via-transparent to-transparent" />
+          {/* Photo credit. The "Coming up" chip below is an announcement
+           * overlay, not a caption — naming what the photograph actually
+           * shows is what keeps that distinction honest. */}
+          <div className="pointer-events-none absolute left-[18px] top-[18px] rounded-full border border-white/15 bg-scrim/70 px-3 py-1 backdrop-blur-md">
+            <span className="font-inter text-[10px] font-semibold uppercase tracking-[0.14em] text-scrim-text-soft">
+              {HERO_PHOTO_CREDIT}
+            </span>
+          </div>
           {nextEvent && (
             <div className="absolute inset-x-[18px] bottom-[18px] overflow-hidden rounded-xl border border-white/15 backdrop-blur-md">
               {/* Gradient scrim, not a flat block — darkens the photo under

--- a/src/components/karibu/photos.ts
+++ b/src/components/karibu/photos.ts
@@ -6,6 +6,15 @@
 
 export const HERO_PHOTO = "/images/community/hero-crowd.webp";
 
+/**
+ * What HERO_PHOTO actually depicts. Rendered as a visible credit on the hero,
+ * because an announcement chip sits on this photo and without a credit the
+ * chip reads as a caption — which is how a Mombasa crowd spent a week on the
+ * homepage implying it was a Nairobi hackathon. If you swap the photo above,
+ * update this line in the same commit.
+ */
+export const HERO_PHOTO_CREDIT = "Mombasa AI & Career Talk";
+
 /** Portrait/gallery photos for the community-in-action collage. */
 export const GALLERY_PHOTOS = {
   tall: "/images/community/mural-laptops.webp",


### PR DESCRIPTION
Peter identified the homepage hero crowd as the Mombasa AI & Career Talk. The markup disagreed twice: the `alt` text said *"members at a Nairobi meetup"*, and the **Coming up** chip overlaid on the photo captioned it as whatever event is announced next — lately "Claude Code Hackathon — Nairobi".

Same class of bug as #85, one instance further upstream.

## Changes

- `alt` now derives from a new `HERO_PHOTO_CREDIT` constant: the photo is described as what it actually shows.
- A small visible credit chip on the image names the event. With the photograph credited, the "Coming up" overlay reads as the announcement it is instead of a caption.
- The credit lives directly beside `HERO_PHOTO` in `photos.ts`, with a comment requiring both to change in the same commit — swapping the photo without updating the credit should be hard to do by accident.

## Not touched here

"Coming up" still names an ended hackathon — that staleness is fixed properly in Ed's #79 (`getUpcomingEvents` becomes date-aware), so it isn't duplicated here.

`tsc --noEmit` clean.

@Spidey-Acer