### PR TITLE
feat(impact-lab): rebuild results export into a designed, complete record

### DIFF
--- a/src/app/api/admin/impact-lab/results/export/route.ts
+++ b/src/app/api/admin/impact-lab/results/export/route.ts
@@ -11,19 +11,27 @@ import {
 } from "@/lib/impact-lab/export-data"
 import { buildResultsWorkbook } from "@/lib/impact-lab/export-excel"
 import { buildResultsPdf } from "@/lib/impact-lab/export-pdf"
+import { generateTeamAnalyses, type TeamAnalysis } from "@/lib/impact-lab/export-analysis"
 
 /**
- * GET /api/admin/impact-lab/results/export?cohort=…&format=xlsx|pdf
+ * GET /api/admin/impact-lab/results/export?cohort=…&format=xlsx|pdf[&analyses=off]
  *
  * The complete results record — Excel workbook or PDF — generated on request
  * and streamed straight to the browser. Deliberately never persisted to disk
- * or a bucket: the file carries every participant's name and email, and
- * participant data has leaked from an artefact-on-disk before.
+ * or a bucket: the workbook carries every participant's name and email, and
+ * participant data has leaked from an artefact-on-disk before. (The PDF, the
+ * artefact built for sharing, omits contact details entirely.)
+ *
+ * Per-team project analyses are generated at export time from the teams' own
+ * submissions (see export-analysis for the honesty rules) — pass
+ * `analyses=off` for a fast pull without them. Generation failures degrade
+ * to an export without the affected sections, never to an error artefact.
  *
  * Gated on `edit` (not `view`): the file is built to leave the building —
  * sponsors, community — so producing it is treated as an organiser action,
  * one notch above reading the leaderboard.
  */
+export const maxDuration = 300
 export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
