### PR TITLE
Fix: email preview named a different champion than publishing would send

### DIFF
--- a/src/app/api/admin/impact-lab/results/preview-email/route.ts
+++ b/src/app/api/admin/impact-lab/results/preview-email/route.ts
@@ -35,12 +35,16 @@ import { APP_URL, impactLabResultsEmail } from "@/lib/email"
  *  - Before publish, there is no snapshot yet, so this computes the same
  *    `ResultsInput` `publish/route.ts` would (via the shared
  *    `buildResultsInputFromRun` helper) and runs it through the same
- *    `buildSnapshot`. There is no announced-winners selection to read at
- *    this point — that choice lives only in the publish form's own state
- *    until the POST that publishes — so a pre-publish preview always shows
- *    the score-only ranking, with nobody yet marked as an announced winner.
- *    Everything else — rank, criterion averages, score range — is the
- *    team's real, current numbers, and publishing freezes exactly this.
+ *    `buildSnapshot`, INCLUDING the announced winners the organiser has
+ *    selected, passed in `?announced=`.
+ *
+ *    Those ids are not decoration: they decide the overall placing and which
+ *    team leads each track. Without them this endpoint rendered the score-only
+ *    ranking — so the preview named a different champion and two different
+ *    track winners than the email it claimed to be previewing, under a banner
+ *    promising publishing would freeze exactly what was on screen. A preview
+ *    that can disagree with the send is worse than no preview, because it is
+ *    trusted.
  * `data.published` tells the caller which path rendered the response, so the
  * UI can say so on screen.
  */
@@ -56,6 +60,19 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     )
   }