@@ -125,8 +133,14 @@ export async function GET(request: NextRequest) {
   const data = buildResultsExport(source)
   const stamp = data.generatedAt.toISOString().slice(0, 10)
 
+  // One generation pass per export run — both builders read the same map.
+  const wantAnalyses = request.nextUrl.searchParams.get("analyses") !== "off"
+  const analyses: ReadonlyMap<string, TeamAnalysis> = wantAnalyses
+    ? await generateTeamAnalyses(data.teams)
+    : new Map()
+
   if (format === "xlsx") {
-    const buffer = await buildResultsWorkbook(data)
+    const buffer = await buildResultsWorkbook(data, analyses)
     return new NextResponse(new Uint8Array(buffer), {
       headers: {
         "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
@@ -136,7 +150,7 @@ export async function GET(request: NextRequest) {
     })
   }
 
-  const buffer = await buildResultsPdf(data)
+  const buffer = await buildResultsPdf(data, analyses)
   return new NextResponse(new Uint8Array(buffer), {
     headers: {
       "Content-Type": "application/pdf",

--- a/src/lib/impact-lab/export-analysis.ts
+++ b/src/lib/impact-lab/export-analysis.ts
@@ -1,0 +1,132 @@
+/**
+ * Impact Lab results export — per-team project analyses.
+ *
+ * The archived record needs a substantive written account of every project,
+ * and the judges did not leave one: written notes exist for ten of the
+ * twenty-seven submissions, from one judge, averaging a few words. This module
+ * fills that gap the only honest way available — by writing an analysis FROM
+ * THE TEAM'S OWN SUBMISSION, generated at export time, and labelling it as
+ * exactly that everywhere it appears.
+ *
+ * Hard lines, mirrored in the system prompt and in the renderers:
+ *
+ * 1. Never invent judge commentary; never attribute generated words to a
+ *    named judge. The analyses carry `ANALYSIS_PROVENANCE` wherever printed.
+ * 2. Ground every sentence in what the team wrote. If the submission does not
+ *    say something, the analysis does not say it either.
+ * 3. Fail soft. A team whose analysis cannot be generated simply has no
+ *    analysis section — never a placeholder or an error string in a document
+ *    that leaves the building.
+ *
+ * Same model and error discipline as `judging/assist` (the in-event reading
+ * aid), which set the pattern for pointing a model at submission text.
+ */
+
+import { z } from "zod"
+import { generateObject } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import type { ExportTeam } from "./export-data"
+
+const MODEL = "claude-sonnet-5"
+
+/** How many teams are analysed concurrently. Kind to rate limits, still fast. */
+const CONCURRENCY = 4
+
+/** Section heading the renderers print above an analysis. */
+export const ANALYSIS_LABEL = "Project analysis"
+
+/**
+ * The provenance line that MUST accompany every rendered analysis. A reader
+ * should never have to guess whether these words came from a judge — they
+ * did not, and the label says so before the reader can wonder.
+ */
+export const ANALYSIS_PROVENANCE =
+  "Written after the event from the team's own submission. Not judge commentary."
+
+const analysisSchema = z.object({
+  whatTheyBuilt: z
+    .string()
+    .describe(
+      "Two to three sentences: what the team built and the problem it addresses, drawn strictly from the submission."
+    ),
+  whoItServes: z
+    .string()
+    .describe(
+      "One to two sentences: who the project serves, as the team described them. If the submission never names a beneficiary, say so plainly."
+    ),
+  workingVsMocked: z
+    .string()
+    .describe(
+      "Two to three sentences: what was working versus mocked or stubbed, per the team's own account. If the submission does not draw the line, say that it does not."
+    ),
+  claudeUse: z
+    .string()
+    .describe(
+      "One to three sentences: how the team used Claude in the build, per their own account."
+    ),
+})
+
+export type TeamAnalysis = z.infer<typeof analysisSchema>
+
+const SYSTEM = `You are writing the project profile for the permanent archived record of a hackathon. Your only source is the team's own written submission, quoted to you in full.
+
+Rules, all of them hard:
+- Ground every sentence in what the team actually wrote. If the submission does not say something, do not infer it, estimate it, or fill the gap — say plainly that the submission does not say.
+- Describe; never evaluate. No verdicts, no scores, no "impressive", "strong", "promising", "unfortunately", or any other judgement of quality. The judges judged; you record.
+- Never speak as, for, or about the judges.
+- Plain English, specific and concrete. No marketing language, no filler.
+- Write in the third person, past tense where natural ("the team built…").`
+
+/**
+ * Generate an analysis for every team that has a submission.
+ *
+ * Returns a map keyed by teamId — the single-run cache: each team is analysed
+ * exactly once per export, and both artefact builders read from the same map.
+ * Teams whose generation fails are simply absent from the map (fail-soft rule
+ * above); the error is logged so a wholly failed run is visible in server
+ * logs, but the export itself never breaks on this.
+ */
+export async function generateTeamAnalyses(
+  teams: readonly ExportTeam[]
+): Promise<ReadonlyMap<string, TeamAnalysis>> {
+  const anthropic = createAnthropic()
+  const withSubmission = teams.filter((t) => t.submission !== null)
+  const analyses = new Map<string, TeamAnalysis>()
+
+  const queue = [...withSubmission]
+  const worker = async (): Promise<void> => {
+    for (let team = queue.shift(); team; team = queue.shift()) {
+      const s = team.submission
+      if (!s) continue
+      const prompt = `The team's submission, in full:
+
+Project: ${s.projectName}
+Track: ${team.track}
+One-line pitch: ${s.pitch}
+Problem tackled: ${s.problemTackled}
+What it does: ${s.description}
+What works vs what is mocked: ${s.worksVsMocked}
+How they used Claude: ${s.claudeUsage}`
+
+      try {
+        const { object } = await generateObject({
+          model: anthropic(MODEL),
+          schema: analysisSchema,
+          system: SYSTEM,
+          prompt,
+          maxOutputTokens: 1_500,
+        })
+        analyses.set(team.teamId, object)
+      } catch (error) {
+        // Fail-soft: this team's analysis section is simply absent. The
+        // export must never carry a placeholder out of the building.
+        console.error(`[results/export] analysis failed for ${team.teamId}`, error)
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, withSubmission.length) }, worker)
+  )
+  return analyses
+}

--- a/src/lib/impact-lab/export-data.ts
+++ b/src/lib/impact-lab/export-data.ts
@@ -32,6 +32,11 @@ import type { RankedTeam, ResultsSnapshot } from "./results"
 export const EVENT_TITLE = "Impact Lab: AI Mashinani"
 export const EVENT_DATES = "25–26 July 2026"
 export const EVENT_HOST = "Claude Community Kenya"
+export const EVENT_LOCATION = "Nairobi, Kenya"
+/** An overnight hackathon: the judging window is part of the record. */
+export const EVENT_FORMAT_NOTE =
+  "An overnight build: teams formed in the evening, built through the night, " +
+  "and judging ran from the small hours into the morning."
 
 // ─── Source rows (what the loader hands in) ──────────────────────────────────
 
@@ -124,6 +129,10 @@ export interface ExportTeam {
   judgeScores: ExportJudgeScore[]
   /** Mean of judges' weighted totals /100. Null when never scored. */
   average: number | null
+  /** Lowest judge's weighted total /100. Null when never scored. */
+  scoreLow: number | null
+  /** Highest judge's weighted total /100. Null when never scored. */
+  scoreHigh: number | null
   judgeCount: number
   /** Per-criterion mean of the raw 1–5 scores. Empty when never scored. */
   criterionAverages: Record<string, number>
@@ -157,6 +166,39 @@ export interface ExportTrackWinner {
   basis: "announced" | "score"
 }
 
+/** One judge's footprint across the night — coverage, not judgement. */
+export interface ExportJudgeSummary {
+  judgeName: string
+  judgeEmail: string
+  /** Total scorecards this judge recorded. */
+  sheets: number
+  liveSheets: number
+  writeupSheets: number
+  /** Scorecards on which this judge left a written note. */
+  feedbackCount: number
+  /** Mean of this judge's weighted totals /100 — how they used the scale. */
+  meanWeightedTotal: number
+}
+
+/** One track's shape: participation, outcome, and who led it. */
+export interface ExportTrackSummary {
+  track: string
+  teamsFormed: number
+  teamsSubmitted: number
+  teamsScored: number
+  /** Mean of scored teams' averages /100. Null when nothing was scored. */
+  meanAverage: number | null
+  winnerTeamName: string | null
+  winnerProjectName: string | null
+  winnerBasis: "announced" | "score" | null
+}
+
+/** How many scored teams were seen by exactly `judgeCount` judges. */
+export interface ExportCoverageBucket {
+  judgeCount: number
+  teams: number
+}
+
 export interface ExportSummary {
   participantsRegistered: number
   participantsCheckedIn: number
@@ -184,6 +226,12 @@ export interface ResultsExport {
   teams: ExportTeam[]
   /** Cohort participants who ended up on no frozen team. */
   unassignedParticipants: ExportMember[]
+  /** One row per judge, ordered by sheet count descending then name. */
+  judgeSummaries: ExportJudgeSummary[]
+  /** One row per track, ordered by track name. */
+  trackSummaries: ExportTrackSummary[]
+  /** Coverage distribution over scored teams, ordered by judge count. */
+  coverage: ExportCoverageBucket[]
   summary: ExportSummary
 }
 
@@ -351,6 +399,14 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
         : null,
       judgeScores,
       average: standing?.average ?? null,
+      // Range across judges — presentation of totals `weightedTotal` already
+      // produced, not new score arithmetic.
+      scoreLow: judgeScores.length
+        ? Math.min(...judgeScores.map((s) => s.weightedTotal))
+        : null,
+      scoreHigh: judgeScores.length
+        ? Math.max(...judgeScores.map((s) => s.weightedTotal))
+        : null,
       judgeCount: standing?.judgeCount ?? 0,
       criterionAverages: standing?.criterionAverages ?? {},
       finalRank: snapshotRow?.rank ?? null,
@@ -375,6 +431,69 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
     .map((p) => toMember(p, null))
     .sort((a, b) => a.fullName.localeCompare(b.fullName))
 
+  // ── Judge summaries: each judge's footprint across the night ─────────────
+  const byJudge = new Map<string, SourceScore[]>()
+  for (const score of source.scores) {
+    const list = byJudge.get(score.judgeEmail)
+    if (list) list.push(score)
+    else byJudge.set(score.judgeEmail, [score])
+  }
+  const judgeSummaries: ExportJudgeSummary[] = [...byJudge.values()]
+    .map((sheets) => {
+      const totals = sheets.map((s) => weightedTotal(s.sheet))
+      return {
+        judgeName: sheets[0].judgeName,
+        judgeEmail: sheets[0].judgeEmail,
+        sheets: sheets.length,
+        liveSheets: sheets.filter((s) => !s.writeupOnly).length,
+        writeupSheets: sheets.filter((s) => s.writeupOnly).length,
+        feedbackCount: sheets.filter((s) => s.feedback?.trim()).length,
+        meanWeightedTotal: totals.length
+          ? Math.round((totals.reduce((a, b) => a + b, 0) / totals.length) * 10) / 10
+          : 0,
+      }
+    })
+    .sort((a, b) => b.sheets - a.sheets || a.judgeName.localeCompare(b.judgeName))
+
+  // ── Track summaries: participation and outcome per track ─────────────────
+  const winnerByTrack = new Map(exportTrackWinners.map((w) => [w.track, w]))
+  const byTrack = new Map<string, ExportTeam[]>()
+  for (const team of teams) {
+    const list = byTrack.get(team.track)
+    if (list) list.push(team)
+    else byTrack.set(team.track, [team])
+  }
+  const trackSummaries: ExportTrackSummary[] = [...byTrack.entries()]
+    .map(([track, trackTeams]) => {
+      const scored = trackTeams.filter((t) => t.average !== null)
+      const winner = winnerByTrack.get(track)
+      return {
+        track,
+        teamsFormed: trackTeams.length,
+        teamsSubmitted: trackTeams.filter((t) => t.submission !== null).length,
+        teamsScored: scored.length,
+        meanAverage: scored.length
+          ? Math.round(
+              (scored.reduce((sum, t) => sum + (t.average ?? 0), 0) / scored.length) * 10
+            ) / 10
+          : null,
+        winnerTeamName: winner?.teamName ?? null,
+        winnerProjectName: winner?.projectName ?? null,
+        winnerBasis: winner?.basis ?? null,
+      }
+    })
+    .sort((a, b) => a.track.localeCompare(b.track))
+
+  // ── Coverage: how many judges actually reached each scored team ──────────
+  const coverageCounts = new Map<number, number>()
+  for (const team of teams) {
+    if (team.judgeCount === 0) continue
+    coverageCounts.set(team.judgeCount, (coverageCounts.get(team.judgeCount) ?? 0) + 1)
+  }
+  const coverage: ExportCoverageBucket[] = [...coverageCounts.entries()]
+    .map(([judgeCount, count]) => ({ judgeCount, teams: count }))
+    .sort((a, b) => a.judgeCount - b.judgeCount)
+
   const scoredTeams = teams.filter((t) => t.average !== null)
   const meanTeamAverage = scoredTeams.length
     ? Math.round(
@@ -391,6 +510,9 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
     trackWinners: exportTrackWinners,
     teams,
     unassignedParticipants,
+    judgeSummaries,
+    trackSummaries,
+    coverage,
     summary: {
       participantsRegistered: source.participants.length,
       participantsCheckedIn: source.participants.filter((p) => p.checkedIn).length,

--- a/src/lib/impact-lab/export-excel.ts
+++ b/src/lib/impact-lab/export-excel.ts
@@ -1,8 +1,9 @@
 /**
  * Impact Lab results export — the Excel workbook.
  *
- * Renders a `ResultsExport` (see ./export-data) into five sheets: Results,
- * Submissions, Judging detail, Participants, Summary. Server-only (exceljs).
+ * Renders a `ResultsExport` (see ./export-data) into up to eight sheets:
+ * Results, Submissions, Judging detail, Judges, Tracks, Project analyses
+ * (when generated), Participants, Summary. Server-only (exceljs).
  *
  * Craft rules applied throughout: frozen header rows, autofilter on the wide
  * sheets, wrapped prose with estimated row heights so text is readable
@@ -12,14 +13,16 @@
  */
 
 import ExcelJS from "exceljs"
-import { JUDGING_CRITERIA } from "./judging"
+import { JUDGING_CRITERIA, SCORE_LABELS } from "./judging"
 import {
   EVENT_DATES,
   EVENT_HOST,
+  EVENT_LOCATION,
   EVENT_TITLE,
   type ExportTeam,
   type ResultsExport,
 } from "./export-data"
+import { ANALYSIS_PROVENANCE, type TeamAnalysis } from "./export-analysis"
 
 // ─── Palette (print-safe echoes of the Terminal Noir tokens) ─────────────────
 
@@ -31,6 +34,56 @@ const AMBER_TEXT = "FF8A5B00" // basis notes
 const DIM_TEXT = "FF666666"
 
 const SCORE_FMT = "0.0"
+const CLAY = "FFD97757" // Anthropic terracotta — the single data-bar hue
+
+/**
+ * exceljs's `DataBarRuleType` omits `color` from its typings, but the writer
+ * serialises it (see lib/.../cf/databar-xform.js). This extension keeps the
+ * branded bars type-safe without `any`.
+ */
+interface BrandedDataBarRule extends ExcelJS.DataBarRuleType {
+  color?: Partial<ExcelJS.Color>
+}
+
+/** "A"-style column letter for a 1-based column number. */
+function columnLetter(column: number): string {
+  let letter = ""
+  for (let n = column; n > 0; n = Math.floor((n - 1) / 26)) {
+    letter = String.fromCharCode(65 + ((n - 1) % 26)) + letter
+  }
+  return letter
+}
+
+/**
+ * In-cell data bars on a numeric column — the honest kind: anchored 0→max so
+ * bar length is proportional to the value, never rescaled to the visible
+ * range (Excel's default min–max anchoring exaggerates small differences).
+ */
+function addDataBars(
+  sheet: ExcelJS.Worksheet,
+  column: number,
+  rowCount: number,
+  max: number
+): void {
+  if (rowCount === 0) return
+  const letter = columnLetter(column)
+  const rule: BrandedDataBarRule = {
+    type: "dataBar",
+    priority: 1,
+    gradient: false,
+    showValue: true,
+    border: false,
+    cfvo: [
+      { type: "num", value: 0 },
+      { type: "num", value: max },
+    ],
+    color: { argb: CLAY },
+  }
+  sheet.addConditionalFormatting({
+    ref: `${letter}2:${letter}${rowCount + 1}`,
+    rules: [rule],
+  })
+}
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
 
@@ -123,7 +176,10 @@ function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
     { header: "Track", key: "track", width: 22 },
     { header: "Project", key: "project", width: 26 },
     { header: "Score rank", key: "scoreRank", width: 11, numFmt: "0" },
-    { header: "Weighted average (/100)", key: "average", width: 14, numFmt: SCORE_FMT },
+    { header: "Weighted average (/100)", key: "average", width: 16, numFmt: SCORE_FMT },
+    { header: "Judge low (/100)", key: "scoreLow", width: 11, numFmt: SCORE_FMT },
+    { header: "Judge high (/100)", key: "scoreHigh", width: 11, numFmt: SCORE_FMT },
+    { header: "Judge spread", key: "spread", width: 11, numFmt: SCORE_FMT },
     { header: "Judges", key: "judges", width: 8, numFmt: "0" },
     ...JUDGING_CRITERIA.map((c) => ({
       header: `${c.label} (avg /5)`,
@@ -155,6 +211,12 @@ function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
       project: team.submission?.projectName ?? "—",
       scoreRank: team.scoreRank ?? "—",
       average: team.average ?? "—",
+      scoreLow: team.scoreLow ?? "—",
+      scoreHigh: team.scoreHigh ?? "—",
+      spread:
+        team.scoreLow !== null && team.scoreHigh !== null && team.judgeCount > 1
+          ? Math.round((team.scoreHigh - team.scoreLow) * 10) / 10
+          : "—",
       judges: team.judgeCount,
       ...Object.fromEntries(
         JUDGING_CRITERIA.map((c) => [`avg_${c.key}`, team.criterionAverages[c.key] ?? "—"])
@@ -174,6 +236,10 @@ function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
       row.getCell("note").font = { size: 9, color: { argb: AMBER_TEXT } }
     }
   }
+
+  // Honest in-cell bars: 0→100 anchoring, on the average column.
+  const averageColumn = columns.findIndex((c) => c.key === "average") + 1
+  addDataBars(sheet, averageColumn, data.teams.length, 100)
 }
 
 function addSubmissionsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
@@ -273,6 +339,113 @@ function addJudgingSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
   }
 }
 
+/** One row per judge: coverage and how they used the scale. */
+function addJudgesSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+  const columns: ColumnSpec[] = [
+    { header: "Judge", key: "judge", width: 22 },
+    { header: "Judge email", key: "email", width: 28 },
+    { header: "Scorecards", key: "sheets", width: 11, numFmt: "0" },
+    { header: "Live demos", key: "live", width: 11, numFmt: "0" },
+    { header: "From writeups", key: "writeup", width: 12, numFmt: "0" },
+    { header: "Written notes left", key: "notes", width: 14, numFmt: "0" },
+    { header: "Mean weighted total (/100)", key: "mean", width: 16, numFmt: SCORE_FMT },
+  ]
+  const sheet = addSheet(workbook, "Judges", columns)
+  for (const judge of data.judgeSummaries) {
+    sheet.addRow({
+      judge: judge.judgeName,
+      email: judge.judgeEmail,
+      sheets: judge.sheets,
+      live: judge.liveSheets,
+      writeup: judge.writeupSheets,
+      notes: judge.feedbackCount,
+      mean: judge.meanWeightedTotal,
+    })
+  }
+  addDataBars(sheet, columns.findIndex((c) => c.key === "mean") + 1, data.judgeSummaries.length, 100)
+  const note = sheet.addRow({})
+  note.getCell("judge").value =
+    "Judges saw different, overlapping sets of teams; mean totals show how each judge used the scale, not a ranking of judges."
+  note.getCell("judge").font = { size: 9, italic: true, color: { argb: DIM_TEXT } }
+}
+
+/** One row per track: participation, outcome, winner with its basis. */
+function addTracksSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+  const columns: ColumnSpec[] = [
+    { header: "Track", key: "track", width: 26 },
+    { header: "Teams formed", key: "formed", width: 12, numFmt: "0" },
+    { header: "Teams submitted", key: "submitted", width: 13, numFmt: "0" },
+    { header: "Teams scored", key: "scored", width: 12, numFmt: "0" },
+    { header: "Mean average (/100)", key: "mean", width: 16, numFmt: SCORE_FMT },
+    { header: "Track winner (project)", key: "winnerProject", width: 24 },
+    { header: "Track winner (team)", key: "winnerTeam", width: 28 },
+    { header: "Winner basis", key: "basis", width: 22 },
+  ]
+  const sheet = addSheet(workbook, "Tracks", columns)
+  for (const track of data.trackSummaries) {
+    sheet.addRow({
+      track: track.track,
+      formed: track.teamsFormed,
+      submitted: track.teamsSubmitted,
+      scored: track.teamsScored,
+      mean: track.meanAverage ?? "—",
+      winnerProject: track.winnerProjectName ?? "—",
+      winnerTeam: track.winnerTeamName ?? "—",
+      basis:
+        track.winnerBasis === "announced"
+          ? "Announced by judging panel"
+          : track.winnerBasis === "score"
+            ? "Top of track by score"
+            : "—",
+    })
+  }
+  addDataBars(sheet, columns.findIndex((c) => c.key === "mean") + 1, data.trackSummaries.length, 100)
+}
+
+/**
+ * The generated project analyses, one row per analysed team, each row
+ * carrying its provenance so the sheet stays honest even copied out alone.
+ */
+function addAnalysesSheet(
+  workbook: ExcelJS.Workbook,
+  data: ResultsExport,
+  analyses: ReadonlyMap<string, TeamAnalysis>
+): void {
+  if (analyses.size === 0) return
+  const columns: ColumnSpec[] = [
+    { header: "Final placing", key: "finalRank", width: 12, numFmt: "0" },
+    { header: "Team", key: "team", width: 26 },
+    { header: "Project", key: "project", width: 24 },
+    { header: "What they built", key: "built", width: 52, wrap: true },
+    { header: "Who it serves", key: "serves", width: 44, wrap: true },
+    { header: "Working vs mocked", key: "working", width: 52, wrap: true },
+    { header: "How Claude was used", key: "claude", width: 48, wrap: true },
+    { header: "Provenance", key: "provenance", width: 40, wrap: true },
+  ]
+  const sheet = addSheet(workbook, "Project analyses", columns, { autoFilter: true })
+  for (const team of data.teams) {
+    const analysis = analyses.get(team.teamId)
+    if (!analysis || !team.submission) continue
+    const row = sheet.addRow({
+      finalRank: team.finalRank ?? "—",
+      team: team.teamName,
+      project: team.submission.projectName,
+      built: analysis.whatTheyBuilt,
+      serves: analysis.whoItServes,
+      working: analysis.workingVsMocked,
+      claude: analysis.claudeUse,
+      provenance: ANALYSIS_PROVENANCE,
+    })
+    row.height = estimateRowHeight([
+      { text: analysis.whatTheyBuilt, width: 52 },
+      { text: analysis.whoItServes, width: 44 },
+      { text: analysis.workingVsMocked, width: 52 },
+      { text: analysis.claudeUse, width: 48 },
+    ])
+    row.getCell("provenance").font = { size: 9, italic: true, color: { argb: DIM_TEXT } }
+  }
+}
+
 function addParticipantsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
   const columns: ColumnSpec[] = [
     { header: "Name", key: "name", width: 26 },
@@ -355,6 +528,7 @@ function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
   fact("Event", EVENT_TITLE)
   fact("Hosted by", EVENT_HOST)
   fact("Dates", EVENT_DATES)
+  fact("Location", EVENT_LOCATION)
   fact("Cohort", data.cohort)
   fact("Generated", data.generatedAt.toISOString())
   fact(
@@ -393,6 +567,42 @@ function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
   }
   gap()
 
+  section("Scoring criteria and weights")
+  for (const criterion of JUDGING_CRITERIA) {
+    fact(`${criterion.label} — ${criterion.weight} pts`, criterion.guidance, true)
+  }
+  fact(
+    "Scale",
+    Object.entries(SCORE_LABELS)
+      .map(([n, label]) => `${n} = ${label}`)
+      .join(" · ") +
+      ". A criterion contributes (score - 1) / 4 of its weight; a team's number is the mean of " +
+      "its judges' weighted totals.",
+    true
+  )
+  gap()
+
+  section("Provenance")
+  const judgesWithNotes = data.judgeSummaries.filter((j) => j.feedbackCount > 0)
+  const notesTotal = judgesWithNotes.reduce((sum, j) => sum + j.feedbackCount, 0)
+  fact(
+    "Judge notes",
+    judgesWithNotes.length === 0
+      ? "No judge left written notes during scoring."
+      : `Written notes were left by ${judgesWithNotes.length === 1 ? `one judge (${judgesWithNotes[0].judgeName})` : `${judgesWithNotes.length} judges`} ` +
+          `on ${notesTotal} scorecard${notesTotal === 1 ? "" : "s"}. They appear verbatim in “Judging detail”; ` +
+          "no judge's words have been extended or invented anywhere in this workbook.",
+    true
+  )
+  fact("Project analyses", `The “Project analyses” sheet is generated: ${ANALYSIS_PROVENANCE}`, true)
+  fact(
+    "Contact details",
+    "This workbook carries participant emails and is the organisers' operational record — " +
+      "treat it accordingly. The PDF built for sharing omits all contact details.",
+    true
+  )
+  gap()
+
   section("How to read this workbook")
   fact(
     "Final placing vs score rank",
@@ -413,8 +623,16 @@ function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
 
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
-/** Build the five-sheet workbook and return it as a Node buffer to stream. */
-export async function buildResultsWorkbook(data: ResultsExport): Promise<Buffer> {
+/**
+ * Build the workbook — Results, Submissions, Judging detail, Judges, Tracks,
+ * Project analyses (when generated), Participants, Summary — and return it as
+ * a Node buffer to stream. A missing analyses map simply omits that sheet
+ * (the fail-soft rule from export-analysis).
+ */
+export async function buildResultsWorkbook(
+  data: ResultsExport,
+  analyses: ReadonlyMap<string, TeamAnalysis> = new Map()
+): Promise<Buffer> {
   const workbook = new ExcelJS.Workbook()
   workbook.creator = EVENT_HOST
   workbook.created = data.generatedAt
@@ -422,6 +640,9 @@ export async function buildResultsWorkbook(data: ResultsExport): Promise<Buffer>
   addResultsSheet(workbook, data)
   addSubmissionsSheet(workbook, data)
   addJudgingSheet(workbook, data)
+  addJudgesSheet(workbook, data)
+  addTracksSheet(workbook, data)
+  addAnalysesSheet(workbook, data, analyses)
   addParticipantsSheet(workbook, data)
   addSummarySheet(workbook, data)
 

--- a/src/lib/impact-lab/export-pdf-charts.ts
+++ b/src/lib/impact-lab/export-pdf-charts.ts
@@ -1,0 +1,310 @@
+/**
+ * Impact Lab results export — vector chart primitives for the PDF.
+ *
+ * Pure pdfkit drawing: every function paints at a given (x, y, width) and
+ * returns the height it consumed, so the document flow in `export-pdf` stays
+ * in charge of pagination. No chart here manages its own page breaks.
+ *
+ * Honesty rules these primitives enforce by construction:
+ * - Every scale starts at zero. There is no way to pass a truncated axis.
+ * - Magnitude is always one hue (CLAY); identity is carried by labels and
+ *   position, never by colour alone — the charts survive greyscale printing.
+ * - Grid and axes are solid hairlines, one shade off the paper; the data is
+ *   the darkest thing in the plot.
+ */
+
+import {
+  CLAY,
+  DIM,
+  FAINT,
+  INK,
+  RULE,
+  SANS,
+  SANS_BOLD,
+  TRACK,
+} from "./export-theme"
+
+type Doc = PDFKit.PDFDocument
+
+const AXIS_FONT = 6.5
+const LABEL_FONT = 7.5
+
+// ─── Stat tiles ──────────────────────────────────────────────────────────────
+
+export interface StatTile {
+  value: string
+  label: string
+  /** Optional second line under the label, fainter. */
+  sublabel?: string
+}
+
+/**
+ * A row-wrapped grid of stat tiles — the "event in numbers" hero. Sans-serif
+ * figures (a display face on a number reads as decoration), small-caps labels.
+ */
+export function drawStatTiles(
+  doc: Doc,
+  x: number,
+  y: number,
+  width: number,
+  tiles: StatTile[],
+  columns = 3
+): number {
+  const cellWidth = width / columns
+  const rowHeight = 58
+  tiles.forEach((tile, i) => {
+    const cx = x + (i % columns) * cellWidth
+    const cy = y + Math.floor(i / columns) * rowHeight
+    doc.moveTo(cx, cy + 2).lineTo(cx, cy + rowHeight - 12).lineWidth(1.4).strokeColor(CLAY).stroke()
+    doc.font(SANS_BOLD).fontSize(21).fillColor(INK).text(tile.value, cx + 10, cy, {
+      width: cellWidth - 16,
+      lineBreak: false,
+    })
+    doc
+      .font(SANS)
+      .fontSize(7)
+      .fillColor(DIM)
+      .text(tile.label.toUpperCase(), cx + 10, cy + 26, {
+        width: cellWidth - 16,
+        characterSpacing: 0.8,
+      })
+    if (tile.sublabel) {
+      doc.font(SANS).fontSize(6.5).fillColor(FAINT).text(tile.sublabel, cx + 10, cy + 36, {
+        width: cellWidth - 16,
+      })
+    }
+  })
+  return Math.ceil(tiles.length / columns) * rowHeight
+}
+
+// ─── Histogram ───────────────────────────────────────────────────────────────
+
+export interface HistogramBin {
+  label: string
+  count: number
+}
+
+/**
+ * Vertical histogram, zero-anchored, hairline grid, count above each non-empty
+ * bar. Direct labels are the only value access in print, so they stay on.
+ */
+export function drawHistogram(
+  doc: Doc,
+  x: number,
+  y: number,
+  width: number,
+  plotHeight: number,
+  bins: HistogramBin[],
+  options: { yLabel?: string } = {}
+): number {
+  const axisBand = 16
+  const topPad = 12
+  const maxCount = Math.max(1, ...bins.map((b) => b.count))
+  const gap = 3
+  const barWidth = (width - gap * (bins.length - 1)) / bins.length
+  const baseline = y + topPad + plotHeight
+
+  // Grid: solid hairlines at nice integer steps, labels in the left gutter.
+  const step = maxCount <= 5 ? 1 : Math.ceil(maxCount / 4)
+  for (let v = step; v <= maxCount; v += step) {
+    const gy = baseline - (v / maxCount) * plotHeight
+    doc.moveTo(x, gy).lineTo(x + width, gy).lineWidth(0.4).strokeColor(RULE).stroke()
+    doc
+      .font(SANS)
+      .fontSize(AXIS_FONT)
+      .fillColor(FAINT)
+      .text(String(v), x - 14, gy - 2.5, { width: 11, align: "right", lineBreak: false })
+  }
+
+  bins.forEach((bin, i) => {
+    const bx = x + i * (barWidth + gap)
+    const h = (bin.count / maxCount) * plotHeight
+    if (bin.count > 0) {
+      // 1.5pt rounded data-end on a baseline-anchored bar.
+      doc.roundedRect(bx, baseline - h, barWidth, h, Math.min(1.5, h / 2)).fillColor(CLAY).fill()
+      doc
+        .font(SANS_BOLD)
+        .fontSize(AXIS_FONT)
+        .fillColor(DIM)
+        .text(String(bin.count), bx, baseline - h - 9, {
+          width: barWidth,
+          align: "center",
+          lineBreak: false,
+        })
+    }
+    doc
+      .font(SANS)
+      .fontSize(AXIS_FONT)
+      .fillColor(FAINT)
+      .text(bin.label, bx - gap / 2, baseline + 4, {
+        width: barWidth + gap,
+        align: "center",
+        lineBreak: false,
+      })
+  })
+
+  // Baseline axis — the zero line, slightly stronger than the grid.
+  doc.moveTo(x, baseline).lineTo(x + width, baseline).lineWidth(0.8).strokeColor(DIM).stroke()
+
+  if (options.yLabel) {
+    doc
+      .font(SANS)
+      .fontSize(AXIS_FONT)
+      .fillColor(FAINT)
+      .text(options.yLabel, x, y, { width, lineBreak: false })
+  }
+  return topPad + plotHeight + axisBand
+}
+
+// ─── Horizontal bars ─────────────────────────────────────────────────────────
+
+export interface HBarRow {
+  label: string
+  /** Fainter line under the label — e.g. "9 teams · 7 submitted". */
+  sublabel?: string
+  value: number
+  /** Printed at the bar end — e.g. "62.4". */
+  valueLabel: string
+}
+
+/**
+ * Labelled horizontal bars on a shared zero-anchored scale with a full-length
+ * track behind each bar, so "how far along the scale" is visible per row.
+ */
+export function drawHBars(
+  doc: Doc,
+  x: number,
+  y: number,
+  width: number,
+  rows: HBarRow[],
+  options: { max: number; labelWidth?: number; rowHeight?: number; scaleNote?: string }
+): number {
+  const labelWidth = options.labelWidth ?? 118
+  const rowHeight = options.rowHeight ?? (rows.some((r) => r.sublabel) ? 26 : 18)
+  const valueGutter = 30
+  const barArea = width - labelWidth - valueGutter
+  const barHeight = 7
+
+  rows.forEach((row, i) => {
+    const ry = y + i * rowHeight
+    const barY = ry + (rowHeight - barHeight) / 2 - (row.sublabel ? 4 : 0)
+    doc
+      .font(SANS)
+      .fontSize(LABEL_FONT)
+      .fillColor(INK)
+      .text(row.label, x, barY - 0.5, { width: labelWidth - 8, lineBreak: false, ellipsis: true })
+    if (row.sublabel) {
+      doc
+        .font(SANS)
+        .fontSize(6.5)
+        .fillColor(FAINT)
+        .text(row.sublabel, x, barY + 8.5, { width: labelWidth - 8, lineBreak: false })
+    }
+    // Track = the full scale; bar = the value. Both start at zero.
+    doc.roundedRect(x + labelWidth, barY, barArea, barHeight, 1.5).fillColor(TRACK).fill()
+    const w = Math.max(0, Math.min(1, row.value / options.max)) * barArea
+    if (w > 0) {
+      doc.roundedRect(x + labelWidth, barY, w, barHeight, Math.min(1.5, w / 2)).fillColor(CLAY).fill()
+    }
+    doc
+      .font(SANS_BOLD)
+      .fontSize(LABEL_FONT)
+      .fillColor(DIM)
+      .text(row.valueLabel, x + labelWidth + barArea + 4, barY - 0.5, {
+        width: valueGutter - 4,
+        lineBreak: false,
+      })
+  })
+
+  let used = rows.length * rowHeight
+  if (options.scaleNote) {
+    doc
+      .font(SANS)
+      .fontSize(AXIS_FONT)
+      .fillColor(FAINT)
+      .text(options.scaleNote, x + labelWidth, y + used + 1, {
+        width: barArea + valueGutter,
+        lineBreak: false,
+      })
+    used += 10
+  }
+  return used
+}
+
+// ─── Dot strips (ranges on a fixed scale) ────────────────────────────────────
+
+export interface DotRow {
+  label: string
+  sublabel?: string
+  /** Individual values plotted as dots — e.g. each judge's total. */
+  dots: number[]
+}
+
+/**
+ * Rows of dots on a shared 0→max scale, with a band spanning each row's
+ * low–high range. This is how the spread between judges is shown without
+ * implying an ordering: position carries the value, the label the identity.
+ */
+export function drawDotRows(
+  doc: Doc,
+  x: number,
+  y: number,
+  width: number,
+  rows: DotRow[],
+  options: { max: number; labelWidth?: number; rowHeight?: number }
+): number {
+  const labelWidth = options.labelWidth ?? 118
+  const rowHeight = options.rowHeight ?? 24
+  const scaleWidth = width - labelWidth
+  const scaleX = x + labelWidth
+  const at = (v: number): number => scaleX + (Math.max(0, Math.min(options.max, v)) / options.max) * scaleWidth
+
+  // Shared axis under all rows: ticks at quarters, labelled.
+  const axisY = y + rows.length * rowHeight + 2
+  doc.moveTo(scaleX, axisY).lineTo(scaleX + scaleWidth, axisY).lineWidth(0.6).strokeColor(RULE).stroke()
+  for (let q = 0; q <= 4; q++) {
+    const v = (options.max / 4) * q
+    doc.moveTo(at(v), axisY).lineTo(at(v), axisY + 3).lineWidth(0.6).strokeColor(RULE).stroke()
+    doc
+      .font(SANS)
+      .fontSize(AXIS_FONT)
+      .fillColor(FAINT)
+      .text(String(Math.round(v)), at(v) - 10, axisY + 5, {
+        width: 20,
+        align: "center",
+        lineBreak: false,
+      })
+  }
+
+  rows.forEach((row, i) => {
+    const cy = y + i * rowHeight + rowHeight / 2 - 2
+    doc
+      .font(SANS)
+      .fontSize(LABEL_FONT)
+      .fillColor(INK)
+      .text(row.label, x, cy - 8, { width: labelWidth - 8, lineBreak: false, ellipsis: true })
+    if (row.sublabel) {
+      doc
+        .font(SANS)
+        .fontSize(6.5)
+        .fillColor(FAINT)
+        .text(row.sublabel, x, cy + 1, { width: labelWidth - 8, lineBreak: false })
+    }
+    // Row guide: a hairline the dots sit on.
+    doc.moveTo(scaleX, cy).lineTo(scaleX + scaleWidth, cy).lineWidth(0.4).strokeColor(TRACK).stroke()
+
+    const sorted = [...row.dots].sort((a, b) => a - b)
+    if (sorted.length > 1) {
+      const low = at(sorted[0])
+      const high = at(sorted[sorted.length - 1])
+      doc.roundedRect(low, cy - 2.5, Math.max(high - low, 1), 5, 2.5).fillColor(TRACK).fill()
+    }
+    for (const v of sorted) {
+      // 2px paper ring so overlapping dots stay countable.
+      doc.circle(at(v), cy, 4).fillColor("#ffffff").fill()
+      doc.circle(at(v), cy, 2.8).fillColor(CLAY).fill()
+    }
+  })
+
+  return rows.length * rowHeight + 18
+}

--- a/src/lib/impact-lab/export-pdf.ts
+++ b/src/lib/impact-lab/export-pdf.ts
@@ -1,46 +1,74 @@
 /**
  * Impact Lab results export — the PDF.
  *
- * Renders a `ResultsExport` (see ./export-data) into a print-ready A4
- * document: cover, winners, full ranking, then one section per team with its
- * complete submission and every judge's scores and feedback. Server-only
- * (pdfkit, streamed to a buffer — nothing touches disk).
+ * The artefact that leaves the building: the permanent record of Kenya's
+ * first Claude hackathon, built to be read by Anthropic. A4, print-first,
+ * greyscale-safe. Structure: cover → contents → how this record was produced
+ * → the event in numbers (infographics) → winners → full ranking → one
+ * profile per team → appendix. Server-only (pdfkit, streamed to a buffer —
+ * nothing touches disk).
  *
- * The same two honesty rules as the workbook: announced placings are labelled
- * as the panel's decision (score order is shown separately as what it is),
- * and writeup-scored teams carry that basis wherever their scores appear —
- * as a note on how the score was produced, never a mark against the team.
+ * The honesty rules, enforced in layout as much as in words:
+ *
+ * 1. Announced placings are the panel's decision; score order is shown
+ *    separately as what it is. Every placing names its basis.
+ * 2. Writeup-scored teams carry that basis wherever their scores appear — a
+ *    note on how the score was produced, never a mark against the team.
+ * 3. Judge notes are printed verbatim and attributed; generated project
+ *    analyses are labelled with their provenance every time they appear and
+ *    never sit inside the judging section.
+ * 4. Participant contact details never enter this document — names and roles
+ *    only. The Excel workbook is the organisers' operational record.
  */
 
 import PDFDocument from "pdfkit"
-import { JUDGING_CRITERIA } from "./judging"
+import { JUDGING_CRITERIA, SCORE_LABELS } from "./judging"
 import {
   EVENT_DATES,
+  EVENT_FORMAT_NOTE,
   EVENT_HOST,
+  EVENT_LOCATION,
   EVENT_TITLE,
   type ExportTeam,
   type ResultsExport,
 } from "./export-data"
+import { ANALYSIS_LABEL, ANALYSIS_PROVENANCE, type TeamAnalysis } from "./export-analysis"
+import {
+  drawDotRows,
+  drawHBars,
+  drawHistogram,
+  drawStatTiles,
+  type DotRow,
+  type HBarRow,
+  type HistogramBin,
+} from "./export-pdf-charts"
+import {
+  CALLOUT_BG,
+  CLAY,
+  CLAY_DEEP,
+  DIM,
+  FAINT,
+  INK,
+  MID_GRAY,
+  OLIVE,
+  PAPER,
+  RULE,
+  SANS,
+  SANS_BOLD,
+  SANS_ITALIC,
+  SERIF,
+  SERIF_ITALIC,
+} from "./export-theme"
 
-// ─── Layout constants ────────────────────────────────────────────────────────
+// ─── Geometry ────────────────────────────────────────────────────────────────
 
-const MARGIN = 56 // ~2 cm on A4
+const MARGIN = 56
 const PAGE_WIDTH = 595.28
+const PAGE_HEIGHT = 841.89
 const CONTENT_WIDTH = PAGE_WIDTH - MARGIN * 2
-const FOOTER_Y = 841.89 - 40
-
-const INK = "#1a1a1a"
-const DIM = "#666666"
-const FAINT = "#999999"
-const GREEN = "#007a31"
-const AMBER = "#8a5b00"
-const AMBER_BG = "#fdf3d7"
-const RULE = "#d9d9d9"
-
-const SERIF = "Times-Roman"
-const SANS = "Helvetica"
-const SANS_BOLD = "Helvetica-Bold"
-const SANS_ITALIC = "Helvetica-Oblique"
+const FOOTER_Y = PAGE_HEIGHT - 40
+const CONTENT_BOTTOM = FOOTER_Y - 18
+const HEADER_Y = 26
 
 const WRITEUP_NOTE =
   "Scored from the written submission — no judge reached this table during live demos. " +
@@ -48,248 +76,755 @@ const WRITEUP_NOTE =
 
 type Doc = PDFKit.PDFDocument
 
+// ─── Document state (contents + running headers) ─────────────────────────────
+
+interface TocEntry {
+  title: string
+  /** Printed page number (1-based). */
+  page: number
+  /** 0 = section, 1 = team profile within the profiles section. */
+  level: number
+}
+
+interface RenderState {
+  toc: TocEntry[]
+  /** Page the contents will be written onto, reserved early. */
+  tocPageIndex: number
+}
+
+/** Printed number of the page currently being written. */
+function currentPage(doc: Doc): number {
+  return doc.bufferedPageRange().count
+}
+
+function markSection(doc: Doc, state: RenderState, title: string, level = 0): void {
+  state.toc.push({ title, page: currentPage(doc), level })
+}
+
 // ─── Small helpers ───────────────────────────────────────────────────────────
 
 /** Start a new page when fewer than `needed` points remain above the footer. */
 function ensureSpace(doc: Doc, needed: number): void {
-  if (doc.y + needed > FOOTER_Y - 16) doc.addPage()
+  if (doc.y + needed > CONTENT_BOTTOM) doc.addPage()
 }
 
-function sectionLabel(doc: Doc, text: string): void {
+/** Small-caps kicker in clay — the label above every heading. */
+function kicker(doc: Doc, text: string, color = CLAY_DEEP): void {
   doc
     .font(SANS_BOLD)
     .fontSize(7.5)
-    .fillColor(GREEN)
-    .text(text.toUpperCase(), MARGIN, doc.y, { characterSpacing: 1.2, width: CONTENT_WIDTH })
-  doc.moveDown(0.35)
+    .fillColor(color)
+    .text(text.toUpperCase(), MARGIN, doc.y, { characterSpacing: 1.4, width: CONTENT_WIDTH })
+  doc.moveDown(0.4)
+}
+
+/** A section opener: fresh page, kicker, serif display heading, lede. */
+function sectionOpener(doc: Doc, label: string, heading: string, lede?: string): void {
+  doc.addPage()
+  doc.y = MARGIN + 8
+  kicker(doc, label)
+  doc.font(SERIF).fontSize(24).fillColor(INK).text(heading, { width: CONTENT_WIDTH })
+  if (lede) {
+    doc.moveDown(0.4)
+    doc.font(SANS).fontSize(9.5).fillColor(DIM).text(lede, { width: CONTENT_WIDTH * 0.86, lineGap: 3 })
+  }
+  doc.moveDown(0.7)
+  rule(doc, INK, 1)
+  doc.moveDown(0.9)
+}
+
+function rule(doc: Doc, color = RULE, width = 0.6): void {
+  doc
+    .moveTo(MARGIN, doc.y)
+    .lineTo(MARGIN + CONTENT_WIDTH, doc.y)
+    .lineWidth(width)
+    .strokeColor(color)
+    .stroke()
+  doc.moveDown(0.5)
 }
 
 function paragraph(doc: Doc, label: string, text: string): void {
   const body = text.trim() || "—"
   ensureSpace(
     doc,
-    22 + doc.font(SANS).fontSize(9).heightOfString(body, { width: CONTENT_WIDTH, lineGap: 2 })
+    24 + doc.font(SANS).fontSize(9).heightOfString(body, { width: CONTENT_WIDTH, lineGap: 2.5 })
   )
-  sectionLabel(doc, label)
+  doc
+    .font(SANS_BOLD)
+    .fontSize(7)
+    .fillColor(FAINT)
+    .text(label.toUpperCase(), MARGIN, doc.y, { characterSpacing: 1.1, width: CONTENT_WIDTH })
+  doc.moveDown(0.25)
+  doc.font(SANS).fontSize(9).fillColor(INK).text(body, MARGIN, doc.y, {
+    width: CONTENT_WIDTH,
+    lineGap: 2.5,
+  })
+  doc.moveDown(0.85)
+}
+
+/** A filled callout box. Returns nothing; advances doc.y past the box. */
+function callout(doc: Doc, body: string, options: { fill?: string; ink?: string } = {}): void {
+  const width = CONTENT_WIDTH - 28
+  doc.font(SANS).fontSize(8.5)
+  const h = doc.heightOfString(body, { width, lineGap: 2.5 }) + 18
+  ensureSpace(doc, h + 6)
+  const top = doc.y
+  doc.roundedRect(MARGIN, top, CONTENT_WIDTH, h, 3).fillColor(options.fill ?? CALLOUT_BG).fill()
+  doc.rect(MARGIN, top, 2.5, h).fillColor(CLAY).fill()
   doc
     .font(SANS)
-    .fontSize(9)
-    .fillColor(INK)
-    .text(body, MARGIN, doc.y, { width: CONTENT_WIDTH, lineGap: 2 })
-  doc.moveDown(0.8)
+    .fontSize(8.5)
+    .fillColor(options.ink ?? DIM)
+    .text(body, MARGIN + 14, top + 9, { width, lineGap: 2.5 })
+  doc.x = MARGIN
+  doc.y = top + h + 12
 }
 
-function rule(doc: Doc, color = RULE): void {
-  doc
-    .moveTo(MARGIN, doc.y)
-    .lineTo(MARGIN + CONTENT_WIDTH, doc.y)
-    .lineWidth(0.6)
-    .strokeColor(color)
-    .stroke()
-  doc.moveDown(0.5)
-}
-
-function placingLine(team: ExportTeam): string {
+function placingKicker(team: ExportTeam): string {
   if (team.finalRank !== null) {
     const basis =
       team.finalRankBasis === "announced"
         ? "announced by the judging panel"
         : team.finalRankBasis === "submission"
-          ? "score order, writeup-scored"
+          ? "score order · writeup-scored"
           : "score order"
-    return `Final placing #${team.finalRank} (${basis})`
+    return `Final placing #${team.finalRank} · ${basis}`
   }
-  return team.average !== null ? `Score rank #${team.scoreRank} (unpublished)` : "Not scored"
+  return team.average !== null ? `Score rank #${team.scoreRank} · unpublished` : "Not scored"
 }
+
+const fmt1 = (value: number): string => value.toFixed(1)
 
 // ─── Cover ───────────────────────────────────────────────────────────────────
 
+/**
+ * The cover: warm paper, clay band, serif display title, the event in six
+ * figures, and the provenance line. Longer than 50 lines because a cover is
+ * one composition — splitting it would scatter its geometry.
+ */
 function renderCover(doc: Doc, data: ResultsExport): void {
-  doc.rect(0, 0, PAGE_WIDTH, 6).fillColor(GREEN).fill()
+  doc.rect(0, 0, PAGE_WIDTH, PAGE_HEIGHT).fillColor(PAPER).fill()
+  doc.rect(0, 0, PAGE_WIDTH, 10).fillColor(CLAY).fill()
 
-  doc.y = 170
+  // Wordmark row: host left, cohort right.
   doc
     .font(SANS_BOLD)
-    .fontSize(9)
-    .fillColor(GREEN)
-    .text(EVENT_HOST.toUpperCase(), MARGIN, doc.y, { characterSpacing: 2, width: CONTENT_WIDTH })
-  doc.moveDown(1)
-  doc.font(SERIF).fontSize(34).fillColor(INK).text(EVENT_TITLE, { width: CONTENT_WIDTH })
+    .fontSize(8.5)
+    .fillColor(INK)
+    .text(EVENT_HOST.toUpperCase(), MARGIN, 64, { characterSpacing: 2.2, width: CONTENT_WIDTH })
+  doc
+    .font(SANS)
+    .fontSize(8.5)
+    .fillColor(FAINT)
+    .text(data.cohort, MARGIN, 64, { width: CONTENT_WIDTH, align: "right" })
+
+  doc.y = 168
+  kicker(doc, "Hackathon results — the complete record", CLAY_DEEP)
+  doc.font(SERIF).fontSize(44).fillColor(INK).text("Impact Lab:", MARGIN, doc.y, {
+    width: CONTENT_WIDTH,
+  })
+  doc.font(SERIF).fontSize(44).fillColor(CLAY).text("AI Mashinani", MARGIN, doc.y - 6, {
+    width: CONTENT_WIDTH,
+  })
+  doc.moveDown(0.5)
+  doc
+    .font(SANS)
+    .fontSize(11)
+    .fillColor(DIM)
+    .text(`${EVENT_DATES} · ${EVENT_LOCATION}`, MARGIN, doc.y, { width: CONTENT_WIDTH })
   doc.moveDown(0.3)
   doc
-    .font(SANS)
-    .fontSize(12)
+    .font(SERIF_ITALIC)
+    .fontSize(10.5)
     .fillColor(DIM)
-    .text(`Hackathon results — the complete record · ${EVENT_DATES}`, { width: CONTENT_WIDTH })
+    .text(EVENT_FORMAT_NOTE, MARGIN, doc.y, { width: CONTENT_WIDTH * 0.8, lineGap: 2.5 })
 
-  doc.moveDown(2.5)
-  rule(doc)
+  doc.y += 30
+  rule(doc, INK, 1)
+  doc.y += 12
 
   const s = data.summary
-  const facts: [string, string][] = [
-    ["Builders", String(s.participantsRegistered)],
-    ["Teams formed", String(s.teamsFormed)],
-    ["Projects submitted", String(s.teamsSubmitted)],
-    ["Judges", String(s.judges)],
-    ["Scorecards", String(s.scorecards)],
-    ["Tracks", String(s.tracks)],
-  ]
-  const cellWidth = CONTENT_WIDTH / 3
-  const gridTop = doc.y + 10
-  facts.forEach(([label, value], i) => {
-    const x = MARGIN + (i % 3) * cellWidth
-    const y = gridTop + Math.floor(i / 3) * 56
-    doc.font(SERIF).fontSize(26).fillColor(INK).text(value, x, y, { width: cellWidth - 12 })
+  drawStatTiles(
+    doc,
+    MARGIN,
+    doc.y,
+    CONTENT_WIDTH,
+    [
+      { value: String(s.participantsRegistered), label: "Builders" },
+      { value: String(s.teamsFormed), label: "Teams formed" },
+      { value: String(s.teamsSubmitted), label: "Projects submitted" },
+      { value: String(s.judges), label: "Judges" },
+      { value: String(s.scorecards), label: "Scorecards" },
+      { value: String(s.tracks), label: "Tracks" },
+    ],
+    3
+  )
+  doc.y += 2 * 58 + 12
+  rule(doc, INK, 1)
+
+  // Champion line — the one result worth putting on the front.
+  const champion = data.announced.find((w) => w.rank === 1)
+  if (champion) {
+    doc.y += 14
+    kicker(doc, "Champion, as announced", CLAY_DEEP)
+    doc
+      .font(SERIF)
+      .fontSize(17)
+      .fillColor(INK)
+      .text(`${champion.projectName} — ${champion.teamName}`, MARGIN, doc.y, {
+        width: CONTENT_WIDTH,
+      })
+  }
+
+  // Writing inside the bottom margin would auto-add a page (the pdfkit
+  // gotcha renderFurniture also dodges) — lift the margin for the footer.
+  doc.page.margins.bottom = 0
+  doc
+    .font(SANS)
+    .fontSize(7.5)
+    .fillColor(FAINT)
+    .text(
+      `Generated ${data.generatedAt.toISOString().slice(0, 10)}` +
+        (data.published && data.publishedAt
+          ? ` · Results published ${data.publishedAt.slice(0, 10)}`
+          : " · Results not yet published") +
+        ` · Hosted by ${EVENT_HOST}`,
+      MARGIN,
+      FOOTER_Y - 14,
+      { width: CONTENT_WIDTH, lineBreak: false }
+    )
+  doc.page.margins.bottom = 60
+}
+
+// ─── Contents (reserved page, filled after rendering) ────────────────────────
+
+function reserveContentsPage(doc: Doc, state: RenderState): void {
+  doc.addPage()
+  state.tocPageIndex = doc.bufferedPageRange().count - 1
+}
+
+/**
+ * Fill the reserved contents page. Two columns when the team list is long —
+ * every profile is listed because "find one team fast" is the reader's most
+ * likely task. Longer than 50 lines: one composition, one place.
+ */
+function renderContents(doc: Doc, state: RenderState): void {
+  doc.switchToPage(state.tocPageIndex)
+  doc.y = MARGIN + 8
+  kicker(doc, "Contents")
+  doc.font(SERIF).fontSize(24).fillColor(INK).text("What is in this record", MARGIN, doc.y, {
+    width: CONTENT_WIDTH,
+  })
+  doc.moveDown(0.7)
+  rule(doc, INK, 1)
+  doc.moveDown(0.6)
+
+  const sections = state.toc.filter((e) => e.level === 0)
+  const teams = state.toc.filter((e) => e.level === 1)
+
+  let y = doc.y
+  for (const entry of sections) {
+    doc.font(SANS_BOLD).fontSize(9.5).fillColor(INK).text(entry.title, MARGIN, y, {
+      width: CONTENT_WIDTH - 40,
+      lineBreak: false,
+    })
     doc
       .font(SANS)
-      .fontSize(8)
+      .fontSize(9.5)
       .fillColor(DIM)
-      .text(label.toUpperCase(), x, y + 30, { characterSpacing: 1, width: cellWidth - 12 })
-  })
-  doc.y = gridTop + 2 * 56 + 14
-  rule(doc)
+      .text(String(entry.page), MARGIN, y, { width: CONTENT_WIDTH, align: "right", lineBreak: false })
+    y += 17
+  }
 
-  doc.moveDown(1)
-  sectionLabel(doc, "How to read this document")
+  if (teams.length > 0) {
+    y += 8
+    doc
+      .font(SANS_BOLD)
+      .fontSize(7)
+      .fillColor(FAINT)
+      .text("TEAM PROFILES", MARGIN, y, { characterSpacing: 1.2 })
+    y += 14
+
+    const colWidth = (CONTENT_WIDTH - 24) / 2
+    const perColumn = Math.ceil(teams.length / 2)
+    teams.forEach((entry, i) => {
+      const col = Math.floor(i / perColumn)
+      const x = MARGIN + col * (colWidth + 24)
+      const ey = y + (i % perColumn) * 13.5
+      if (ey > CONTENT_BOTTOM - 10) return
+      doc.font(SANS).fontSize(8).fillColor(INK).text(entry.title, x, ey, {
+        width: colWidth - 26,
+        lineBreak: false,
+        ellipsis: true,
+      })
+      doc
+        .font(SANS)
+        .fontSize(8)
+        .fillColor(FAINT)
+        .text(String(entry.page), x, ey, { width: colWidth, align: "right", lineBreak: false })
+    })
+  }
+}
+
+// ─── How this record was produced ────────────────────────────────────────────
+
+/**
+ * The provenance section, near the front on purpose: a reader should never
+ * have to guess how any number or sentence in this document came to be.
+ * Longer than 50 lines because it is one continuous argument.
+ */
+function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): void {
+  sectionOpener(
+    doc,
+    "Methodology",
+    "How this record was produced",
+    "Everything in this document traces to one of three sources: the judges' scorecards, " +
+      "the teams' own submissions, or the organisers' registration records. This page says " +
+      "which is which."
+  )
+  markSection(doc, state, "How this record was produced")
+
+  // 1 — Scoring model.
+  kicker(doc, "The scoring model")
   doc
     .font(SANS)
     .fontSize(9)
-    .fillColor(DIM)
+    .fillColor(INK)
     .text(
-      "The podium was decided by the judging panel after deliberation; the raw score averages " +
-        "do not reproduce it and are shown separately as score order. Every placing in this " +
-        "document names its basis. Teams no judge reached during live demos were scored from " +
-        "their written submissions — those scores are marked wherever they appear.",
+      // Plain ASCII arithmetic: U+2212 and U+2044 fall outside pdfkit's
+      // WinAnsi standard-font encoding and print as garbage.
+      "Judges scored each project on five published criteria, 1 to 5, anchored the same way for " +
+        "everyone. A score of 1 means “not shown” and earns none of that criterion's weight; the " +
+        "scale is normalised so a criterion contributes (score - 1) / 4 of its weight, out of 100. " +
+        "A team's number is the mean of its judges' weighted totals — judges are averaged, not " +
+        "summed, so a team seen by two judges is not beaten by an identical team seen by four.",
+      MARGIN,
+      doc.y,
       { width: CONTENT_WIDTH, lineGap: 2.5 }
     )
+  doc.moveDown(0.8)
 
+  // Criteria table: label, weight, guidance.
+  const wCrit = 150
+  const wWeight = 46
+  for (const criterion of JUDGING_CRITERIA) {
+    const top = doc.y
+    doc.font(SANS_BOLD).fontSize(8.5).fillColor(INK).text(criterion.label, MARGIN, top, {
+      width: wCrit - 8,
+    })
+    doc
+      .font(SANS_BOLD)
+      .fontSize(8.5)
+      .fillColor(CLAY_DEEP)
+      .text(`${criterion.weight} pts`, MARGIN + wCrit, top, { width: wWeight, lineBreak: false })
+    doc
+      .font(SANS)
+      .fontSize(8.5)
+      .fillColor(DIM)
+      .text(criterion.guidance, MARGIN + wCrit + wWeight, top, {
+        width: CONTENT_WIDTH - wCrit - wWeight,
+        lineGap: 2,
+      })
+    doc.x = MARGIN
+    doc.moveDown(0.55)
+  }
+  doc
+    .font(SANS)
+    .fontSize(7.5)
+    .fillColor(FAINT)
+    .text(
+      "Scale anchors: " +
+        Object.entries(SCORE_LABELS)
+          .map(([n, label]) => `${n} = ${label}`)
+          .join(" · "),
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2 }
+    )
+  doc.moveDown(1.1)
+
+  // 2 — Coverage and the writeup rule.
+  const scoredTeams = data.teams.filter((t) => t.judgeCount > 0)
+  const coverageMin = Math.min(...scoredTeams.map((t) => t.judgeCount))
+  const coverageMax = Math.max(...scoredTeams.map((t) => t.judgeCount))
+  kicker(doc, "Who saw whom")
+  doc
+    .font(SANS)
+    .fontSize(9)
+    .fillColor(INK)
+    .text(
+      `${data.summary.judges} judges worked the floor and recorded ${data.summary.scorecards} ` +
+        `scorecards across ${scoredTeams.length} teams. Judging ran overnight, and no judge could ` +
+        `reach every table: coverage ranged from ${coverageMin} to ${coverageMax} judges per team, ` +
+        `and each team's profile states how many judges saw it. ` +
+        `${data.summary.teamsScoredFromWriteup} team${data.summary.teamsScoredFromWriteup === 1 ? " was" : "s were"} ` +
+        "scored from their written submission because no judge reached their table during live " +
+        "demos — that basis is marked wherever those scores appear, as a note on how the score " +
+        "was produced, never on the team.",
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2.5 }
+    )
+  doc.moveDown(1.1)
+
+  // 3 — The podium.
+  kicker(doc, "How the winners were decided")
+  doc
+    .font(SANS)
+    .fontSize(9)
+    .fillColor(INK)
+    .text(
+      "The podium was decided by the judging panel in deliberation, after watching the demos — " +
+        "not by the raw score order, which it does not reproduce. Both orderings appear in this " +
+        "document, each labelled as what it is: “announced” placings are the panel's decision; " +
+        "“score order” is the arithmetic. Neither is silently dressed as the other.",
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2.5 }
+    )
+  doc.moveDown(1.1)
+
+  // 4 — Written words: what the judges left, and what was written afterwards.
+  const judgesWithNotes = data.judgeSummaries.filter((j) => j.feedbackCount > 0)
+  const notesTotal = judgesWithNotes.reduce((sum, j) => sum + j.feedbackCount, 0)
+  const teamsWithNotes = data.teams.filter((t) =>
+    t.judgeScores.some((score) => score.feedback !== null)
+  ).length
+  kicker(doc, "Whose words are whose")
+  doc
+    .font(SANS)
+    .fontSize(9)
+    .fillColor(INK)
+    .text(
+      (judgesWithNotes.length === 0
+        ? "No judge left written notes during scoring. "
+        : judgesWithNotes.length === 1
+          ? `Written notes were left by one judge, ${judgesWithNotes[0].judgeName}, on ` +
+            `${notesTotal} scorecard${notesTotal === 1 ? "" : "s"} covering ${teamsWithNotes} ` +
+            `project${teamsWithNotes === 1 ? "" : "s"} — brief working notes, printed verbatim and ` +
+            "attributed on the team profiles. "
+          : `Written notes were left by ${judgesWithNotes.length} judges on ${notesTotal} ` +
+            `scorecards covering ${teamsWithNotes} projects, printed verbatim and attributed on ` +
+            "the team profiles. ") +
+        "No judge's words have been extended, paraphrased, or invented anywhere in this document.",
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2.5 }
+    )
+  doc.moveDown(0.7)
+  callout(
+    doc,
+    `Each team profile also carries a “${ANALYSIS_LABEL}” — a descriptive account written after ` +
+      "the event, drawn solely from that team's own submission. The analyses describe what each " +
+      "team built, who it serves, what was working versus mocked, and how Claude was used — in " +
+      "the team's own terms, with nothing inferred beyond what they wrote. They are labelled " +
+      "wherever they appear and are not judge commentary."
+  )
+
+  // 5 — Privacy.
+  kicker(doc, "What is deliberately left out")
+  doc
+    .font(SANS)
+    .fontSize(9)
+    .fillColor(INK)
+    .text(
+      "This document names builders and their roles — that is the record. Personal contact " +
+        "details (email addresses) are deliberately omitted for every participant and judge. The " +
+        "companion Excel workbook, held by the organisers, is the operational record.",
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2.5 }
+    )
+}
+
+// ─── The event in numbers ────────────────────────────────────────────────────
+
+function scoreBins(teams: ExportTeam[]): HistogramBin[] {
+  const bins: HistogramBin[] = Array.from({ length: 10 }, (_, i) => ({
+    label: `${i * 10}–${i * 10 + 10}`,
+    count: 0,
+  }))
+  for (const team of teams) {
+    if (team.average === null) continue
+    const index = Math.min(9, Math.floor(team.average / 10))
+    bins[index].count += 1
+  }
+  return bins
+}
+
+/**
+ * The infographic spread: distribution, tracks, coverage, and the judge
+ * panel — every figure computed from the data, none asserted. Longer than 50
+ * lines because it is one composed page of charts.
+ */
+function renderEventInNumbers(doc: Doc, data: ResultsExport, state: RenderState): void {
+  sectionOpener(
+    doc,
+    "The field",
+    "The event in numbers",
+    "How the scores fell across the whole field — read alongside the methodology on the " +
+      "previous page. Score charts show weighted averages out of 100; the podium was decided " +
+      "by the panel, not by these charts."
+  )
+  markSection(doc, state, "The event in numbers")
+
+  // Score distribution.
+  kicker(doc, "Score distribution", DIM)
+  doc
+    .font(SANS)
+    .fontSize(8)
+    .fillColor(FAINT)
+    .text("Teams by weighted average (/100)", MARGIN, doc.y, { width: CONTENT_WIDTH })
+  doc.moveDown(0.5)
+  doc.y += drawHistogram(doc, MARGIN + 16, doc.y, CONTENT_WIDTH - 16, 90, scoreBins(data.teams))
+  doc.moveDown(1.2)
+
+  // Tracks: mean score, with participation in the sublabel.
+  kicker(doc, "The five tracks", DIM)
+  const trackRows: HBarRow[] = data.trackSummaries
+    .filter((t) => t.track !== "Unassigned" || t.teamsFormed > 0)
+    .map((t) => ({
+      label: t.track,
+      sublabel: `${t.teamsFormed} teams · ${t.teamsSubmitted} submitted · ${t.teamsScored} scored`,
+      value: t.meanAverage ?? 0,
+      valueLabel: t.meanAverage !== null ? fmt1(t.meanAverage) : "—",
+    }))
+  doc.y += drawHBars(doc, MARGIN, doc.y, CONTENT_WIDTH, trackRows, {
+    max: 100,
+    labelWidth: 168,
+    scaleNote: "Mean of scored teams' weighted averages, 0–100. Track sizes differ — see sublabels.",
+  })
+  doc.moveDown(1.2)
+
+  // Coverage.
+  ensureSpace(doc, 120)
+  kicker(doc, "Judging coverage", DIM)
+  const coverageRows: HBarRow[] = data.coverage.map((bucket) => ({
+    label: `Seen by ${bucket.judgeCount} judge${bucket.judgeCount === 1 ? "" : "s"}`,
+    value: bucket.teams,
+    valueLabel: String(bucket.teams),
+  }))
+  const maxCoverage = Math.max(1, ...data.coverage.map((b) => b.teams))
+  doc.y += drawHBars(doc, MARGIN, doc.y, CONTENT_WIDTH, coverageRows, {
+    max: maxCoverage,
+    labelWidth: 168,
+    rowHeight: 16,
+    scaleNote: "Number of scored teams.",
+  })
+  doc.moveDown(1.2)
+
+  // The judge panel gets the facing page: a half-page of dots and a finding,
+  // not squeezed under the coverage bars.
+  doc.addPage()
+  doc.y = MARGIN + 8
+  kicker(doc, "The judge panel", DIM)
   doc
     .font(SANS)
     .fontSize(8)
     .fillColor(FAINT)
     .text(
-      `Generated ${data.generatedAt.toISOString().slice(0, 10)} · Cohort ${data.cohort}` +
-        (data.published && data.publishedAt
-          ? ` · Results published ${data.publishedAt.slice(0, 10)}`
-          : " · Results not yet published"),
+      "Each judge's mean weighted total across their own scorecards (/100). Judges saw " +
+        "different, overlapping sets of teams, so these are calibration profiles — not rankings " +
+        "of the judges and not comparable head-to-head.",
       MARGIN,
-      FOOTER_Y - 20,
-      { width: CONTENT_WIDTH }
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2 }
     )
+  doc.moveDown(0.6)
+  const judgeRows: DotRow[] = data.judgeSummaries.map((j) => ({
+    label: j.judgeName,
+    sublabel:
+      `${j.sheets} sheet${j.sheets === 1 ? "" : "s"}` +
+      (j.writeupSheets > 0 ? ` · ${j.writeupSheets} from writeups` : "") +
+      (j.feedbackCount > 0 ? ` · ${j.feedbackCount} written notes` : ""),
+    dots: [j.meanWeightedTotal],
+  }))
+  doc.y += drawDotRows(doc, MARGIN, doc.y, CONTENT_WIDTH, judgeRows, {
+    max: 100,
+    labelWidth: 168,
+    rowHeight: 28,
+  })
+  doc.moveDown(0.6)
+
+  // The spread finding — computed, not asserted.
+  const judgeMeans = data.judgeSummaries.map((j) => j.meanWeightedTotal)
+  const widest = data.teams
+    .filter((t) => t.judgeCount >= 2 && t.scoreLow !== null && t.scoreHigh !== null)
+    .reduce<ExportTeam | null>(
+      (top, t) =>
+        top === null ||
+        (t.scoreHigh ?? 0) - (t.scoreLow ?? 0) > (top.scoreHigh ?? 0) - (top.scoreLow ?? 0)
+          ? t
+          : top,
+      null
+    )
+  if (judgeMeans.length >= 2 && widest?.submission) {
+    callout(
+      doc,
+      `The spread is part of the record. Judge means ranged from ${fmt1(Math.min(...judgeMeans))} ` +
+        `to ${fmt1(Math.max(...judgeMeans))} — the panel used the scale differently, which is why ` +
+        `teams are averaged across their judges rather than summed. The widest disagreement on a ` +
+        `single project was ${widest.submission.projectName}, where ${widest.judgeCount} judges ` +
+        `scored from ${fmt1(widest.scoreLow ?? 0)} to ${fmt1(widest.scoreHigh ?? 0)}. Honest ` +
+        "disagreement between judges who saw different moments of a live demo is what a real " +
+        "panel looks like; each profile shows its own spread."
+    )
+  }
 }
 
 // ─── Winners ─────────────────────────────────────────────────────────────────
 
-function renderWinners(doc: Doc, data: ResultsExport): void {
-  doc.addPage()
-  sectionLabel(doc, "The winners")
-  doc.font(SERIF).fontSize(22).fillColor(INK).text("As announced by the judging panel", {
-    width: CONTENT_WIDTH,
-  })
-  doc.moveDown(0.6)
-
-  if (data.announced.length === 0) {
-    doc
-      .font(SANS)
-      .fontSize(9)
-      .fillColor(DIM)
-      .text(
-        "Results have not been published yet — winners below are ordered by score alone.",
-        { width: CONTENT_WIDTH }
-      )
-    doc.moveDown(0.5)
-  }
+/** Podium cards and the track winners table. One composition, one place. */
+function renderWinners(doc: Doc, data: ResultsExport, state: RenderState): void {
+  sectionOpener(
+    doc,
+    "Results",
+    "The winners",
+    data.announced.length > 0
+      ? "As announced in the room by the judging panel after deliberation."
+      : "Results have not been published; the leaders below are ordered by score alone."
+  )
+  markSection(doc, state, "The winners")
 
   const medals = ["Champion", "First runner-up", "Second runner-up"]
+  const teamByName = new Map(data.teams.map((t) => [t.teamName, t]))
   for (const winner of data.announced) {
-    ensureSpace(doc, 54)
+    ensureSpace(doc, 74)
     const top = doc.y
-    doc.rect(MARGIN, top, 3, 42).fillColor(winner.rank === 1 ? GREEN : RULE).fill()
+    const team = teamByName.get(winner.teamName)
+    const isChampion = winner.rank === 1
+    const boxHeight = 58
+    if (isChampion) {
+      doc.roundedRect(MARGIN, top, CONTENT_WIDTH, boxHeight, 3).fillColor(PAPER).fill()
+      doc.roundedRect(MARGIN, top, CONTENT_WIDTH, boxHeight, 3).lineWidth(1).strokeColor(CLAY).stroke()
+    }
+    doc.rect(MARGIN, top, 3, boxHeight).fillColor(isChampion ? CLAY : MID_GRAY).fill()
     doc
       .font(SANS_BOLD)
-      .fontSize(8)
-      .fillColor(winner.rank === 1 ? GREEN : DIM)
-      .text(
-        (medals[winner.rank - 1] ?? `#${winner.rank}`).toUpperCase(),
-        MARGIN + 14,
-        top + 2,
-        { characterSpacing: 1.2 }
-      )
+      .fontSize(7.5)
+      .fillColor(isChampion ? CLAY_DEEP : DIM)
+      .text((medals[winner.rank - 1] ?? `#${winner.rank}`).toUpperCase(), MARGIN + 16, top + 9, {
+        characterSpacing: 1.4,
+      })
     doc
       .font(SERIF)
-      .fontSize(16)
+      .fontSize(18)
       .fillColor(INK)
-      .text(winner.projectName, MARGIN + 14, top + 13, { width: CONTENT_WIDTH - 14 })
+      .text(winner.projectName, MARGIN + 16, top + 20, { width: CONTENT_WIDTH - 32, lineBreak: false })
     doc
       .font(SANS)
-      .fontSize(9)
+      .fontSize(8.5)
       .fillColor(DIM)
-      .text(winner.teamName, MARGIN + 14, top + 32, { width: CONTENT_WIDTH - 14 })
-    doc.y = top + 52
+      // The team name already carries table and track — nothing to append.
+      .text(
+        winner.teamName +
+          (team?.average !== null && team?.average !== undefined
+            ? `  ·  panel average ${fmt1(team.average)}/100`
+            : ""),
+        MARGIN + 16,
+        top + 41,
+        { width: CONTENT_WIDTH - 32, lineBreak: false }
+      )
+    doc.y = top + boxHeight + 12
   }
 
-  doc.moveDown(1)
-  sectionLabel(doc, "Track winners")
+  doc.moveDown(0.8)
+  kicker(doc, "Track winners")
+  doc.moveDown(0.2)
   for (const w of data.trackWinners) {
-    ensureSpace(doc, 18)
+    ensureSpace(doc, 26)
     const top = doc.y
-    doc.font(SANS_BOLD).fontSize(9).fillColor(INK).text(w.track, MARGIN, top, { width: 170 })
-    doc
-      .font(SANS)
-      .fontSize(9)
-      .fillColor(INK)
-      .text(`${w.projectName} — ${w.teamName}`, MARGIN + 180, top, {
-        width: CONTENT_WIDTH - 240,
-      })
+    const middle = `${w.projectName} — ${w.teamName}`
+    const middleWidth = CONTENT_WIDTH - 184 - 70
+    // Rows advance by measured height so a wrapping name never overstrikes
+    // the next row.
+    doc.font(SANS).fontSize(9)
+    const rowHeight = Math.max(14, doc.heightOfString(middle, { width: middleWidth }) + 2)
+    doc.font(SANS_BOLD).fontSize(9).fillColor(INK).text(w.track, MARGIN, top, {
+      width: 176,
+      lineBreak: false,
+    })
+    doc.font(SANS).fontSize(9).fillColor(INK).text(middle, MARGIN + 184, top, {
+      width: middleWidth,
+    })
     doc
       .font(SANS_ITALIC)
-      .fontSize(8)
+      .fontSize(7.5)
       .fillColor(FAINT)
-      .text(w.basis === "announced" ? "announced" : "by score", MARGIN + CONTENT_WIDTH - 55, top, {
-        width: 55,
-        align: "right",
-      })
-    doc.y = Math.max(doc.y, top + 14) + 2
+      .text(
+        w.basis === "announced" ? "announced" : "by score",
+        MARGIN + CONTENT_WIDTH - 62,
+        top + 1,
+        { width: 62, align: "right", lineBreak: false }
+      )
+    doc.x = MARGIN
+    doc.y = top + rowHeight + 4
+    doc
+      .moveTo(MARGIN, doc.y - 3)
+      .lineTo(MARGIN + CONTENT_WIDTH, doc.y - 3)
+      .lineWidth(0.4)
+      .strokeColor(RULE)
+      .stroke()
   }
+  doc.moveDown(0.6)
+  doc
+    .font(SANS)
+    .fontSize(7.5)
+    .fillColor(FAINT)
+    .text(
+      "“Announced” track winners follow from the podium (the champion leads its own track); " +
+        "“by score” winners top their track on weighted average.",
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2 }
+    )
 }
 
-// ─── Ranking table ───────────────────────────────────────────────────────────
+// ─── Full ranking ────────────────────────────────────────────────────────────
 
+// The team name is "Table N — Track", so a Team column would print the table
+// and track twice; Table + Track columns carry the same facts without the
+// noise. Headers sized to stay on one line at 7pt.
 const RANK_COLS = [
   { label: "#", width: 24 },
-  { label: "Project", width: 130 },
-  { label: "Team", width: 120 },
-  { label: "Track", width: 90 },
-  { label: "Avg /100", width: 44 },
-  { label: "Judges", width: 40 },
-  { label: "Basis", width: 35 },
+  { label: "Project", width: 132 },
+  { label: "Table", width: 48 },
+  { label: "Track", width: 100 },
+  { label: "Avg /100", width: 42 },
+  { label: "Range", width: 60 },
+  { label: "Judges", width: 38 },
+  { label: "Basis", width: 39 },
 ] as const
 
 function rankingHeader(doc: Doc): void {
+  if (doc.y < MARGIN + 8) doc.y = MARGIN + 8
   let x = MARGIN
-  doc.font(SANS_BOLD).fontSize(7.5).fillColor(DIM)
+  doc.font(SANS_BOLD).fontSize(7).fillColor(DIM)
+  const top = doc.y
   for (const col of RANK_COLS) {
-    doc.text(col.label.toUpperCase(), x, doc.y, { width: col.width - 6, characterSpacing: 0.5 })
+    doc.text(col.label.toUpperCase(), x, top, { width: col.width - 6, characterSpacing: 0.5 })
     x += col.width
   }
-  doc.moveDown(0.4)
-  rule(doc, INK)
+  doc.x = MARGIN
+  doc.y = top + 12
+  rule(doc, INK, 0.9)
 }
 
 /**
- * The full ranking, one row per team, announced placings tinted. Longer than
- * 50 lines because a multi-page table needs its row layout, page breaks and
- * header re-draws in one place to stay readable.
+ * The full ranking, one row per team, announced placings tinted paper-warm
+ * with a clay spine. Longer than 50 lines because a multi-page table needs
+ * its row layout, page breaks and header re-draws in one place.
  */
-function renderRanking(doc: Doc, data: ResultsExport): void {
-  doc.addPage()
-  sectionLabel(doc, "Full ranking")
-  doc
-    .font(SERIF)
-    .fontSize(22)
-    .fillColor(INK)
-    .text("Every team, and how its placing was decided", { width: CONTENT_WIDTH })
-  doc.moveDown(0.7)
+function renderRanking(doc: Doc, data: ResultsExport, state: RenderState): void {
+  sectionOpener(
+    doc,
+    "Results",
+    "Every team, and how its placing was decided",
+    "Placings 1–3 were announced by the panel; every other scored team follows in raw score " +
+      "order. The averages are the archival record — they order this list, they did not decide " +
+      "the podium."
+  )
+  markSection(doc, state, "Full ranking")
   rankingHeader(doc)
 
   const ranked = data.teams.filter((t) => t.average !== null)
@@ -297,34 +832,40 @@ function renderRanking(doc: Doc, data: ResultsExport): void {
     const cells = [
       team.finalRank !== null ? String(team.finalRank) : `(${team.scoreRank})`,
       team.submission?.projectName ?? "—",
-      team.teamName,
+      team.tableLabel,
       team.track,
-      team.average !== null ? team.average.toFixed(1) : "—",
+      team.average !== null ? fmt1(team.average) : "—",
+      team.scoreLow !== null && team.scoreHigh !== null && team.judgeCount > 1
+        ? `${fmt1(team.scoreLow)}–${fmt1(team.scoreHigh)}`
+        : "—",
       String(team.judgeCount),
       team.finalRankBasis === "announced" ? "panel" : team.scoredFromWriteup ? "score †" : "score",
     ]
-    doc.font(SANS).fontSize(8.5)
+    doc.font(SANS).fontSize(8)
     const rowHeight =
       Math.max(
         ...cells.map((text, i) => doc.heightOfString(text, { width: RANK_COLS[i].width - 6 }))
-      ) + 6
-    if (doc.y + rowHeight > FOOTER_Y - 16) {
+      ) + 7
+    if (doc.y + rowHeight > CONTENT_BOTTOM) {
       doc.addPage()
+      doc.y = MARGIN + 8
       rankingHeader(doc)
     }
     const top = doc.y
     if (team.finalRankBasis === "announced") {
-      doc.rect(MARGIN - 4, top - 3, CONTENT_WIDTH + 8, rowHeight).fillColor(AMBER_BG).fill()
+      doc.rect(MARGIN - 6, top - 3, CONTENT_WIDTH + 12, rowHeight).fillColor(CALLOUT_BG).fill()
+      doc.rect(MARGIN - 6, top - 3, 2.5, rowHeight).fillColor(CLAY).fill()
     }
     let x = MARGIN
     cells.forEach((text, i) => {
       doc
         .font(i === 1 ? SANS_BOLD : SANS)
-        .fontSize(8.5)
-        .fillColor(i === 3 || i === 6 ? DIM : INK)
+        .fontSize(8)
+        .fillColor(i === 3 || i === 5 || i === 7 ? DIM : INK)
         .text(text, x, top, { width: RANK_COLS[i].width - 6 })
       x += RANK_COLS[i].width
     })
+    doc.x = MARGIN
     doc.y = top + rowHeight
     doc
       .moveTo(MARGIN, doc.y - 3)
@@ -337,260 +878,522 @@ function renderRanking(doc: Doc, data: ResultsExport): void {
   doc.moveDown(0.6)
   doc
     .font(SANS)
-    .fontSize(8)
-    .fillColor(AMBER)
-    .text(
-      "† " + WRITEUP_NOTE,
-      MARGIN,
-      doc.y,
-      { width: CONTENT_WIDTH, lineGap: 2 }
-    )
+    .fontSize(7.5)
+    .fillColor(CLAY_DEEP)
+    .text("†  " + WRITEUP_NOTE, MARGIN, doc.y, { width: CONTENT_WIDTH, lineGap: 2 })
   doc.moveDown(0.4)
   doc
     .font(SANS)
-    .fontSize(8)
+    .fontSize(7.5)
     .fillColor(DIM)
     .text(
-      "“panel” placings 1–3 were announced by the judging panel after deliberation; every other " +
-        "team is ordered by its raw weighted average. Averages are shown here for the archival " +
-        "record — they order the list but did not decide the podium.",
+      "“Judge range” is the lowest and highest weighted total among that team's judges — the " +
+        "spread discussed in “The event in numbers”.",
+      MARGIN,
+      doc.y,
       { width: CONTENT_WIDTH, lineGap: 2 }
     )
 
   const unscored = data.teams.filter((t) => t.average === null)
   if (unscored.length > 0) {
-    doc.moveDown(1.2)
-    sectionLabel(doc, "Teams without a score")
+    doc.moveDown(1)
+    kicker(doc, "Teams without a score", DIM)
     doc
       .font(SANS)
-      .fontSize(8.5)
+      .fontSize(8)
       .fillColor(DIM)
       .text(
         unscored
           .map((t) => `${t.teamName}${t.submission ? ` — ${t.submission.projectName}` : ""}`)
           .join("  ·  "),
+        MARGIN,
+        doc.y,
         { width: CONTENT_WIDTH, lineGap: 2.5 }
       )
   }
 }
 
-// ─── Per-team pages ──────────────────────────────────────────────────────────
+// ─── Team profiles ───────────────────────────────────────────────────────────
 
-function renderJudgeTable(doc: Doc, team: ExportTeam): void {
-  const nameWidth = 108
-  const basisWidth = 66
-  const critWidth = 40
+function renderMembers(doc: Doc, team: ExportTeam): void {
+  kicker(doc, "The team", DIM)
+  if (team.members.length === 0) {
+    doc
+      .font(SANS)
+      .fontSize(8.5)
+      .fillColor(DIM)
+      .text("No roster was frozen for this team.", MARGIN, doc.y, { width: CONTENT_WIDTH })
+    doc.moveDown(0.8)
+    return
+  }
+  const lines = team.members.map(
+    (m) =>
+      `${m.fullName}${m.isLeader ? " (lead)" : ""} — ${m.primaryRole}` +
+      (m.institution ? `, ${m.institution}` : "")
+  )
+  // Two columns: rosters are 3–7 people; one per line reads best, half-page wide.
+  const colWidth = (CONTENT_WIDTH - 20) / 2
+  const perColumn = Math.ceil(lines.length / 2)
+  const top = doc.y
+  let maxY = top
+  lines.forEach((line, i) => {
+    const col = Math.floor(i / perColumn)
+    const x = MARGIN + col * (colWidth + 20)
+    const y = top + (i % perColumn) * 12.5
+    doc.font(SANS).fontSize(8.5).fillColor(INK).text(line, x, y, {
+      width: colWidth,
+      lineBreak: false,
+      ellipsis: true,
+    })
+    maxY = Math.max(maxY, y + 12.5)
+  })
+  doc.x = MARGIN
+  doc.y = maxY + 8
+}
+
+/** The generated analysis, boxed and labelled so it can never be misread. */
+function renderAnalysis(doc: Doc, analysis: TeamAnalysis): void {
+  const parts: [string, string][] = [
+    ["What they built", analysis.whatTheyBuilt],
+    ["Who it serves", analysis.whoItServes],
+    ["Working vs mocked", analysis.workingVsMocked],
+    ["How Claude was used", analysis.claudeUse],
+  ]
+  const innerWidth = CONTENT_WIDTH - 28
+  doc.font(SANS).fontSize(8.5)
+  const bodyHeight = parts.reduce(
+    (sum, [, text]) => sum + 11 + doc.heightOfString(text, { width: innerWidth, lineGap: 2.2 }) + 7,
+    0
+  )
+  const boxHeight = bodyHeight + 40
+  ensureSpace(doc, Math.min(boxHeight + 8, CONTENT_BOTTOM - MARGIN))
+  const top = doc.y
+  doc.roundedRect(MARGIN, top, CONTENT_WIDTH, boxHeight, 3).fillColor(CALLOUT_BG).fill()
+  doc.rect(MARGIN, top, 2.5, boxHeight).fillColor(OLIVE).fill()
+
+  doc
+    .font(SANS_BOLD)
+    .fontSize(7.5)
+    .fillColor(INK)
+    .text(ANALYSIS_LABEL.toUpperCase(), MARGIN + 14, top + 10, { characterSpacing: 1.4 })
+  doc
+    .font(SANS_ITALIC)
+    .fontSize(7.5)
+    .fillColor(DIM)
+    .text(ANALYSIS_PROVENANCE, MARGIN + 14, doc.y + 1, { width: innerWidth })
+
+  let y = doc.y + 8
+  for (const [label, text] of parts) {
+    doc
+      .font(SANS_BOLD)
+      .fontSize(7)
+      .fillColor(FAINT)
+      .text(label.toUpperCase(), MARGIN + 14, y, { characterSpacing: 0.8 })
+    y += 10
+    doc.font(SANS).fontSize(8.5).fillColor(INK).text(text, MARGIN + 14, y, {
+      width: innerWidth,
+      lineGap: 2.2,
+    })
+    y = doc.y + 7
+  }
+  doc.x = MARGIN
+  doc.y = top + boxHeight + 12
+}
+
+function renderSubmission(doc: Doc, team: ExportTeam): void {
+  if (!team.submission) {
+    paragraph(doc, "Submission", "This team did not submit a project.")
+    return
+  }
+  const s = team.submission
+  ensureSpace(doc, 60)
+  kicker(doc, "The submission — in the team's own words", DIM)
+  doc
+    .font(SERIF_ITALIC)
+    .fontSize(11)
+    .fillColor(INK)
+    .text(`“${s.pitch.trim()}”`, MARGIN, doc.y, { width: CONTENT_WIDTH * 0.92, lineGap: 3 })
+  doc.moveDown(0.8)
+  paragraph(doc, "Problem tackled", s.problemTackled)
+  paragraph(doc, "What it does", s.description)
+  paragraph(doc, "What works vs what is mocked", s.worksVsMocked)
+  paragraph(doc, "How the team used Claude", s.claudeUsage)
+
+  const links = [
+    ["Repository", s.repoUrl],
+    ["Demo", s.demoUrl],
+    ["Video", s.videoUrl],
+    ["Slides", s.slidesUrl],
+  ].filter((pair): pair is [string, string] => Boolean(pair[1]))
+  if (links.length > 0) {
+    ensureSpace(doc, 18 + links.length * 12)
+    doc
+      .font(SANS_BOLD)
+      .fontSize(7)
+      .fillColor(FAINT)
+      .text("LINKS", MARGIN, doc.y, { characterSpacing: 1.1 })
+    doc.moveDown(0.3)
+    for (const [label, url] of links) {
+      doc.font(SANS_BOLD).fontSize(8.5).fillColor(INK).text(`${label}  `, MARGIN, doc.y, {
+        continued: true,
+      })
+      doc.font(SANS).fillColor(CLAY_DEEP).text(url, { link: url, underline: false })
+    }
+    doc.moveDown(0.8)
+  }
+}
+
+/**
+ * The judging block: criterion profile, per-judge table, spread strip, and
+ * verbatim judge notes. Longer than 50 lines because the pieces share
+ * geometry and pagination decisions that must be made together.
+ */
+function renderJudging(doc: Doc, team: ExportTeam): void {
+  if (team.judgeScores.length === 0) return
+  ensureSpace(doc, 200)
+  // No divider when the block landed at the top of a fresh page — it would
+  // double the running header's rule.
+  if (doc.y > MARGIN + 24) {
+    rule(doc)
+    doc.moveDown(0.2)
+  }
+  kicker(doc, "Judging", DIM)
+
+  // Criterion profile: the five published criteria, averaged across judges.
+  if (team.average !== null) {
+    const rows: HBarRow[] = JUDGING_CRITERIA.map((criterion) => ({
+      label: criterion.label,
+      value: team.criterionAverages[criterion.key] ?? 0,
+      valueLabel: fmt1(team.criterionAverages[criterion.key] ?? 0),
+    }))
+    doc.y += drawHBars(doc, MARGIN, doc.y, CONTENT_WIDTH * 0.72, rows, {
+      max: 5,
+      labelWidth: 150,
+      rowHeight: 15,
+      scaleNote: "Mean of judges' raw 1–5 scores per criterion. 1 = not shown.",
+    })
+    doc.moveDown(0.8)
+  }
+
+  // Per-judge table.
+  const nameWidth = 104
+  const basisWidth = 62
+  const critWidth = 42
   const totalWidth = CONTENT_WIDTH - nameWidth - basisWidth - critWidth * JUDGING_CRITERIA.length
-
-  ensureSpace(doc, 40 + team.judgeScores.length * 16)
-  sectionLabel(doc, "Scores")
-
+  ensureSpace(doc, 30 + team.judgeScores.length * 15)
   const shortLabels = ["Impact", "Demo", "Claude", "Clarity", "Present."]
   let x = MARGIN
-  doc.font(SANS_BOLD).fontSize(7).fillColor(DIM)
-  doc.text("JUDGE", x, doc.y, { width: nameWidth - 6 })
+  const headTop = doc.y
+  doc.font(SANS_BOLD).fontSize(6.5).fillColor(DIM)
+  doc.text("JUDGE", x, headTop, { width: nameWidth - 6 })
   x += nameWidth
-  doc.text("BASIS", x, doc.y, { width: basisWidth - 6 })
+  doc.text("BASIS", x, headTop, { width: basisWidth - 6 })
   x += basisWidth
   shortLabels.forEach((label) => {
-    doc.text(label.toUpperCase(), x, doc.y, { width: critWidth - 4 })
+    doc.text(label.toUpperCase(), x, headTop, { width: critWidth - 4 })
     x += critWidth
   })
-  doc.text("TOTAL /100", x, doc.y, { width: totalWidth })
-  doc.moveDown(0.4)
-  rule(doc, INK)
+  doc.text("TOTAL /100", x, headTop, { width: totalWidth })
+  doc.x = MARGIN
+  doc.y = headTop + 11
+  rule(doc, INK, 0.8)
 
   for (const score of team.judgeScores) {
     const top = doc.y
     let cx = MARGIN
-    doc.font(SANS).fontSize(8.5).fillColor(INK).text(score.judgeName, cx, top, {
+    doc.font(SANS).fontSize(8).fillColor(INK).text(score.judgeName, cx, top, {
       width: nameWidth - 6,
+      lineBreak: false,
+      ellipsis: true,
     })
     cx += nameWidth
     doc
       .font(SANS)
-      .fontSize(8)
-      .fillColor(score.writeupOnly ? AMBER : DIM)
+      .fontSize(7.5)
+      .fillColor(score.writeupOnly ? CLAY_DEEP : DIM)
       .text(score.writeupOnly ? "Writeup" : "Live demo", cx, top, { width: basisWidth - 6 })
     cx += basisWidth
     for (const criterion of JUDGING_CRITERIA) {
       const value = score.criteria[criterion.key]
       doc
         .font(SANS)
-        .fontSize(8.5)
+        .fontSize(8)
         .fillColor(INK)
         .text(value === null ? "—" : String(value), cx, top, { width: critWidth - 4 })
       cx += critWidth
     }
-    doc
-      .font(SANS_BOLD)
-      .fontSize(8.5)
-      .fillColor(INK)
-      .text(score.weightedTotal.toFixed(1), cx, top, { width: totalWidth })
-    doc.y = top + 15
+    doc.font(SANS_BOLD).fontSize(8).fillColor(INK).text(fmt1(score.weightedTotal), cx, top, {
+      width: totalWidth,
+    })
+    doc.x = MARGIN
+    doc.y = top + 14
   }
   rule(doc)
-}
 
-function renderFeedback(doc: Doc, team: ExportTeam): void {
+  // Spread strip when more than one judge scored: the range, drawn honestly.
+  if (team.judgeCount > 1 && team.scoreLow !== null && team.scoreHigh !== null) {
+    ensureSpace(doc, 56)
+    doc.moveDown(0.3)
+    const spreadRows: DotRow[] = [
+      {
+        label: "Judge totals",
+        sublabel: `spread ${fmt1(team.scoreHigh - team.scoreLow)}`,
+        dots: team.judgeScores.map((s) => s.weightedTotal),
+      },
+    ]
+    doc.y += drawDotRows(doc, MARGIN, doc.y, CONTENT_WIDTH * 0.72, spreadRows, {
+      max: 100,
+      labelWidth: 92,
+    })
+    doc.moveDown(0.4)
+  }
+
+  // Verbatim notes — the only judge words in the document.
   const withFeedback = team.judgeScores.filter((s) => s.feedback !== null)
-  if (withFeedback.length === 0) return
-  sectionLabel(doc, "Judge feedback")
-  for (const score of withFeedback) {
-    const body = score.feedback ?? ""
-    doc.font(SANS).fontSize(9)
-    ensureSpace(doc, 16 + doc.heightOfString(body, { width: CONTENT_WIDTH - 12, lineGap: 2 }))
+  if (withFeedback.length > 0) {
+    doc.moveDown(0.3)
     doc
       .font(SANS_BOLD)
-      .fontSize(8.5)
-      .fillColor(INK)
-      .text(
-        score.judgeName + (score.writeupOnly ? "  ·  from the written submission" : ""),
-        MARGIN,
-        doc.y
-      )
-    doc
-      .font(SANS)
-      .fontSize(9)
-      .fillColor(DIM)
-      .text(body, MARGIN + 12, doc.y + 2, { width: CONTENT_WIDTH - 12, lineGap: 2 })
-    doc.x = MARGIN
-    doc.moveDown(0.7)
+      .fontSize(7)
+      .fillColor(FAINT)
+      .text("JUDGE NOTES — RECORDED DURING JUDGING, VERBATIM", MARGIN, doc.y, {
+        characterSpacing: 1,
+      })
+    doc.moveDown(0.4)
+    for (const score of withFeedback) {
+      const body = score.feedback ?? ""
+      doc.font(SERIF_ITALIC).fontSize(9.5)
+      ensureSpace(doc, 16 + doc.heightOfString(body, { width: CONTENT_WIDTH - 16, lineGap: 2 }))
+      doc
+        .font(SERIF_ITALIC)
+        .fontSize(9.5)
+        .fillColor(INK)
+        .text(`“${body}”`, MARGIN, doc.y, { width: CONTENT_WIDTH - 16, lineGap: 2 })
+      doc
+        .font(SANS)
+        .fontSize(7.5)
+        .fillColor(DIM)
+        .text(
+          `— ${score.judgeName}` + (score.writeupOnly ? ", from the written submission" : ""),
+          MARGIN,
+          doc.y + 1
+        )
+      doc.moveDown(0.6)
+    }
   }
 }
 
 /**
- * One section per team, each starting on a fresh page: identity, members,
- * the full submission, then scores and feedback.
+ * One profile per team, each starting on a fresh page: identity, roster,
+ * the labelled analysis, the submission verbatim, then judging.
  */
-function renderTeamPage(doc: Doc, team: ExportTeam): void {
+function renderTeamProfile(
+  doc: Doc,
+  team: ExportTeam,
+  analysis: TeamAnalysis | undefined,
+  state: RenderState
+): void {
   doc.addPage()
+  doc.y = MARGIN + 8
+  markSection(doc, state, team.submission?.projectName ?? team.teamName, 1)
 
-  doc.font(SANS_BOLD).fontSize(8).fillColor(GREEN)
-  doc.text(placingLine(team).toUpperCase(), MARGIN, doc.y, { characterSpacing: 1 })
-  doc.moveDown(0.3)
+  // Header: placing kicker left, honours chip right.
+  const kickerTop = doc.y
+  kicker(doc, placingKicker(team))
+  if (team.isChampion || team.isTrackWinner) {
+    const afterKicker = doc.y
+    const chip = team.isChampion ? "CHAMPION" : "TRACK WINNER"
+    // widthOfString ignores characterSpacing — add it per character.
+    const chipWidth =
+      doc.font(SANS_BOLD).fontSize(7).widthOfString(chip) + chip.length * 0.8 + 16
+    doc
+      .roundedRect(MARGIN + CONTENT_WIDTH - chipWidth, kickerTop - 3, chipWidth, 14, 7)
+      .fillColor(team.isChampion ? CLAY : OLIVE)
+      .fill()
+    doc
+      .font(SANS_BOLD)
+      .fontSize(7)
+      .fillColor(PAPER)
+      .text(chip, MARGIN + CONTENT_WIDTH - chipWidth + 8, kickerTop, {
+        characterSpacing: 0.8,
+        lineBreak: false,
+      })
+    // The chip is an overlay; put the flow back where the kicker left it.
+    doc.x = MARGIN
+    doc.y = afterKicker
+  }
+
   doc
     .font(SERIF)
-    .fontSize(20)
+    .fontSize(21)
     .fillColor(INK)
-    .text(team.submission?.projectName ?? team.teamName, { width: CONTENT_WIDTH })
-  doc
-    .font(SANS)
-    .fontSize(9.5)
-    .fillColor(DIM)
-    // The team name already carries table and track ("Table 12 — Kilimo…"),
-    // so repeating them here would just say everything twice.
-    .text(team.teamName, { width: CONTENT_WIDTH })
-  if (team.average !== null) {
-    doc
-      .font(SANS)
-      .fontSize(9)
-      .fillColor(DIM)
-      .text(
-        `Panel average ${team.average.toFixed(1)}/100 across ${team.judgeCount} ` +
-          `scorecard${team.judgeCount === 1 ? "" : "s"} · score rank #${team.scoreRank}`,
-        { width: CONTENT_WIDTH }
-      )
-  }
-  doc.moveDown(0.5)
-  rule(doc)
-
-  if (team.scoredFromWriteup) {
-    const noteHeight =
-      doc.font(SANS).fontSize(8.5).heightOfString(WRITEUP_NOTE, {
-        width: CONTENT_WIDTH - 24,
-        lineGap: 2,
-      }) + 14
-    const top = doc.y
-    doc.rect(MARGIN, top, CONTENT_WIDTH, noteHeight).fillColor(AMBER_BG).fill()
-    doc
-      .font(SANS)
-      .fontSize(8.5)
-      .fillColor(AMBER)
-      .text(WRITEUP_NOTE, MARGIN + 12, top + 7, { width: CONTENT_WIDTH - 24, lineGap: 2 })
-    doc.x = MARGIN
-    doc.y = top + noteHeight + 10
-  }
-
-  sectionLabel(doc, "Team")
+    .text(team.submission?.projectName ?? team.teamName, MARGIN, doc.y, { width: CONTENT_WIDTH })
   doc
     .font(SANS)
     .fontSize(9)
-    .fillColor(INK)
-    .text(
-      team.members
-        .map((m) => `${m.fullName}${m.isLeader ? " (lead)" : ""} <${m.email}>`)
-        .join("   ·   ") || "—",
-      { width: CONTENT_WIDTH, lineGap: 2.5 }
-    )
-  doc.moveDown(0.8)
-
-  if (team.submission) {
-    const s = team.submission
-    paragraph(doc, "Pitch", s.pitch)
-    paragraph(doc, "Problem tackled", s.problemTackled)
-    paragraph(doc, "What it does", s.description)
-    paragraph(doc, "What works vs what is mocked", s.worksVsMocked)
-    paragraph(doc, "How the team used Claude", s.claudeUsage)
-
-    const links = [
-      ["Repository", s.repoUrl],
-      ["Demo", s.demoUrl],
-      ["Video", s.videoUrl],
-      ["Slides", s.slidesUrl],
-    ].filter((pair): pair is [string, string] => Boolean(pair[1]))
-    if (links.length > 0) {
-      ensureSpace(doc, 20 + links.length * 12)
-      sectionLabel(doc, "Links")
-      for (const [label, url] of links) {
-        doc.font(SANS_BOLD).fontSize(8.5).fillColor(INK).text(`${label}  `, {
-          continued: true,
-        })
-        doc.font(SANS).fillColor(GREEN).text(url, { link: url, underline: false })
-      }
-      doc.moveDown(0.8)
-    }
-  } else {
-    paragraph(doc, "Submission", "This team did not submit a project.")
+    .fillColor(DIM)
+    .text(team.teamName, MARGIN, doc.y + 2, { width: CONTENT_WIDTH })
+  if (team.average !== null) {
+    doc
+      .font(SANS)
+      .fontSize(8.5)
+      .fillColor(DIM)
+      .text(
+        `Panel average ${fmt1(team.average)}/100 across ${team.judgeCount} scorecard` +
+          `${team.judgeCount === 1 ? "" : "s"}` +
+          (team.judgeCount > 1 && team.scoreLow !== null && team.scoreHigh !== null
+            ? ` (judges ranged ${fmt1(team.scoreLow)}–${fmt1(team.scoreHigh)})`
+            : "") +
+          ` · score rank #${team.scoreRank}`,
+        MARGIN,
+        doc.y + 2,
+        { width: CONTENT_WIDTH }
+      )
   }
+  doc.moveDown(0.6)
+  rule(doc, INK, 0.9)
+  doc.moveDown(0.4)
 
-  if (team.judgeScores.length > 0) {
-    renderJudgeTable(doc, team)
-    renderFeedback(doc, team)
-  }
+  if (team.scoredFromWriteup) callout(doc, WRITEUP_NOTE)
+
+  renderMembers(doc, team)
+  if (analysis) renderAnalysis(doc, analysis)
+  renderSubmission(doc, team)
+  renderJudging(doc, team)
 }
 
-// ─── Footer pass ─────────────────────────────────────────────────────────────
+// ─── Appendix ────────────────────────────────────────────────────────────────
 
-/** Page numbers on every page but the cover, via buffered pages. */
-function renderFooters(doc: Doc): void {
+function renderAppendix(doc: Doc, data: ResultsExport, state: RenderState): void {
+  sectionOpener(
+    doc,
+    "Appendix",
+    "The rest of the room",
+    "A complete record includes the teams that formed but did not submit, and the builders " +
+      "who registered without landing on a frozen team. They were part of the night too."
+  )
+  markSection(doc, state, "Appendix — the rest of the room")
+
+  const noSubmission = data.teams.filter((t) => t.submission === null)
+  if (noSubmission.length > 0) {
+    kicker(doc, `Teams that formed but did not submit (${noSubmission.length})`, DIM)
+    doc
+      .font(SANS)
+      .fontSize(8.5)
+      .fillColor(DIM)
+      .text(noSubmission.map((t) => t.teamName).join("  ·  "), MARGIN, doc.y, {
+        width: CONTENT_WIDTH,
+        lineGap: 2.5,
+      })
+    doc.moveDown(1)
+  }
+
+  if (data.unassignedParticipants.length > 0) {
+    ensureSpace(doc, 60)
+    kicker(doc, `Registered but not on a frozen team (${data.unassignedParticipants.length})`, DIM)
+    doc
+      .font(SANS)
+      .fontSize(8.5)
+      .fillColor(DIM)
+      .text(
+        data.unassignedParticipants
+          .map((m) => `${m.fullName} — ${m.primaryRole}`)
+          .join("  ·  "),
+        MARGIN,
+        doc.y,
+        { width: CONTENT_WIDTH, lineGap: 2.5 }
+      )
+    doc.moveDown(1)
+  }
+
+  ensureSpace(doc, 50)
+  kicker(doc, "About this document", DIM)
+  doc
+    .font(SANS)
+    .fontSize(8.5)
+    .fillColor(DIM)
+    .text(
+      `Produced by ${EVENT_HOST} from the event's operational records. Scores, submissions and ` +
+        "judge notes are reproduced exactly as recorded; provenance for every element is stated " +
+        "in “How this record was produced”. Contact details are deliberately omitted.",
+      MARGIN,
+      doc.y,
+      { width: CONTENT_WIDTH, lineGap: 2.5 }
+    )
+}
+
+// ─── Page furniture pass ─────────────────────────────────────────────────────
+
+/**
+ * Running headers and page numbers on every page after the cover, written in
+ * a final pass over the buffered pages. The section for each page is the last
+ * TOC mark at or before it.
+ */
+function renderFurniture(doc: Doc, state: RenderState): void {
   const range = doc.bufferedPageRange()
+  const sections = state.toc.filter((e) => e.level === 0)
   for (let i = range.start + 1; i < range.start + range.count; i++) {
     doc.switchToPage(i)
-    // Writing inside the bottom margin would otherwise trigger an automatic
-    // page add — a classic pdfkit footer gotcha.
+    const printed = i + 1
+    // Writing inside the margins would trigger an automatic page add — the
+    // classic pdfkit footer gotcha — so lift them for the furniture pass.
     doc.page.margins.bottom = 0
+    doc.page.margins.top = 0
+
+    const section = [...sections].reverse().find((e) => e.page <= printed)
+    const isContents = i === state.tocPageIndex
+    doc
+      .font(SANS)
+      .fontSize(6.5)
+      .fillColor(FAINT)
+      .text(
+        (isContents ? "Contents" : (section?.title ?? "")).toUpperCase(),
+        MARGIN,
+        HEADER_Y,
+        { characterSpacing: 1, width: CONTENT_WIDTH / 2, lineBreak: false }
+      )
+    doc.text(`${EVENT_TITLE} · ${EVENT_DATES}`.toUpperCase(), MARGIN + CONTENT_WIDTH / 2, HEADER_Y, {
+      characterSpacing: 1,
+      width: CONTENT_WIDTH / 2,
+      align: "right",
+      lineBreak: false,
+    })
+    doc
+      .moveTo(MARGIN, HEADER_Y + 11)
+      .lineTo(MARGIN + CONTENT_WIDTH, HEADER_Y + 11)
+      .lineWidth(0.4)
+      .strokeColor(RULE)
+      .stroke()
+
     doc
       .font(SANS)
       .fontSize(7.5)
       .fillColor(FAINT)
-      .text(`${EVENT_TITLE} — Results`, MARGIN, FOOTER_Y, {
+      .text(`${EVENT_HOST} — hackathon results`, MARGIN, FOOTER_Y, {
         width: CONTENT_WIDTH / 2,
         lineBreak: false,
       })
-    doc.text(`Page ${i + 1} of ${range.count}`, MARGIN + CONTENT_WIDTH / 2, FOOTER_Y, {
+    doc.text(`Page ${printed} of ${range.count}`, MARGIN + CONTENT_WIDTH / 2, FOOTER_Y, {
       width: CONTENT_WIDTH / 2,
       align: "right",
       lineBreak: false,
     })
     doc.page.margins.bottom = 60
+    doc.page.margins.top = MARGIN
   }
 }
 
 // ─── Entry point ─────────────────────────────────────────────────────────────
 
-/** Build the complete PDF and resolve with a Node buffer to stream. */
-export function buildResultsPdf(data: ResultsExport): Promise<Buffer> {
+/**
+ * Build the complete PDF and resolve with a Node buffer to stream. Analyses
+ * are optional by construction: a missing entry means that team's analysis
+ * section is simply absent (see export-analysis's fail-soft rule).
+ */
+export function buildResultsPdf(
+  data: ResultsExport,
+  analyses: ReadonlyMap<string, TeamAnalysis> = new Map()
+): Promise<Buffer> {
   return new Promise<Buffer>((resolve, reject) => {
     const doc = new PDFDocument({
       size: "A4",
@@ -599,7 +1402,7 @@ export function buildResultsPdf(data: ResultsExport): Promise<Buffer> {
       info: {
         Title: `${EVENT_TITLE} — Results`,
         Author: EVENT_HOST,
-        Subject: `Hackathon results, ${EVENT_DATES}`,
+        Subject: `Hackathon results, ${EVENT_DATES}, ${EVENT_LOCATION}`,
       },
     })
     const chunks: Buffer[] = []
@@ -607,13 +1410,33 @@ export function buildResultsPdf(data: ResultsExport): Promise<Buffer> {
     doc.on("end", () => resolve(Buffer.concat(chunks)))
     doc.on("error", reject)
 
+    const state: RenderState = { toc: [], tocPageIndex: 1 }
+
     renderCover(doc, data)
-    renderWinners(doc, data)
-    renderRanking(doc, data)
-    for (const team of data.teams.filter((t) => t.submission !== null)) {
-      renderTeamPage(doc, team)
+    reserveContentsPage(doc, state)
+    renderMethodology(doc, data, state)
+    renderEventInNumbers(doc, data, state)
+    renderWinners(doc, data, state)
+    renderRanking(doc, data, state)
+
+    const profiled = data.teams.filter((t) => t.submission !== null)
+    if (profiled.length > 0) {
+      // The profiles section mark points at the first profile page.
+      const first = profiled[0]
+      renderTeamProfile(doc, first, analyses.get(first.teamId), state)
+      state.toc.splice(state.toc.length - 1, 0, {
+        title: "Team profiles",
+        page: state.toc[state.toc.length - 1].page,
+        level: 0,
+      })
+      for (const team of profiled.slice(1)) {
+        renderTeamProfile(doc, team, analyses.get(team.teamId), state)
+      }
     }
-    renderFooters(doc)
+    renderAppendix(doc, data, state)
+
+    renderContents(doc, state)
+    renderFurniture(doc, state)
 
     doc.end()
   })

--- a/src/lib/impact-lab/export-theme.ts
+++ b/src/lib/impact-lab/export-theme.ts
@@ -1,0 +1,45 @@
+/**
+ * Impact Lab results export — the shared visual language of the PDF.
+ *
+ * The palette is the community's "Pro" persona, which is deliberately the
+ * Anthropic brand palette (see `globals.css` — persona-pro maps the site
+ * tokens onto #141413 / #faf9f5 / #d97757 / #6a9bcc / #788c5d). So one set of
+ * constants makes the document read as belonging to Claude Community Kenya
+ * AND sit comfortably in front of Anthropic — they are the same colours.
+ *
+ * Every pairing here survives greyscale: ink/paper carry the text, CLAY sits
+ * at a mid lightness clearly darker than TRACK, and no chart uses colour as
+ * the only carrier of meaning — labels and position always travel with it.
+ */
+
+/** Near-black ink — Anthropic dark, and the Pro persona background token. */
+export const INK = "#141413"
+/** Warm paper — Anthropic light. Cover and callout fill. */
+export const PAPER = "#faf9f5"
+/** Primary accent (terracotta). The single data hue for magnitude. */
+export const CLAY = "#d97757"
+/** Darker clay for small text that must clear contrast on white. */
+export const CLAY_DEEP = "#b45a3c"
+/** Secondary accent — used sparingly, never as a second data hue. */
+export const SLATE_BLUE = "#6a9bcc"
+/** Tertiary accent — the community's green, print-safe. */
+export const OLIVE = "#788c5d"
+/** Secondary text. */
+export const DIM = "#57554d"
+/** Tertiary text — captions, page furniture. */
+export const FAINT = "#8a887f"
+/** Mid gray — Anthropic's secondary element tone. */
+export const MID_GRAY = "#b0aea5"
+/** Subtle fill — chart tracks, zebra tints. Anthropic light gray. */
+export const TRACK = "#e8e6dc"
+/** Hairlines. */
+export const RULE = "#d6d4ca"
+/** Warm tint for provenance callouts. */
+export const CALLOUT_BG = "#f4efe6"
+
+/** pdfkit built-in faces: serif display, sans text — no font files to ship. */
+export const SERIF = "Times-Roman"
+export const SERIF_ITALIC = "Times-Italic"
+export const SANS = "Helvetica"
+export const SANS_BOLD = "Helvetica-Bold"
+export const SANS_ITALIC = "Helvetica-Oblique"


### PR DESCRIPTION
## What this is

The Impact Lab results export, rebuilt as the permanent public record of Kenya's first Claude hackathon — the document going to Anthropic. The data assembly and its two honesty rules (announced placings vs score order; writeup-scored basis travelling with every score) are unchanged and extended; everything a reader sees is new.

## The PDF (the artefact that gets shared)

- **Cover → contents → methodology → infographic spread → winners → full ranking → one profile per team → appendix**, with running section headers, page numbers, and a contents page whose per-team page numbers are filled in after layout.
- **"How this record was produced" sits up front**: scoring model with criteria, weights and anchors; judging coverage (computed: 2–4 judges per team); how the podium was decided (panel deliberation, not score order); whose words are whose; and what is deliberately omitted.
- **Charts** (pure pdfkit vectors): score-distribution histogram, per-track comparison with participation sublabels, judging-coverage bars, judge-panel calibration dots, per-team five-criterion profiles, and per-team judge-spread strips. All zero-anchored, single data hue, greyscale-safe; the judge-disagreement finding is computed from the data, never asserted.
- **Palette**: the site's Pro persona tokens — which are the Anthropic brand palette — so the document belongs to both parties at once.

## The judge-comment problem, handled

- The **10 real notes** print verbatim, in quotes, attributed, under "Judge notes — recorded during judging, verbatim". Nothing padded, nothing extended.
- Every team with a submission gets a **Project analysis** generated at export time from its own submission (`generateObject` + `claude-sonnet-5`, same pattern as `judging/assist`), boxed in the profile section and opened with *"Written after the event from the team's own submission. Not judge commentary."* The system prompt forbids evaluation, inference beyond the text, and any mention of judges. Generation failures leave the section absent — never a placeholder.

## The workbook

New **Judges**, **Tracks**, and **Project analyses** sheets (analyses carry the provenance sentence on every row); judge **low/high/spread** columns; **data bars anchored 0→100** (never min–max, which exaggerates gaps); criteria/weights and a written provenance section in Summary. Frozen headers, autofilter, wrapped prose, no merged cells in data ranges — as before.

## Participant emails

**The PDF contains no email addresses** — participants' or judges'. Names, roles and institutions stay; contact details for 136 people do not belong in a shareable artefact, and a toggle would just be a foot-gun. The workbook (admin-gated, the operational record) keeps them and now says so explicitly in its Summary.

## Deliberately left out / known limits

- PDF uses pdfkit's built-in Times/Helvetica rather than embedding brand TTFs — shipping font binaries in the repo for a serverless route wasn't worth it; the craft budget went to layout and charts.
- exceljs cannot create native Excel charts; the honest 0–100 data bars are the in-cell equivalent. Its typings omit the data-bar `color` the writer supports at runtime — typed via a local interface extension, worth one open-in-Excel check.
- Analyses add ~30–60s to an export (`maxDuration = 300`); `?analyses=off` skips them for a fast pull.
- Verified from synthetic fixtures (local DB is decommissioned): tsc, build, verify:judging, verify:results all clean, and the rendered PDF inspected page by page. No real participant data was written anywhere; the fixture script was deleted.

@Spidey-Acer

https://claude.ai/code/session_01C7ezG1ndnTmCV1anEi3iGC