+
+  // Comma-separated team ids, in announced order. Capped and de-duplicated:
+  // this only ever feeds a render, but an unbounded list from a query string
+  // has no business reaching the snapshot builder.
+  const announcedParam = (request.nextUrl.searchParams.get("announced") ?? "").trim()
+  const requestedAnnounced = announcedParam === ""
+    ? []
+    : [...new Set(
+        announcedParam
+          .split(",")
+          .map((id) => id.trim())
+          .filter((id) => id !== "" && id.length <= 64)
+      )].slice(0, 3)
 
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
@@ -123,8 +140,10 @@ export async function GET(request: NextRequest) {
     const input: ResultsInput = {
       ...inputBase,
       publishedAt: new Date().toISOString(),
-      // See the header comment: no winners are chosen yet at preview time.
-      announcedTeamIds: [],
+      // Filter to scored teams — the same eligibility publish enforces, so a
+      // stale selection left in the form cannot make this preview show a
+      // winner that publishing would then refuse.
+      announcedTeamIds: requestedAnnounced.filter((id) => scoredTeamIds.has(id)),
     }
     snapshot = buildSnapshot(input)
     teamName = team.name

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -369,15 +369,28 @@ const EMPTY_RESULTS_INPUT_EXTRAS = {
  * the same code that computes the stored snapshot, not a second
  * reimplementation that could quietly drift from it.
  */
-function PublishPanel({ cohort }: { cohort: string }) {
+function PublishPanel({
+  cohort,
+  firstPlace,
+  secondPlace,
+  thirdPlace,
+  setFirstPlace,
+  setSecondPlace,
+  setThirdPlace,
+}: {
+  cohort: string
+  firstPlace: string
+  secondPlace: string
+  thirdPlace: string
+  setFirstPlace: (id: string) => void
+  setSecondPlace: (id: string) => void
+  setThirdPlace: (id: string) => void
+}) {
   const [judging, setJudging] = useState<JudgingData | null>(null)
   const [publishStatus, setPublishStatus] = useState<PublishStatus | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
 
-  const [firstPlace, setFirstPlace] = useState("")
-  const [secondPlace, setSecondPlace] = useState("")
-  const [thirdPlace, setThirdPlace] = useState("")
   const [confirmText, setConfirmText] = useState("")
   const [publishing, setPublishing] = useState(false)
   const [publishError, setPublishError] = useState<string | null>(null)
@@ -733,7 +746,13 @@ interface PreviewEmailData {
  * renderer — so what is shown here cannot drift from what actually goes
  * out. It only ever reads; nothing is sent and nothing is written.
  */
-function PreviewEmailPanel({ cohort }: { cohort: string }) {
+function PreviewEmailPanel({
+  cohort,
+  announcedTeamIds,
+}: {
+  cohort: string
+  announcedTeamIds: string[]
+}) {
   const [teams, setTeams] = useState<PreviewEmailOption[] | null>(null)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [selectedTeamId, setSelectedTeamId] = useState("")
@@ -766,6 +785,13 @@ function PreviewEmailPanel({ cohort }: { cohort: string }) {
     }
   }, [cohort])
 
+  // Re-render whenever the announced winners change: a preview showing a
+  // placing the organiser has since altered is worse than no preview.
+  useEffect(() => {
+    if (selectedTeamId !== "") void loadPreview(selectedTeamId)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [announcedTeamIds.join(",")])
+
   async function loadPreview(teamId: string) {
     setSelectedTeamId(teamId)
     setPreview(null)
@@ -774,7 +800,14 @@ function PreviewEmailPanel({ cohort }: { cohort: string }) {
     setLoadingPreview(true)
     try {
       const data = await apiGet<PreviewEmailData>(
-        `/api/admin/impact-lab/results/preview-email?cohort=${cohort}&teamId=${encodeURIComponent(teamId)}`
+        // The announced winners are part of what the email says — they decide
+        // the overall placing AND which team leads each track. Sending them
+        // means a pre-publish preview renders what publishing would actually
+        // produce, rather than the score-only ranking the panel overrode.
+        `/api/admin/impact-lab/results/preview-email?cohort=${cohort}&teamId=${encodeURIComponent(teamId)}` +
+          (announcedTeamIds.length > 0
+            ? `&announced=${encodeURIComponent(announcedTeamIds.join(","))}`
+            : "")
       )
       setPreview(data)
     } catch (e) {
@@ -841,7 +874,10 @@ function PreviewEmailPanel({ cohort }: { cohort: string }) {
               className="flex items-start gap-2 rounded border border-[#ffb000]/30 bg-[#ffb000]/10 p-3 text-[11px] font-mono text-[#ffb000]"
             >
               <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-              <span>Computed from current data; publishing will freeze exactly this.</span>
+              <span>
+                Computed from current data, including the winners selected above;
+                publishing will freeze exactly this.
+              </span>
             </div>
           )}
 
@@ -1205,14 +1241,36 @@ function ExportPanel({ cohort }: { cohort: string }) {
  * stack, fetching its own data independently.
  */
 export function ResultsTab({ cohort }: { cohort: string }) {
+  // The announced winners live here, not inside PublishPanel, because two
+  // panels depend on them: the one that publishes and the one that previews
+  // what publishing would send. While this state was private to PublishPanel,
+  // the preview had no way to read it and rendered the score-only ranking —
+  // so it showed a different champion and different track winners than the
+  // email it was supposed to be previewing.
+  const [firstPlace, setFirstPlace] = useState("")
+  const [secondPlace, setSecondPlace] = useState("")
+  const [thirdPlace, setThirdPlace] = useState("")
+  const announcedTeamIds = useMemo(
+    () => [firstPlace, secondPlace, thirdPlace].filter((id) => id !== ""),
+    [firstPlace, secondPlace, thirdPlace]
+  )
+
   return (
     <div className="space-y-6">
       <AwaitingScoreSection cohort={cohort} />
       <div className="border-t border-[#1e1e1e] pt-6">
-        <PublishPanel cohort={cohort} />
+        <PublishPanel
+          cohort={cohort}
+          firstPlace={firstPlace}
+          secondPlace={secondPlace}
+          thirdPlace={thirdPlace}
+          setFirstPlace={setFirstPlace}
+          setSecondPlace={setSecondPlace}
+          setThirdPlace={setThirdPlace}
+        />
       </div>
       <div className="border-t border-[#1e1e1e] pt-6">
-        <PreviewEmailPanel cohort={cohort} />
+        <PreviewEmailPanel cohort={cohort} announcedTeamIds={announcedTeamIds} />
       </div>
       <div className="border-t border-[#1e1e1e] pt-6">
         <NotifyPanel cohort={cohort} />


### PR DESCRIPTION
Caught by comparing two screenshots of the admin panel side by side. The publish preview and the email preview disagreed about who won:

| Track | Publish preview | Email preview |
|---|---|---|
| Afya | **VilCare** | ReferNet |
| Biashara | **BiasharaGPT** | Whatsy |

And the email called BiasharaGPT **"2nd overall"** — it was announced first.

## Cause

`preview-email/route.ts` passed `announcedTeamIds: []` on the pre-publish path, so `buildSnapshot` fell back to pure score order. BiasharaGPT was announced champion but sits second on raw score, and the announced-winners-lead-their-track rule never applied — so two track winners changed too.

All of this rendered under a banner reading *"publishing will freeze exactly this."* It would not have.

The route's own comment described the limitation accurately — the selection lived only in `PublishPanel`'s private state, and `PreviewEmailPanel` is a sibling with no way to read it. Honest, but it left the preview structurally unable to do the one thing it exists for: answer *"is what I see what goes out?"*

## Fix

The winner selection moves up to `ResultsTab` and is shared by the panel that publishes and the panel that previews. `PreviewEmailPanel` sends it as `?announced=`, and re-renders whenever it changes — a preview showing a placing you have since altered is worse than none.

Server side, ids are capped at three, de-duplicated, and filtered to **scored** teams, matching the eligibility `publish` already enforces. A stale selection left in the form after a re-match cannot render a winner that publishing would then refuse.

The banner now reads *"including the winners selected above"*.

## Verification

`tsc --noEmit` clean. Built in an isolated worktree.

**After merging, re-check the preview before publishing** — with the three dropdowns set, BiasharaGPT should read *1st overall*, and the track winners should match the publish panel exactly.

@Spidey-Acer