### PR TITLE
feat(impact-lab): written feedback for all 27 teams — judge notes quoted, community reviews drafted, edited, and approved

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "verify:rematch": "tsx scripts/verify-rematch.ts",
     "verify:judging": "tsx scripts/verify-judging.ts",
     "verify:results": "tsx scripts/verify-results.ts",
+    "verify:reviews": "tsx scripts/verify-reviews.ts",
     "import:manual-teams": "tsx scripts/import-manual-teams.ts"
   },
   "prisma": {

--- a/prisma/migrations/20260728120000_impact_lab_team_reviews/migration.sql
+++ b/prisma/migrations/20260728120000_impact_lab_team_reviews/migration.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "impact_lab_team_reviews" (
+  "id" TEXT NOT NULL,
+  "cohort" TEXT NOT NULL,
+  "runId" TEXT NOT NULL,
+  "teamId" TEXT NOT NULL,
+  "text" TEXT NOT NULL,
+  "generatedBy" TEXT NOT NULL,
+  "editedAt" TIMESTAMP(3),
+  "editedBy" TEXT,
+  "approvedAt" TIMESTAMP(3),
+  "approvedBy" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "impact_lab_team_reviews_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "impact_lab_team_reviews_runId_teamId_key"
+  ON "impact_lab_team_reviews" ("runId", "teamId");
+
+CREATE INDEX "impact_lab_team_reviews_cohort_idx"
+  ON "impact_lab_team_reviews" ("cohort");
+
+ALTER TABLE "impact_lab_team_reviews"
+  ADD CONSTRAINT "impact_lab_team_reviews_runId_fkey"
+  FOREIGN KEY ("runId") REFERENCES "impact_lab_match_runs"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -741,6 +741,7 @@ model ImpactLabMatchRun {
   resultsEmails        ImpactLabResultsEmail[]
   submissions          ImpactLabSubmission[]
   scores               ImpactLabScore[]
+  teamReviews          ImpactLabTeamReview[]
   createdById          String?
   createdBy            User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdAt            DateTime @default(now())
@@ -827,6 +828,49 @@ model ImpactLabScore {
   @@unique([runId, teamId, judgeEmail])
   @@index([cohort, teamId])
   @@map("impact_lab_scores")
+}
+
+/// One written review per team, from the community — not from any judge.
+///
+/// Three of the four judges left scores and no written feedback, so a team
+/// that built through the night would otherwise receive five numbers and
+/// silence. This row is the community's substantive review of that team's
+/// submission, signed "Claude Community Kenya" wherever it is shown. It is
+/// keyed per team (not per judge) precisely so it can never be mistaken for,
+/// or merged into, a judge's scorecard — judge words live only in
+/// ImpactLabScore.feedback, written by the judge named on that row.
+///
+/// Nothing publishes unapproved: every surface that shows `text` to a
+/// participant (dashboard, results email, exports) requires approvedAt to be
+/// non-null. Drafts are generated; the organiser edits, then approves.
+model ImpactLabTeamReview {
+  id      String @id @default(cuid())
+  cohort  String
+  runId   String
+  /// Team id from the run's result JSON — teams have no table, so no FK.
+  teamId  String
+  /// The review as it will publish. Starts as a generated draft; the
+  /// organiser may rewrite any of it before approving.
+  text    String @db.Text
+  /// Provenance of the current draft: the model id for generated text, or
+  /// the organiser's email once they have hand-written/edited it.
+  generatedBy String
+  /// Set when an organiser saves an edit. A non-null value protects the text:
+  /// regeneration refuses to overwrite it unless explicitly forced.
+  editedAt DateTime?
+  editedBy String?
+  /// The publish gate. Only reviews with approvedAt set reach participants.
+  approvedAt DateTime?
+  approvedBy String?
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  run ImpactLabMatchRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+
+  /// One review per team per run: regeneration edits the row, never doubles it.
+  @@unique([runId, teamId])
+  @@index([cohort])
+  @@map("impact_lab_team_reviews")
 }
 
 /// One row per intended recipient of the results email. This is what makes the

--- a/scripts/verify-reviews.ts
+++ b/scripts/verify-reviews.ts
@@ -1,0 +1,184 @@
+/**
+ * Impact Lab team reviews — verification harness.
+ *
+ * Follows scripts/verify-results.ts. The rules asserted here decide what
+ * words reach 27 teams and whose name those words carry, so the hard rule —
+ * never attribute written words to a judge who did not write them — is
+ * asserted rather than trusted, along with the publish gate (nothing
+ * unapproved reaches a participant) and the note-correction table (spelling
+ * and casing only, one audited fragment omitted, everything else verbatim).
+ *
+ * Run with: npm run verify:reviews
+ */
+
+import {
+  presentableJudgeNote,
+  publishableReview,
+  REVIEW_SIGNATURE,
+} from "../src/lib/impact-lab/reviews"
+import { buildMemberPayload, buildSnapshot, type ResultsInput } from "../src/lib/impact-lab/results"
+import type { TeamStanding } from "../src/lib/impact-lab/judging"
+
+let failures = 0
+
+function assert(condition: boolean, message: string): void {
+  if (condition) {
+    console.log(`  ✓ ${message}`)
+  } else {
+    console.error(`  ✗ ${message}`)
+    failures += 1
+  }
+}
+
+console.log("\nJudge note corrections — spelling and casing only, nothing added")
+assert(
+  presentableJudgeNote(
+    "Build in programatic access and after you're live get a data protection certificate"
+  ) === "Build in programmatic access and after you're live get a data protection certificate",
+  "'programatic' is corrected to 'programmatic', the rest untouched"
+)
+assert(
+  presentableJudgeNote("Brillant\nPlease pilot it") === "Brilliant\nPlease pilot it",
+  "'Brillant' is corrected to 'Brilliant', the second line untouched"
+)
+assert(
+  presentableJudgeNote("Create a chrome extension or mobile app") ===
+    "Create a Chrome extension or mobile app",
+  "'chrome' gains its proper-noun capital, nothing else changes"
+)
+assert(
+  presentableJudgeNote("Please build in the Product") === "Please build in the product",
+  "'Product' loses its stray capital, nothing else changes"
+)
+assert(
+  presentableJudgeNote("Please pilot!!!") === "Please pilot!!!",
+  "her exclamation marks are hers — they stay"
+)
+assert(
+  presentableJudgeNote("Please talk to some medics") === "Please talk to some medics",
+  "a clean note passes through byte-identical"
+)
+
+console.log("\nThe omitted fragment")
+assert(
+  presentableJudgeNote("Please") === null,
+  "the bare 'Please' fragment is omitted entirely, never published"
+)
+assert(
+  presentableJudgeNote("  Please  ") === null,
+  "the fragment is omitted regardless of surrounding whitespace"
+)
+
+console.log("\nUnknown and empty notes")
+assert(
+  presentableJudgeNote("A note nobody audited") === "A note nobody audited",
+  "an unaudited note is shown verbatim — the judge's own words are always safe"
+)
+assert(
+  presentableJudgeNote("Brillant\r\nPlease pilot it") === "Brilliant\nPlease pilot it",
+  "CRLF line endings still match the correction table"
+)
+assert(presentableJudgeNote(null) === null, "null feedback publishes nothing")
+assert(presentableJudgeNote("   ") === null, "whitespace-only feedback publishes nothing")
+
+console.log("\nExactly nine of the ten stored notes publish")
+const storedNotes = [
+  "Build in programatic access and after you're live get a data protection certificate",
+  "Brillant\nPlease pilot it",
+  "Brilliant product\nFocus on what you've built and share it",
+  "Please talk to some medics",
+  "Create a chrome extension or mobile app",
+  "Please pilot!!!",
+  "Please build in the Product",
+  "Please",
+  "Use images and a chat partner instead",
+  "Please talk to businesses and investors",
+]
+const published = storedNotes
+  .map((n) => presentableJudgeNote(n))
+  .filter((n): n is string => n !== null)
+assert(published.length === 9, "nine notes publish; only the fragment is dropped")
+assert(
+  published.every((n) => n.length > 0),
+  "no published note is empty"
+)
+
+console.log("\nThe publish gate — nothing unapproved reaches a participant")
+assert(
+  publishableReview({ text: "A good review.", approvedAt: null }) === null,
+  "an unapproved draft never publishes, however finished it looks"
+)
+assert(
+  publishableReview({ text: "A good review.", approvedAt: new Date() }) === "A good review.",
+  "an approved review publishes its text"
+)
+assert(
+  publishableReview({ text: "A good review.", approvedAt: "2026-07-28T10:00:00Z" }) ===
+    "A good review.",
+  "an ISO-string approvedAt (as it arrives over the wire) also passes the gate"
+)
+assert(
+  publishableReview({ text: "   ", approvedAt: new Date() }) === null,
+  "an approved-but-empty review publishes nothing rather than blank space"
+)
+assert(publishableReview(null) === null, "no review row publishes nothing")
+assert(publishableReview(undefined) === null, "an absent row publishes nothing")
+
+console.log("\nMember payload — feedback rides only inside yourTeam")
+const standing = (teamId: string, average: number): TeamStanding => ({
+  teamId,
+  average,
+  judgeCount: 2,
+  criterionAverages: { impact: 4, demo: 4, claude: 4, clarity: 4, presentation: 4 },
+})
+const input: ResultsInput = {
+  publishedAt: "2026-07-27T09:00:00.000Z",
+  announcedTeamIds: [],
+  standings: [standing("t-a", 70), standing("t-b", 60)],
+  teams: new Map([
+    ["t-a", { projectName: "A", track: "Afya (Health)" }],
+    ["t-b", { projectName: "B", track: "Afya (Health)" }],
+  ]),
+  writeupOnly: new Set(),
+  range: new Map(),
+}
+const snap = buildSnapshot(input)
+const feedback = {
+  judgeNotes: [{ judgeName: "Favour", text: "Please pilot!!!" }],
+  review: "You built something specific and it shows.",
+}
+
+const withTeam = buildMemberPayload(snap, "t-a", feedback)
+assert(
+  withTeam.yourTeam?.review?.text === feedback.review &&
+    withTeam.yourTeam.review.signedBy === REVIEW_SIGNATURE,
+  "the review arrives signed by the community — the signature crosses the wire with the words"
+)
+assert(
+  withTeam.yourTeam?.judgeNotes?.length === 1 &&
+    withTeam.yourTeam.judgeNotes[0].judgeName === "Favour",
+  "a judge's note arrives under the judge's own name"
+)
+assert(
+  !JSON.stringify(withTeam.yourTeam?.review).includes("judgeName"),
+  "the review payload carries no judge identity anywhere — it cannot be dressed as a judge's"
+)
+
+const noTeam = buildMemberPayload(snap, null, feedback)
+assert(
+  !("yourTeam" in noTeam) && !JSON.stringify(noTeam).includes("Favour"),
+  "a viewer with no resolvable team receives no feedback at all, even when the caller passes some"
+)
+
+const noReview = buildMemberPayload(snap, "t-a", { judgeNotes: [], review: null })
+assert(
+  noReview.yourTeam !== undefined &&
+    !("review" in noReview.yourTeam) &&
+    !("judgeNotes" in noReview.yourTeam),
+  "empty feedback attaches no keys at all — absence is absence, not null"
+)
+
+console.log(
+  failures === 0 ? "\nALL CHECKS PASSED\n" : `\n${failures} CHECK(S) FAILED\n`
+)
+process.exit(failures === 0 ? 0 : 1)

--- a/src/app/api/admin/impact-lab/results/export/route.ts
+++ b/src/app/api/admin/impact-lab/results/export/route.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/impact-lab/export-data"
 import { buildResultsWorkbook } from "@/lib/impact-lab/export-excel"
 import { buildResultsPdf } from "@/lib/impact-lab/export-pdf"
+import { publishableReview } from "@/lib/impact-lab/reviews"
 
 /**
  * GET /api/admin/impact-lab/results/export?cohort=…&format=xlsx|pdf
@@ -51,7 +52,7 @@ export async function GET(request: NextRequest) {
 
   const teams = extractFrozenTeams(run.result) ?? []
 
-  const [participants, submissions, scores] = await Promise.all([
+  const [participants, submissions, scores, reviewRows] = await Promise.all([
     prisma.impactLabParticipant.findMany({
       where: { cohort },
       select: {
@@ -91,6 +92,10 @@ export async function GET(request: NextRequest) {
         writeupOnly: true,
       },
     }),
+    prisma.impactLabTeamReview.findMany({
+      where: { runId: run.id },
+      select: { teamId: true, text: true, approvedAt: true },
+    }),
   ])
 
   const source: ExportSource = {
@@ -120,6 +125,12 @@ export async function GET(request: NextRequest) {
       feedback: s.feedback,
       writeupOnly: s.writeupOnly,
     })),
+    // Approved reviews only — publishableReview is the gate every
+    // participant-facing surface shares; drafts never leave the admin panel.
+    reviews: reviewRows.flatMap((r) => {
+      const text = publishableReview(r)
+      return text === null ? [] : [{ teamId: r.teamId, text }]
+    }),
   }
 
   const data = buildResultsExport(source)

--- a/src/app/api/admin/impact-lab/results/notify/route.ts
+++ b/src/app/api/admin/impact-lab/results/notify/route.ts
@@ -8,6 +8,7 @@ import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { safeCohort } from "@/lib/impact-lab/constants"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { isResultsSnapshot } from "@/lib/impact-lab/results"
+import { loadTeamFeedback } from "@/lib/impact-lab/results-input"
 import { APP_URL, impactLabResultsEmail, sendEmailBatchTracked, type BatchEmailItem } from "@/lib/email"
 
 /**
@@ -238,6 +239,19 @@ export async function POST(request: NextRequest) {
   })
   const nameById = new Map(participants.map((p) => [p.id, p.fullName]))
 
+  // Written feedback (judge notes + approved community review) for every team
+  // in this batch, in one query pair — same gates as the dashboard, so an
+  // email can never carry words its team's dashboard would not show.
+  const batchTeamIds = [
+    ...new Set(
+      lockedRows.flatMap((row) => {
+        const team = run.teams.find((t) => t.memberIds.includes(row.participantId))
+        return team ? [team.id] : []
+      })
+    ),
+  ]
+  const feedbackByTeam = await loadTeamFeedback(prisma, run.runId, batchTeamIds)
+
   const sendable: { row: LockedRow; item: BatchEmailItem }[] = []
   const unmatched: { row: LockedRow; error: string }[] = []
 
@@ -262,6 +276,8 @@ export async function POST(request: NextRequest) {
       overall: run.snapshot.overall,
       trackWinners: run.snapshot.trackWinners,
       dashboardUrl,
+      judgeNotes: feedbackByTeam.get(team.id)?.judgeNotes ?? [],
+      communityReview: feedbackByTeam.get(team.id)?.review ?? null,
     })
     sendable.push({ row, item: { to: row.email, subject: built.subject, html: built.html } })
   }

--- a/src/app/api/admin/impact-lab/results/preview-email/route.ts
+++ b/src/app/api/admin/impact-lab/results/preview-email/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { checkApiPermission } from "@/lib/rbac"
 import { safeCohort } from "@/lib/impact-lab/constants"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
-import { buildResultsInputFromRun } from "@/lib/impact-lab/results-input"
+import { buildResultsInputFromRun, loadTeamFeedback } from "@/lib/impact-lab/results-input"
 import { buildSnapshot, isResultsSnapshot, type ResultsInput, type ResultsSnapshot } from "@/lib/impact-lab/results"
 import { APP_URL, impactLabResultsEmail } from "@/lib/email"
 
@@ -140,6 +140,12 @@ export async function GET(request: NextRequest) {
     )
   }
 
+  // Same feedback loader and gates as the batch send: judge notes quoted
+  // under the judge's name, community review only once approved. The preview
+  // therefore shows exactly what would go out — an unapproved draft is
+  // absent here precisely because it would be absent from the real send.
+  const feedback = (await loadTeamFeedback(prisma, run.id, [teamId])).get(teamId)
+
   const dashboardUrl = `${APP_URL}/dashboard/impact-lab`
   const built = impactLabResultsEmail({
     // The batch send personalises this per recipient; a team's email is
@@ -157,6 +163,8 @@ export async function GET(request: NextRequest) {
     overall: snapshot.overall,
     trackWinners: snapshot.trackWinners,
     dashboardUrl,
+    judgeNotes: feedback?.judgeNotes ?? [],
+    communityReview: feedback?.review ?? null,
   })
 
   return NextResponse.json({

--- a/src/app/api/admin/impact-lab/reviews/route.ts
+++ b/src/app/api/admin/impact-lab/reviews/route.ts
@@ -1,0 +1,558 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { generateObject } from "ai"
+import { createAnthropic } from "@ai-sdk/anthropic"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit } from "@/lib/rate-limit"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import { extractFrozenTeams } from "@/lib/impact-lab/member"
+import {
+  JUDGING_CRITERIA,
+  standings,
+  trackOf,
+  type ScoreSheet,
+} from "@/lib/impact-lab/judging"
+import { presentableJudgeNote, type TeamJudgeNote } from "@/lib/impact-lab/reviews"
+
+/**
+ * The Impact Lab review — one substantive written review per team, signed
+ * "Claude Community Kenya".
+ *
+ * Why this exists: four judges scored 73 sheets across five criteria, and
+ * three of the four never wrote a word of feedback. A team that built through
+ * the night would receive five numbers and silence. This route drafts the
+ * words that close that gap, and gives the organiser the pen: every draft is
+ * editable, and nothing reaches a participant until the organiser has read it
+ * and pressed Approve (see `publishableReview` in @/lib/impact-lab/reviews —
+ * the gate every participant-facing surface goes through).
+ *
+ * Provenance is structural, not stylistic: the review is stored per team,
+ * never per judge, and every surface labels it as the community's review. A
+ * judge's actual words live only in ImpactLabScore.feedback and are quoted
+ * under that judge's name — the two streams never mix.
+ *
+ * Reviews deliberately still work after judging closes and results publish:
+ * they are commentary on the submission, not scores, so `judgingClosedAt`
+ * does not block them the way it blocks the scoring routes.
+ */
+
+// Generating a batch of reviews is several sequential model calls; the 300s
+// platform ceiling is why the batch below is small and resumable rather than
+// "all 23 in one request".
+export const maxDuration = 300
+
+// Same model as the judging assist and writeup-draft routes.
+const MODEL = "claude-sonnet-5"
+const anthropic = createAnthropic()
+
+/** Teams drafted per generate call; the client calls again until none remain. */
+const GENERATE_BATCH = 4
+
+const reviewSchema = z.object({
+  paragraphs: z
+    .array(z.string().min(40))
+    .min(3)
+    .max(4)
+    .describe(
+      "Three to four short paragraphs, each two to four sentences, addressed to the team."
+    ),
+})
+
+const SYSTEM = `You are writing the review a hackathon team receives for their project, on behalf of Claude Community Kenya — the community that hosted Impact Lab: AI Mashinani, where roughly 135 people built through the night. The judging panel returned scores but almost no written feedback, so this review is the community making sure a team that built all night receives real words about their work, not five numbers and silence.
+
+You write as the community, never as a judge. Do not mention any judge, do not speculate about what the panel thought, and do not present any opinion as the panel's. The scores are context for you, not something to explain or defend — the team can already see their own numbers, so never quote or restate them.
+
+Write three to four short paragraphs, addressed directly to the team as "you".
+
+Ground every claim in what the team wrote. If a sentence could not be traced back to their own submission, cut it. If the submission does not say something, do not infer it — "your writeup does not say who runs this day to day" is honest feedback; guessing an answer for them is not. Name the specific thing they built and what is genuinely interesting or difficult about it. The test: the team should read this and know it could not have been written about any other project in the room.
+
+Be honest about weaknesses, and kind in how you say it. Where a team openly said what was mocked or unfinished, treat that honesty as the professional act it is — acknowledge it plainly, then talk straight about the gap it reveals. A team that scored low still receives something useful and human: what the strongest idea in their submission is, and the one thing that most held it back. Never pad, never console, never perform enthusiasm.
+
+End with one or two concrete next steps for this specific project — actions the team could start this week, drawn from what they said they built and where they said it stops. Not "keep going": name the step.
+
+If the prompt includes a judge's handwritten note, your review will be shown directly beside that note. Do not repeat its advice, do not contradict it, and do not refer to it or its author — write feedback that stands on its own next to it.
+
+Style: plain English, warm and direct, written for adults who built something. No Swahili words. No exclamation marks. No hype. No greeting and no sign-off — the page this appears on adds the signature. Use the project's name at most twice.`
+
+const bodySchema = z.discriminatedUnion("action", [
+  z.object({
+    action: z.literal("generate"),
+    teamId: z.string().min(1).max(64).optional(),
+    /** Required to overwrite a review the organiser has edited or approved. */
+    force: z.boolean().optional(),
+  }),
+  z.object({
+    action: z.literal("save"),
+    teamId: z.string().min(1).max(64),
+    text: z.string().min(1).max(8000),
+  }),
+  z.object({ action: z.literal("approve"), teamId: z.string().min(1).max(64) }),
+  z.object({ action: z.literal("unapprove"), teamId: z.string().min(1).max(64) }),
+])
+
+interface SubmissionRow {
+  teamId: string
+  projectName: string
+  pitch: string
+  description: string
+  worksVsMocked: string
+  claudeUsage: string
+  track: string
+  problemTackled: string
+}
+
+interface TeamContext {
+  submission: SubmissionRow
+  teamName: string
+  criterionAverages: Record<string, number> | null
+  writeupOnly: boolean
+  judgeNote: string | null
+}
+
+function buildPrompt(ctx: TeamContext): string {
+  const s = ctx.submission
+
+  const scoreLines = ctx.criterionAverages
+    ? JUDGING_CRITERIA.map((c) => {
+        const value = ctx.criterionAverages?.[c.key]
+        return `- ${c.label}: ${typeof value === "number" ? value.toFixed(1) : "—"} / 5`
+      }).join("\n")
+    : "This team was never scored."
+
+  const basisLine = ctx.criterionAverages
+    ? ctx.writeupOnly
+      ? "These scores came from the written submission only — no judge reached their table for a live demo."
+      : "These scores came from live demos at the team's table."
+    : ""
+
+  const noteBlock = ctx.judgeNote
+    ? `\nA judge's handwritten note will be shown beside your review:\n"${ctx.judgeNote}"\n`
+    : ""
+
+  return `The team's submission:
+
+Project: ${s.projectName}
+Track: ${s.track}
+One-line pitch: ${s.pitch}
+Problem tackled: ${s.problemTackled}
+What it does: ${s.description}
+What works vs what is mocked: ${s.worksVsMocked}
+How they used Claude: ${s.claudeUsage}
+
+Panel averages per criterion, for your context only (never restate them):
+${scoreLines}
+${basisLine}
+${noteBlock}`
+}
+
+/**
+ * One generation attempt with one retry — the same error discipline as the
+ * writeup-draft route. Returns the review text (paragraphs joined by blank
+ * lines) or null when both attempts failed.
+ */
+async function generateReview(ctx: TeamContext): Promise<string | null> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      const { object } = await generateObject({
+        model: anthropic(MODEL),
+        schema: reviewSchema,
+        system: SYSTEM,
+        prompt: buildPrompt(ctx),
+        maxOutputTokens: 1_500,
+      })
+      return object.paragraphs.map((p) => p.trim()).join("\n\n")
+    } catch (error) {
+      console.error(
+        `[impact-lab/reviews] generation attempt ${attempt + 1} failed for ${ctx.submission.projectName}`,
+        error
+      )
+    }
+  }
+  return null
+}
+
+async function loadFinalRun(cohort: string) {
+  return prisma.impactLabMatchRun.findFirst({
+    where: { cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true },
+  })
+}
+
+/**
+ * Everything generation and the GET listing need about a run's teams:
+ * submissions in full, per-team criterion averages, scoring basis, and the
+ * (corrected) judge notes.
+ */
+async function loadTeamContexts(runId: string, runResult: unknown) {
+  const teams = extractFrozenTeams(runResult) ?? []
+  const nameById = new Map(teams.map((t) => [t.id, t.name]))
+
+  const [submissions, scores] = await Promise.all([
+    prisma.impactLabSubmission.findMany({
+      where: { runId },
+      select: {
+        teamId: true,
+        projectName: true,
+        pitch: true,
+        description: true,
+        worksVsMocked: true,
+        claudeUsage: true,
+        track: true,
+        problemTackled: true,
+      },
+    }),
+    prisma.impactLabScore.findMany({
+      where: { runId },
+      select: {
+        teamId: true,
+        judgeName: true,
+        scores: true,
+        feedback: true,
+        writeupOnly: true,
+      },
+    }),
+  ])
+
+  const table = standings(
+    scores.map((s, i) => ({
+      // standings() groups by judge+team via the caller's rows; judge identity
+      // is irrelevant here beyond keeping rows distinct.
+      judgeEmail: String(i),
+      teamId: s.teamId,
+      sheet: (s.scores ?? {}) as ScoreSheet,
+    }))
+  )
+  const standingByTeam = new Map(table.map((t) => [t.teamId, t]))
+
+  const writeupOnlyTeams = new Set<string>()
+  const scoresByTeam = new Map<string, typeof scores>()
+  for (const s of scores) {
+    const list = scoresByTeam.get(s.teamId)
+    if (list) list.push(s)
+    else scoresByTeam.set(s.teamId, [s])
+  }
+  for (const [teamId, rows] of scoresByTeam) {
+    if (rows.every((r) => r.writeupOnly)) writeupOnlyTeams.add(teamId)
+  }
+
+  /** Corrected judge notes per team — the judge's own words only. */
+  const judgeNotesByTeam = new Map<string, TeamJudgeNote[]>()
+  for (const s of scores) {
+    const text = presentableJudgeNote(s.feedback)
+    if (text === null) continue
+    const list = judgeNotesByTeam.get(s.teamId) ?? []
+    list.push({ judgeName: s.judgeName, text })
+    judgeNotesByTeam.set(s.teamId, list)
+  }
+
+  const contextFor = (submission: SubmissionRow): TeamContext => ({
+    submission,
+    teamName: nameById.get(submission.teamId) ?? submission.teamId,
+    criterionAverages: standingByTeam.get(submission.teamId)?.criterionAverages ?? null,
+    writeupOnly: writeupOnlyTeams.has(submission.teamId),
+    judgeNote:
+      judgeNotesByTeam
+        .get(submission.teamId)
+        ?.map((n) => n.text)
+        .join("\n") ?? null,
+  })
+
+  return { teams, nameById, submissions, judgeNotesByTeam, contextFor }
+}
+
+/** GET — every submitted team with its judge notes and current review state. */
+export async function GET(request: NextRequest) {
+  const check = await checkApiPermission("impact-lab", "edit")
+  if (!check.authorized) return check.response
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await loadFinalRun(cohort)
+  if (!run) {
+    return NextResponse.json({ success: true, data: { teams: [] } })
+  }
+
+  const { nameById, submissions, judgeNotesByTeam } = await loadTeamContexts(
+    run.id,
+    run.result
+  )
+  const reviews = await prisma.impactLabTeamReview.findMany({
+    where: { runId: run.id },
+    select: {
+      teamId: true,
+      text: true,
+      generatedBy: true,
+      editedAt: true,
+      approvedAt: true,
+      updatedAt: true,
+    },
+  })
+  const reviewByTeam = new Map(reviews.map((r) => [r.teamId, r]))
+
+  const teams = submissions
+    .map((s) => {
+      const review = reviewByTeam.get(s.teamId)
+      const teamName = nameById.get(s.teamId) ?? s.teamId
+      return {
+        teamId: s.teamId,
+        teamName,
+        projectName: s.projectName,
+        track: trackOf(teamName),
+        judgeNotes: judgeNotesByTeam.get(s.teamId) ?? [],
+        review: review
+          ? {
+              text: review.text,
+              generatedBy: review.generatedBy,
+              editedAt: review.editedAt?.toISOString() ?? null,
+              approvedAt: review.approvedAt?.toISOString() ?? null,
+              updatedAt: review.updatedAt.toISOString(),
+            }
+          : null,
+      }
+    })
+    .sort((a, b) => a.teamName.localeCompare(b.teamName))
+
+  return NextResponse.json({ success: true, data: { teams } })
+}
+
+/** See the writeup route for why failures must leave as JSON, not throws. */
+export async function POST(request: NextRequest) {
+  try {
+    return await handlePost(request)
+  } catch (error) {
+    console.error("[impact-lab/reviews] unhandled failure", error)
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          error instanceof Error
+            ? `Reviews failed: ${error.message}`
+            : "Reviews failed for an unknown reason.",
+      },
+      { status: 500 }
+    )
+  }
+}
+
+async function handlePost(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  // "edit", not "view" — these words end up in front of participants, and
+  // MODERATOR (the judge sign-in role) must not be able to write or approve
+  // them.
+  const check = await checkApiPermission("impact-lab", "edit")
+  if (!check.authorized) return check.response
+
+  // Generating 23 reviews takes ~6 batch calls; editing is many small saves.
+  const rl = await rateLimit(request, {
+    maxRequests: 60,
+    windowInSeconds: 300,
+    identifier: () => `impact-lab-reviews:${check.user.id}`,
+  })
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: "Pick an action." },
+      { status: 400 }
+    )
+  }
+  const body = parsed.data
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const run = await loadFinalRun(cohort)
+  if (!run) {
+    return NextResponse.json(
+      { success: false, error: "No final run for this cohort." },
+      { status: 409 }
+    )
+  }
+
+  const audit = async (changes: Record<string, unknown>) =>
+    logAudit({
+      userId: check.user.id,
+      userName: check.user.name,
+      userEmail: check.user.email,
+      action: "UPDATE",
+      entity: "ImpactLabTeamReview",
+      entityId: run.id,
+      changes: { cohort, ...changes },
+      ...getRequestMetadata(request),
+    })
+
+  // ── save / approve / unapprove ─────────────────────────────────────────────
+  if (body.action !== "generate") {
+    const existing = await prisma.impactLabTeamReview.findUnique({
+      where: { runId_teamId: { runId: run.id, teamId: body.teamId } },
+      select: { id: true, text: true },
+    })
+
+    if (body.action === "save") {
+      const submission = await prisma.impactLabSubmission.findUnique({
+        where: { runId_teamId: { runId: run.id, teamId: body.teamId } },
+        select: { teamId: true },
+      })
+      if (!submission) {
+        return NextResponse.json(
+          { success: false, error: "That team has no submission to review." },
+          { status: 404 }
+        )
+      }
+      // An organiser's save keeps any existing approval: the editor and the
+      // approver are the same authority here, so clearing approval on every
+      // typo fix would only add a second click that teaches nothing.
+      await prisma.impactLabTeamReview.upsert({
+        where: { runId_teamId: { runId: run.id, teamId: body.teamId } },
+        create: {
+          cohort,
+          runId: run.id,
+          teamId: body.teamId,
+          text: body.text,
+          generatedBy: check.user.email,
+          editedAt: new Date(),
+          editedBy: check.user.email,
+        },
+        update: {
+          text: body.text,
+          editedAt: new Date(),
+          editedBy: check.user.email,
+        },
+      })
+      await audit({ action: "save", teamId: body.teamId })
+      return NextResponse.json({ success: true, data: { saved: true } })
+    }
+
+    if (!existing) {
+      return NextResponse.json(
+        { success: false, error: "No review exists for that team yet." },
+        { status: 404 }
+      )
+    }
+
+    if (body.action === "approve" && existing.text.trim() === "") {
+      return NextResponse.json(
+        { success: false, error: "Cannot approve an empty review." },
+        { status: 400 }
+      )
+    }
+
+    await prisma.impactLabTeamReview.update({
+      where: { id: existing.id },
+      data:
+        body.action === "approve"
+          ? { approvedAt: new Date(), approvedBy: check.user.email }
+          : { approvedAt: null, approvedBy: null },
+    })
+    await audit({ action: body.action, teamId: body.teamId })
+    return NextResponse.json({ success: true, data: { saved: true } })
+  }
+
+  // ── generate ───────────────────────────────────────────────────────────────
+  const { submissions, contextFor } = await loadTeamContexts(run.id, run.result)
+  const existingReviews = await prisma.impactLabTeamReview.findMany({
+    where: { runId: run.id },
+    select: { teamId: true, editedAt: true, approvedAt: true },
+  })
+  const existingByTeam = new Map(existingReviews.map((r) => [r.teamId, r]))
+
+  if (body.teamId) {
+    const submission = submissions.find((s) => s.teamId === body.teamId)
+    if (!submission) {
+      return NextResponse.json(
+        { success: false, error: "That team has no submission to review." },
+        { status: 404 }
+      )
+    }
+    const existing = existingByTeam.get(body.teamId)
+    // A draft the organiser has touched — edited or approved — is their text
+    // now. Regenerating over it needs an explicit second decision.
+    if (existing && (existing.editedAt || existing.approvedAt) && !body.force) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "This review has been edited or approved. Regenerating will replace that text with a fresh draft — confirm to proceed.",
+          code: "REVIEW_PROTECTED",
+        },
+        { status: 409 }
+      )
+    }
+
+    const text = await generateReview(contextFor(submission))
+    if (text === null) {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            "Could not draft a review for that team right now. You can write it by hand — nothing is blocked.",
+        },
+        // 4xx so Cloudflare passes our JSON through — see the writeup route.
+        { status: 422 }
+      )
+    }
+
+    // A regenerated draft is unread text: it always re-enters the flow
+    // unedited and unapproved, whatever state the row held before.
+    await prisma.impactLabTeamReview.upsert({
+      where: { runId_teamId: { runId: run.id, teamId: body.teamId } },
+      create: { cohort, runId: run.id, teamId: body.teamId, text, generatedBy: MODEL },
+      update: {
+        text,
+        generatedBy: MODEL,
+        editedAt: null,
+        editedBy: null,
+        approvedAt: null,
+        approvedBy: null,
+      },
+    })
+    await audit({ action: "generate", teamId: body.teamId, forced: body.force === true })
+    return NextResponse.json({ success: true, data: { generated: 1, remaining: 0 } })
+  }
+
+  // Batch: only teams with no review row at all. Edited, approved, and even
+  // untouched existing drafts are never overwritten from the batch path —
+  // "generate all" fills gaps, it never destroys work.
+  const missing = submissions.filter((s) => !existingByTeam.has(s.teamId))
+  const batch = missing.slice(0, GENERATE_BATCH)
+
+  let generated = 0
+  const failedProjects: string[] = []
+  for (const submission of batch) {
+    const text = await generateReview(contextFor(submission))
+    if (text === null) {
+      failedProjects.push(submission.projectName)
+      continue
+    }
+    try {
+      await prisma.impactLabTeamReview.create({
+        data: { cohort, runId: run.id, teamId: submission.teamId, text, generatedBy: MODEL },
+      })
+      generated += 1
+    } catch {
+      // Unique violation — a concurrent call already drafted this team. Its
+      // text is fine; losing this duplicate costs nothing.
+    }
+  }
+
+  const remaining = missing.length - batch.length + failedProjects.length
+  await audit({ action: "generate-batch", generated, remaining, failed: failedProjects })
+
+  return NextResponse.json({
+    success: true,
+    data: {
+      generated,
+      remaining,
+      failed: failedProjects,
+    },
+  })
+}

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -3,7 +3,12 @@ import { prisma } from "@/lib/prisma"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
-import { buildMemberPayload, type ResultsSnapshot } from "@/lib/impact-lab/results"
+import {
+  buildMemberPayload,
+  type ResultsSnapshot,
+  type TeamFeedback,
+} from "@/lib/impact-lab/results"
+import { presentableJudgeNote, publishableReview } from "@/lib/impact-lab/reviews"
 
 /**
  * The published result, for one participant.
@@ -31,7 +36,7 @@ export async function GET(request: NextRequest) {
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort: DEFAULT_COHORT, isFinal: true },
     orderBy: { createdAt: "desc" },
-    select: { result: true, resultsPublishedAt: true, resultsSnapshot: true },
+    select: { id: true, result: true, resultsPublishedAt: true, resultsSnapshot: true },
   })
 
   // Never leak an unpublished snapshot — including its mere existence.
@@ -53,5 +58,33 @@ export async function GET(request: NextRequest) {
     viewerTeamId = team?.id ?? null
   }
 
-  return NextResponse.json(buildMemberPayload(snapshot, viewerTeamId))
+  // Written feedback for the viewer's own team only — queried by teamId, so
+  // no other team's words are ever even loaded. Two separate streams with
+  // separate provenance: a judge's quoted note (spelling/casing corrected via
+  // presentableJudgeNote, never reworded) and the community's review, which
+  // reaches a participant only once the organiser has approved it
+  // (publishableReview — the gate every participant surface goes through).
+  // Read live rather than from the frozen snapshot: reviews are written and
+  // approved after publication, and withholding them until a hypothetical
+  // second publish would leave teams with numbers and silence again.
+  let feedback: TeamFeedback | undefined
+  if (viewerTeamId) {
+    const [scoreRows, reviewRow] = await Promise.all([
+      prisma.impactLabScore.findMany({
+        where: { runId: run.id, teamId: viewerTeamId, feedback: { not: null } },
+        select: { judgeName: true, feedback: true },
+      }),
+      prisma.impactLabTeamReview.findUnique({
+        where: { runId_teamId: { runId: run.id, teamId: viewerTeamId } },
+        select: { text: true, approvedAt: true },
+      }),
+    ])
+    const judgeNotes = scoreRows.flatMap((row) => {
+      const text = presentableJudgeNote(row.feedback)
+      return text === null ? [] : [{ judgeName: row.judgeName, text }]
+    })
+    feedback = { judgeNotes, review: publishableReview(reviewRow) }
+  }
+
+  return NextResponse.json(buildMemberPayload(snapshot, viewerTeamId, feedback))
 }

--- a/src/app/dashboard/impact-lab/ResultsView.tsx
+++ b/src/app/dashboard/impact-lab/ResultsView.tsx
@@ -8,7 +8,10 @@ import type {
   PublicRankedTeam,
   ResultsTrackWinner,
   TeamCard,
+  TeamReviewPayload,
 } from "@/lib/impact-lab/results";
+import { REVIEW_PROVENANCE } from "@/lib/impact-lab/reviews";
+import type { TeamJudgeNote } from "@/lib/impact-lab/reviews";
 
 export interface ResultsViewProps {
   results: {
@@ -21,6 +24,8 @@ export interface ResultsViewProps {
     teamId: string;
     projectName: string;
     card: TeamCard;
+    judgeNotes?: TeamJudgeNote[];
+    review?: TeamReviewPayload;
   };
 }
 
@@ -207,6 +212,47 @@ export function ResultsView({ results, yourTeam }: ResultsViewProps) {
               Score range across judges: {yourTeam.card.low.toFixed(1)}–
               {yourTeam.card.high.toFixed(1)}
             </p>
+          )}
+
+          {/* Written feedback. Two streams with two provenances, kept visibly
+              apart: a judge's own note is quoted under that judge's name; the
+              community review is signed by the community and says so. Nothing
+              here ever presents generated words as a judge's. */}
+          {yourTeam.judgeNotes && yourTeam.judgeNotes.length > 0 && (
+            <div className="mt-6 space-y-3">
+              {yourTeam.judgeNotes.map((note) => (
+                <figure
+                  key={`${note.judgeName}-${note.text.slice(0, 24)}`}
+                  className="rounded border border-amber/30 bg-amber/5 p-4"
+                >
+                  <figcaption className="font-mono text-[11px] uppercase tracking-wider text-amber">
+                    Judge&apos;s note — {note.judgeName}
+                  </figcaption>
+                  <blockquote className="mt-2 whitespace-pre-line text-sm italic leading-relaxed text-text-primary">
+                    &ldquo;{note.text}&rdquo;
+                  </blockquote>
+                </figure>
+              ))}
+            </div>
+          )}
+
+          {yourTeam.review && (
+            <div className="mt-6 rounded border border-border-default bg-bg-card p-5">
+              <p className="font-mono text-[11px] uppercase tracking-wider text-cyan">
+                Impact Lab review
+              </p>
+              <div className="mt-3 space-y-3 text-sm leading-relaxed text-text-secondary">
+                {yourTeam.review.text.split(/\n\n+/).map((paragraph, i) => (
+                  <p key={i}>{paragraph}</p>
+                ))}
+              </div>
+              <p className="mt-4 font-mono text-xs text-text-primary">
+                — {yourTeam.review.signedBy}
+              </p>
+              <p className="mt-1 font-mono text-[11px] leading-relaxed text-text-dim">
+                {REVIEW_PROVENANCE}
+              </p>
+            </div>
           )}
         </motion.section>
       )}

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -8,6 +8,7 @@ import {
   FileSpreadsheet,
   FileText,
   Loader2,
+  MessageSquareText,
   Save,
   Send,
   Sparkles,
@@ -702,6 +703,419 @@ function PublishPanel({ cohort }: { cohort: string }) {
   )
 }
 
+// ─── Team reviews ───────────────────────────────────────────────────────────
+
+interface ReviewJudgeNote {
+  judgeName: string
+  text: string
+}
+
+interface ReviewRecord {
+  text: string
+  generatedBy: string
+  editedAt: string | null
+  approvedAt: string | null
+  updatedAt: string
+}
+
+interface ReviewTeam {
+  teamId: string
+  teamName: string
+  projectName: string
+  track: string
+  judgeNotes: ReviewJudgeNote[]
+  review: ReviewRecord | null
+}
+
+interface ReviewTeamState {
+  /** Local edit of the review text; null = not touched, show the server's. */
+  draftText: string | null
+  busy: "generate" | "save" | "approve" | null
+  /** Set after a 409 REVIEW_PROTECTED — the next generate press sends force. */
+  confirmRegenerate: boolean
+  error: string | null
+}
+
+function emptyReviewState(): ReviewTeamState {
+  return { draftText: null, busy: null, confirmRegenerate: false, error: null }
+}
+
+interface GenerateBatchResult {
+  generated: number
+  remaining: number
+  failed?: string[]
+}
+
+/**
+ * Section: the written review every team receives.
+ *
+ * Three of the four judges left scores and not one written word, so a team
+ * that built through the night would get five numbers and silence. This
+ * section drafts a substantive review per team (signed "Claude Community
+ * Kenya" — never attributed to a judge), and gives the organiser the pen:
+ * read each one, edit any of it, approve. Nothing reaches a participant
+ * until it is approved, and a draft the organiser has edited is never
+ * regenerated over without an explicit second confirmation.
+ *
+ * The judge's own notes (the ten Favour wrote) are shown read-only beside
+ * each review — they publish as quotes under her name, and the review is
+ * written to sit alongside them, so the organiser should see both together.
+ */
+function ReviewsSection({ cohort }: { cohort: string }) {
+  const [teams, setTeams] = useState<ReviewTeam[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [states, setStates] = useState<Record<string, ReviewTeamState>>({})
+  const [generatingAll, setGeneratingAll] = useState(false)
+  const [generateAllStatus, setGenerateAllStatus] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    try {
+      const data = await apiGet<{ teams: ReviewTeam[] }>(
+        `/api/admin/impact-lab/reviews?cohort=${cohort}`
+      )
+      setTeams(data.teams)
+      setLoadError(null)
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Failed to load reviews")
+    } finally {
+      setLoading(false)
+    }
+  }, [cohort])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const stateFor = useCallback(
+    (teamId: string): ReviewTeamState => states[teamId] ?? emptyReviewState(),
+    [states]
+  )
+
+  const patch = useCallback((teamId: string, next: Partial<ReviewTeamState>) => {
+    setStates((prev) => ({
+      ...prev,
+      [teamId]: { ...(prev[teamId] ?? emptyReviewState()), ...next },
+    }))
+  }, [])
+
+  const counts = useMemo(() => {
+    const total = teams?.length ?? 0
+    const drafted = teams?.filter((t) => t.review !== null).length ?? 0
+    const approved = teams?.filter((t) => t.review?.approvedAt).length ?? 0
+    return { total, drafted, approved }
+  }, [teams])
+
+  /**
+   * Fill every gap: the server drafts a few teams per call and reports how
+   * many are left, so this loops until nothing remains — and stops when a
+   * call makes no progress, so one persistently failing team cannot spin
+   * this forever. Existing drafts (edited or not) are never overwritten.
+   */
+  async function generateAll() {
+    setGeneratingAll(true)
+    setGenerateAllStatus(null)
+    try {
+      let total = 0
+      for (;;) {
+        const result = await apiSend<GenerateBatchResult>(
+          `/api/admin/impact-lab/reviews?cohort=${cohort}`,
+          "POST",
+          { action: "generate" }
+        )
+        total += result.generated
+        setGenerateAllStatus(
+          `Generated ${total} so far — ${result.remaining} remaining…`
+        )
+        await load()
+        if (result.remaining === 0 || result.generated === 0) {
+          setGenerateAllStatus(
+            result.remaining === 0
+              ? `Done — ${total} draft${total === 1 ? "" : "s"} generated. Read and edit each one below, then approve.`
+              : `Generated ${total}; ${result.remaining} could not be drafted right now (${(result.failed ?? []).join(", ") || "try again"}). You can retry or write them by hand.`
+          )
+          break
+        }
+      }
+    } catch (e) {
+      setGenerateAllStatus(null)
+      setLoadError(e instanceof Error ? e.message : "Generation failed.")
+    } finally {
+      setGeneratingAll(false)
+    }
+  }
+
+  async function generateOne(teamId: string, force: boolean) {
+    patch(teamId, { busy: "generate", error: null })
+    try {
+      await apiSend(`/api/admin/impact-lab/reviews?cohort=${cohort}`, "POST", {
+        action: "generate",
+        teamId,
+        ...(force ? { force: true } : {}),
+      })
+      patch(teamId, { busy: null, draftText: null, confirmRegenerate: false })
+      await load()
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Could not generate."
+      // The protected-review refusal: arm the confirm step instead of erroring.
+      const isProtected = message.includes("edited or approved")
+      patch(teamId, {
+        busy: null,
+        confirmRegenerate: isProtected,
+        error: isProtected ? null : message,
+      })
+    }
+  }
+
+  async function save(teamId: string) {
+    const state = stateFor(teamId)
+    if (state.draftText === null) return
+    patch(teamId, { busy: "save", error: null })
+    try {
+      await apiSend(`/api/admin/impact-lab/reviews?cohort=${cohort}`, "POST", {
+        action: "save",
+        teamId,
+        text: state.draftText,
+      })
+      patch(teamId, { busy: null, draftText: null })
+      await load()
+    } catch (e) {
+      patch(teamId, {
+        busy: null,
+        error: e instanceof Error ? e.message : "That did not save.",
+      })
+    }
+  }
+
+  async function setApproval(teamId: string, approve: boolean) {
+    patch(teamId, { busy: "approve", error: null })
+    try {
+      await apiSend(`/api/admin/impact-lab/reviews?cohort=${cohort}`, "POST", {
+        action: approve ? "approve" : "unapprove",
+        teamId,
+      })
+      patch(teamId, { busy: null })
+      await load()
+    } catch (e) {
+      patch(teamId, {
+        busy: null,
+        error: e instanceof Error ? e.message : "Could not update approval.",
+      })
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (loadError && !teams) {
+    return (
+      <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+        {loadError}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-sm font-mono font-semibold text-[#e0e0e0]">Team reviews</h2>
+        <p className="mt-1 text-[11px] font-mono text-[#888]">
+          A written review for every team, signed Claude Community Kenya — because three of
+          the four judges left no written feedback at all. Claude drafts from each team&apos;s
+          own submission; you read, edit, and approve. Only approved reviews reach the
+          dashboard, the results email, and the exports.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={() => void generateAll()}
+          disabled={generatingAll || (teams?.length ?? 0) === 0}
+          className="flex items-center gap-2 rounded border border-[#00d4ff]/30 bg-[#00d4ff]/10 px-3 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00d4ff] transition-colors hover:bg-[#00d4ff]/20 disabled:opacity-40"
+        >
+          <Sparkles className="h-3.5 w-3.5" />
+          {generatingAll ? "Generating…" : "Generate missing drafts"}
+        </button>
+        <span className="text-[11px] font-mono text-[#888]">
+          {counts.drafted}/{counts.total} drafted ·{" "}
+          <span className={counts.approved === counts.total && counts.total > 0 ? "text-[#00ff41]" : ""}>
+            {counts.approved}/{counts.total} approved
+          </span>
+        </span>
+      </div>
+
+      {generateAllStatus && (
+        <div
+          role="status"
+          className="rounded border border-[#00d4ff]/30 bg-[#00d4ff]/10 p-3 text-[11px] font-mono text-[#00d4ff]"
+        >
+          {generateAllStatus}
+        </div>
+      )}
+
+      {loadError && (
+        <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
+          {loadError}
+        </div>
+      )}
+
+      {(teams ?? []).length === 0 ? (
+        <p className="p-8 text-center text-sm font-mono text-[#555]">
+          No submitted teams yet — reviews are written about submissions.
+        </p>
+      ) : (
+        (teams ?? []).map((team) => {
+          const state = stateFor(team.teamId)
+          const serverText = team.review?.text ?? ""
+          const text = state.draftText ?? serverText
+          const dirty = state.draftText !== null && state.draftText !== serverText
+          const approved = Boolean(team.review?.approvedAt)
+          const edited = Boolean(team.review?.editedAt)
+
+          return (
+            <div
+              key={team.teamId}
+              className="space-y-3 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] p-4"
+            >
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                  <p className="text-[12px] font-mono font-semibold text-[#e0e0e0]">
+                    {team.projectName}
+                  </p>
+                  <p className="text-[11px] font-mono text-[#888]">{team.teamName}</p>
+                </div>
+                <span
+                  className={
+                    approved
+                      ? "rounded border border-[#00ff41]/40 bg-[#00ff41]/10 px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-[#00ff41]"
+                      : team.review
+                        ? "rounded border border-[#ffb000]/40 bg-[#ffb000]/10 px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-[#ffb000]"
+                        : "rounded border border-[#1e1e1e] bg-[#111] px-2 py-1 text-[10px] font-mono uppercase tracking-wider text-[#555]"
+                  }
+                >
+                  {approved ? "Approved" : team.review ? (edited ? "Edited draft" : "Draft") : "No review"}
+                </span>
+              </div>
+
+              {team.judgeNotes.map((note) => (
+                <div
+                  key={`${note.judgeName}-${note.text.slice(0, 24)}`}
+                  className="rounded border border-[#ffb000]/30 bg-[#ffb000]/5 p-3"
+                >
+                  <p className="text-[10px] font-mono uppercase tracking-wider text-[#ffb000]">
+                    Judge&apos;s note — {note.judgeName} (publishes as a quote under her name)
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap text-[11px] font-mono italic text-[#ccc]">
+                    &ldquo;{note.text}&rdquo;
+                  </p>
+                </div>
+              ))}
+
+              {team.review && (
+                <p className="text-[10px] font-mono text-[#555]">
+                  Drafted by {team.review.generatedBy}
+                  {edited ? " · edited by organiser" : ""}
+                  {" · "}last updated {new Date(team.review.updatedAt).toLocaleString()}
+                </p>
+              )}
+
+              <textarea
+                value={text}
+                onChange={(e) => patch(team.teamId, { draftText: e.target.value })}
+                rows={9}
+                placeholder="No draft yet — generate one, or write the review here yourself."
+                aria-label={`Impact Lab review for ${team.projectName}`}
+                className="w-full rounded border border-[#1e1e1e] bg-[#111] px-3 py-2 text-[12px] font-mono leading-relaxed text-[#e0e0e0] focus:border-[#00ff41] focus:outline-none"
+              />
+
+              {state.confirmRegenerate && (
+                <div
+                  role="alert"
+                  className="flex items-start gap-2 rounded border border-[#ffb000]/30 bg-[#ffb000]/10 p-3 text-[11px] font-mono text-[#ffb000]"
+                >
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>
+                    This review has been edited or approved — your words, not a draft.
+                    Regenerating replaces them and clears approval. Press
+                    &ldquo;Regenerate anyway&rdquo; only if that is what you want.
+                  </span>
+                </div>
+              )}
+
+              <div className="flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => void generateOne(team.teamId, state.confirmRegenerate)}
+                  disabled={state.busy !== null || generatingAll}
+                  className="flex items-center gap-2 rounded border border-[#00d4ff]/30 bg-[#00d4ff]/10 px-3 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00d4ff] transition-colors hover:bg-[#00d4ff]/20 disabled:opacity-40"
+                >
+                  <Sparkles className="h-3.5 w-3.5" />
+                  {state.busy === "generate"
+                    ? "Generating…"
+                    : state.confirmRegenerate
+                      ? "Regenerate anyway"
+                      : team.review
+                        ? "Regenerate"
+                        : "Generate draft"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void save(team.teamId)}
+                  disabled={!dirty || text.trim() === "" || state.busy !== null}
+                  className="flex items-center gap-2 rounded border border-[#00ff41]/40 bg-[#00ff41]/10 px-4 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00ff41] transition-colors hover:bg-[#00ff41]/20 disabled:opacity-40"
+                >
+                  <Save className="h-3.5 w-3.5" />
+                  {state.busy === "save" ? "Saving…" : "Save"}
+                </button>
+                {team.review && (
+                  <button
+                    type="button"
+                    onClick={() => void setApproval(team.teamId, !approved)}
+                    disabled={state.busy !== null || dirty}
+                    title={dirty ? "Save your edit first, then approve what you saved." : undefined}
+                    className={
+                      approved
+                        ? "flex items-center gap-2 rounded border border-[#1e1e1e] bg-[#1a1a1a] px-3 py-2 text-[11px] font-mono uppercase tracking-wider text-[#888] transition-colors hover:bg-[#222] disabled:opacity-40"
+                        : "flex items-center gap-2 rounded border border-[#00ff41]/40 bg-[#00ff41]/10 px-3 py-2 text-[11px] font-mono uppercase tracking-wider text-[#00ff41] transition-colors hover:bg-[#00ff41]/20 disabled:opacity-40"
+                    }
+                  >
+                    <CheckCircle2 className="h-3.5 w-3.5" />
+                    {state.busy === "approve"
+                      ? "Working…"
+                      : approved
+                        ? "Unapprove"
+                        : "Approve"}
+                  </button>
+                )}
+                {state.error && (
+                  <span role="alert" className="text-[11px] font-mono text-[#ff3333]">
+                    {state.error}
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        })
+      )}
+
+      <p className="flex items-start gap-2 text-[11px] font-mono text-[#888]">
+        <MessageSquareText className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[#00d4ff]" aria-hidden />
+        <span>
+          Reviews publish signed &ldquo;Claude Community Kenya&rdquo; with a line saying the
+          community wrote them — never as a judge&apos;s words. Favour&apos;s notes publish
+          separately, quoted under her name, exactly as she wrote them (spelling fixed).
+        </span>
+      </p>
+    </div>
+  )
+}
+
 // ─── Preview a team's email ─────────────────────────────────────────────────
 
 interface PreviewEmailOption {
@@ -1198,11 +1612,12 @@ function ExportPanel({ cohort }: { cohort: string }) {
  * Results tab — organiser-facing surfaces for closing out judging.
  *
  * Starts with the one section this program needs first: the teams the panel
- * never reached. The publish panel follows, then the email preview panel,
- * then the send panel — the preview sits above send deliberately, since it
- * exists to be checked before pressing send, and screen order should teach
- * that order of use. Each section is its own component rendered in a simple
- * stack, fetching its own data independently.
+ * never reached. The publish panel follows, then team reviews, then the email
+ * preview panel, then the send panel — reviews sit above the preview because
+ * the preview renders them, and the preview sits above send deliberately,
+ * since it exists to be checked before pressing send; screen order should
+ * teach that order of use. Each section is its own component rendered in a
+ * simple stack, fetching its own data independently.
  */
 export function ResultsTab({ cohort }: { cohort: string }) {
   return (
@@ -1210,6 +1625,9 @@ export function ResultsTab({ cohort }: { cohort: string }) {
       <AwaitingScoreSection cohort={cohort} />
       <div className="border-t border-[#1e1e1e] pt-6">
         <PublishPanel cohort={cohort} />
+      </div>
+      <div className="border-t border-[#1e1e1e] pt-6">
+        <ReviewsSection cohort={cohort} />
       </div>
       <div className="border-t border-[#1e1e1e] pt-6">
         <PreviewEmailPanel cohort={cohort} />

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -7,6 +7,11 @@ import { Resend } from "resend"
 import { VOLUNTEER_ROLE_LABELS as SHARED_VOLUNTEER_ROLE_LABELS } from "@/lib/volunteer-roles"
 import { JUDGING_CRITERIA } from "@/lib/impact-lab/judging"
 import type { AnnouncedWinner, ResultsTrackWinner } from "@/lib/impact-lab/results"
+import {
+  REVIEW_PROVENANCE,
+  REVIEW_SIGNATURE,
+  type TeamJudgeNote,
+} from "@/lib/impact-lab/reviews"
 
 // Lazy initialization — avoids build-time error when env var is not set
 let _resend: Resend | null = null
@@ -560,6 +565,19 @@ export function impactLabResultsEmail(data: {
   overall: AnnouncedWinner[]
   trackWinners: ResultsTrackWinner[]
   dashboardUrl: string
+  /**
+   * Notes a judge actually wrote on this team's scoresheet, quoted under that
+   * judge's name (already corrected via presentableJudgeNote — never pass raw
+   * DB text here). Optional: most teams received none.
+   */
+  judgeNotes?: TeamJudgeNote[]
+  /**
+   * The approved community review for this team (already gated through
+   * publishableReview — an unapproved draft must never reach this function).
+   * Rendered under the community's own signature, with the provenance line,
+   * so generated words can never read as a judge's.
+   */
+  communityReview?: string | null
 }): { subject: string; html: string } {
   // Publishing with zero announced winners is a legal (if unusual) state —
   // the publish panel warns rather than blocks it. Guard each block the same
@@ -620,6 +638,40 @@ export function impactLabResultsEmail(data: {
       ? `<p style="margin:10px 0 0;font-family:monospace,monospace;font-size:11px;color:#888;">Score range across judges: ${data.low.toFixed(1)}–${data.high.toFixed(1)}</p>`
       : ""
 
+  const judgeNotesSection = (data.judgeNotes ?? [])
+    .map(
+      (note) => `
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 14px;border:1px solid #3a2d00;border-radius:6px;">
+              <tr>
+                <td style="padding:14px 16px;">
+                  <p style="margin:0 0 6px;font-family:monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#ffb000;">Judge&#x27;s note — ${esc(note.judgeName)}</p>
+                  <p style="margin:0;font-family:monospace,monospace;font-size:13px;font-style:italic;line-height:1.6;color:#e0e0e0;">&ldquo;${esc(note.text).replace(/\n/g, "<br>")}&rdquo;</p>
+                </td>
+              </tr>
+            </table>`
+    )
+    .join("")
+
+  const reviewSection = data.communityReview
+    ? `
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px;border:1px solid #1e1e1e;border-radius:6px;">
+              <tr>
+                <td style="padding:16px 18px;">
+                  <p style="margin:0 0 10px;font-family:monospace,monospace;font-size:11px;text-transform:uppercase;letter-spacing:1px;color:#00d4ff;">Impact Lab review</p>
+                  ${data.communityReview
+                    .split(/\n\n+/)
+                    .map(
+                      (paragraph) =>
+                        `<p style="margin:0 0 10px;font-family:monospace,monospace;font-size:13px;line-height:1.7;color:#e0e0e0;">${esc(paragraph).replace(/\n/g, "<br>")}</p>`
+                    )
+                    .join("")}
+                  <p style="margin:8px 0 0;font-family:monospace,monospace;font-size:12px;color:#e0e0e0;">— ${esc(REVIEW_SIGNATURE)}</p>
+                  <p style="margin:4px 0 0;font-family:monospace,monospace;font-size:11px;line-height:1.6;color:#888;">${esc(REVIEW_PROVENANCE)}</p>
+                </td>
+              </tr>
+            </table>`
+    : ""
+
   const submissionNote =
     data.basis === "submission"
       ? `<p style="margin:0 0 14px;font-family:monospace,monospace;font-size:12px;line-height:1.6;color:#888;border:1px solid #1e1e1e;border-radius:4px;padding:10px 12px;">Your project was reviewed from your written submission against the same five criteria. A live demo was not part of that review, which is reflected in the demo criterion below.</p>`
@@ -656,7 +708,8 @@ export function impactLabResultsEmail(data: {
                 </td>
               </tr>
             </table>
-
+            ${judgeNotesSection}
+            ${reviewSection}
             <p style="margin:0 0 20px;font-family:monospace,monospace;font-size:12px;line-height:1.7;color:#888;">${note}</p>
 
             <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 12px;">

--- a/src/lib/impact-lab/export-data.ts
+++ b/src/lib/impact-lab/export-data.ts
@@ -75,6 +75,21 @@ export interface SourceScore {
   writeupOnly: boolean
 }
 
+/**
+ * An APPROVED community review for one team — the organiser-read text that
+ * also reaches the team's dashboard and results email. The loader must gate
+ * rows through `publishableReview` (@/lib/impact-lab/reviews) before handing
+ * them in; an unapproved draft never enters an artefact that leaves the
+ * building. Where a team has one of these, it is the canonical written text
+ * about that project — any machine-written fallback analysis must be skipped
+ * for that team, and the two must never share a label (this is the
+ * community's signed feedback; an analysis is not).
+ */
+export interface SourceReview {
+  teamId: string
+  text: string
+}
+
 export interface ExportSource {
   cohort: string
   publishedAt: string | null
@@ -83,6 +98,8 @@ export interface ExportSource {
   participants: SourceParticipant[]
   submissions: SourceSubmission[]
   scores: SourceScore[]
+  /** Approved community reviews only — see SourceReview. */
+  reviews: SourceReview[]
 }
 
 // ─── Assembled export ────────────────────────────────────────────────────────
@@ -141,6 +158,12 @@ export interface ExportTeam {
   scoredFromWriteup: boolean
   isTrackWinner: boolean
   isChampion: boolean
+  /**
+   * The approved community review, signed "Claude Community Kenya", or null
+   * when none is approved yet. When present this is the canonical written
+   * text about the project in both artefacts.
+   */
+  communityReview: string | null
 }
 
 export interface ExportWinner {
@@ -256,6 +279,7 @@ function toJudgeScore(score: SourceScore): ExportJudgeScore {
 export function buildResultsExport(source: ExportSource, now: Date = new Date()): ResultsExport {
   const participantById = new Map(source.participants.map((p) => [p.id, p]))
   const submissionByTeam = new Map(source.submissions.map((s) => [s.teamId, s]))
+  const reviewByTeam = new Map(source.reviews.map((r) => [r.teamId, r.text]))
 
   const scoresByTeam = new Map<string, SourceScore[]>()
   for (const score of source.scores) {
@@ -359,6 +383,7 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
       scoredFromWriteup,
       isTrackWinner: trackWinnerTeamIds.has(team.id),
       isChampion: team.id === championTeamId,
+      communityReview: reviewByTeam.get(team.id) ?? null,
     }
   })
 

--- a/src/lib/impact-lab/export-excel.ts
+++ b/src/lib/impact-lab/export-excel.ts
@@ -192,6 +192,10 @@ function addSubmissionsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): v
     { header: "Video URL", key: "videoUrl", width: 30 },
     { header: "Slides URL", key: "slidesUrl", width: 30 },
     { header: "Scoring basis", key: "scoringBasis", width: 30, wrap: true },
+    // The approved community review — signed feedback from the host
+    // community, never judge commentary; the header says whose words these
+    // are so the label travels with any copy of the sheet.
+    { header: "Impact Lab review (Claude Community Kenya)", key: "communityReview", width: 70, wrap: true },
   ]
   const sheet = addSheet(workbook, "Submissions", columns, { autoFilter: true })
 
@@ -213,6 +217,7 @@ function addSubmissionsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): v
       videoUrl: s.videoUrl ?? "",
       slidesUrl: s.slidesUrl ?? "",
       scoringBasis: team.scoredFromWriteup ? WRITEUP_NOTE : "Scored at the table (live demo).",
+      communityReview: team.communityReview ?? "",
     })
     row.height = estimateRowHeight([
       { text: s.pitch, width: 46 },
@@ -220,6 +225,7 @@ function addSubmissionsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): v
       { text: s.description, width: 56 },
       { text: s.worksVsMocked, width: 46 },
       { text: s.claudeUsage, width: 46 },
+      { text: team.communityReview ?? "", width: 70 },
     ])
     if (team.scoredFromWriteup) {
       row.getCell("scoringBasis").font = { size: 9, color: { argb: AMBER_TEXT } }

--- a/src/lib/impact-lab/export-pdf.ts
+++ b/src/lib/impact-lab/export-pdf.ts
@@ -21,6 +21,7 @@ import {
   type ExportTeam,
   type ResultsExport,
 } from "./export-data"
+import { REVIEW_PROVENANCE, REVIEW_SIGNATURE } from "./reviews"
 
 // ─── Layout constants ────────────────────────────────────────────────────────
 
@@ -460,6 +461,31 @@ function renderFeedback(doc: Doc, team: ExportTeam): void {
 }
 
 /**
+ * The approved community review, printed under the community's own name.
+ * Distinct label and an explicit provenance line, so these words can never
+ * be read as judge commentary — judge words render only in renderFeedback,
+ * under the judge who wrote them.
+ */
+function renderCommunityReview(doc: Doc, team: ExportTeam): void {
+  if (team.communityReview === null) return
+  const body = team.communityReview
+  doc.font(SANS).fontSize(9)
+  ensureSpace(doc, 34 + doc.heightOfString(body, { width: CONTENT_WIDTH, lineGap: 2 }))
+  sectionLabel(doc, `Impact Lab review — ${REVIEW_SIGNATURE}`)
+  doc
+    .font(SANS)
+    .fontSize(9)
+    .fillColor(INK)
+    .text(body, MARGIN, doc.y, { width: CONTENT_WIDTH, lineGap: 2, paragraphGap: 5 })
+  doc
+    .font(SANS_ITALIC)
+    .fontSize(7.5)
+    .fillColor(FAINT)
+    .text(REVIEW_PROVENANCE, MARGIN, doc.y + 4, { width: CONTENT_WIDTH, lineGap: 2 })
+  doc.moveDown(0.8)
+}
+
+/**
  * One section per team, each starting on a fresh page: identity, members,
  * the full submission, then scores and feedback.
  */
@@ -558,6 +584,7 @@ function renderTeamPage(doc: Doc, team: ExportTeam): void {
     renderJudgeTable(doc, team)
     renderFeedback(doc, team)
   }
+  renderCommunityReview(doc, team)
 }
 
 // ─── Footer pass ─────────────────────────────────────────────────────────────

--- a/src/lib/impact-lab/results-input.ts
+++ b/src/lib/impact-lab/results-input.ts
@@ -14,7 +14,8 @@
 import type { Prisma } from "@/generated/prisma/client"
 import { extractFrozenTeams } from "./member"
 import { standings, trackOf, weightedTotal, type JudgeScore, type ScoreSheet } from "./judging"
-import type { ResultsInput } from "./results"
+import type { ResultsInput, TeamFeedback } from "./results"
+import { presentableJudgeNote, publishableReview } from "./reviews"
 import type { Team } from "@/lib/matching"
 
 /** Accepts either the top-level Prisma client or a `$transaction` callback's `tx`. */
@@ -101,4 +102,46 @@ export async function buildResultsInputFromRun(db: Db, runId: string, runResult:
     scoredTeamIds,
     displayName,
   }
+}
+
+/**
+ * Written feedback per team for one run, as it may be shown to that team:
+ * judge notes quoted through `presentableJudgeNote` (spelling/casing
+ * corrections only — the stored record is never altered) and the community
+ * review gated through `publishableReview` (approved rows only).
+ *
+ * One loader for every sender/previewer of the results email, for the same
+ * reason `buildResultsInputFromRun` exists: two implementations of "what
+ * feedback does this team get" is how a preview and a real send drift apart.
+ */
+export async function loadTeamFeedback(
+  db: Db,
+  runId: string,
+  teamIds: string[]
+): Promise<Map<string, TeamFeedback>> {
+  const [scoreRows, reviewRows] = await Promise.all([
+    db.impactLabScore.findMany({
+      where: { runId, teamId: { in: teamIds }, feedback: { not: null } },
+      select: { teamId: true, judgeName: true, feedback: true },
+    }),
+    db.impactLabTeamReview.findMany({
+      where: { runId, teamId: { in: teamIds } },
+      select: { teamId: true, text: true, approvedAt: true },
+    }),
+  ])
+
+  const reviewByTeam = new Map(reviewRows.map((r) => [r.teamId, r]))
+  const feedback = new Map<string, TeamFeedback>()
+  for (const teamId of teamIds) {
+    feedback.set(teamId, {
+      judgeNotes: [],
+      review: publishableReview(reviewByTeam.get(teamId)),
+    })
+  }
+  for (const row of scoreRows) {
+    const text = presentableJudgeNote(row.feedback)
+    if (text === null) continue
+    feedback.get(row.teamId)?.judgeNotes.push({ judgeName: row.judgeName, text })
+  }
+  return feedback
 }

--- a/src/lib/impact-lab/results.ts
+++ b/src/lib/impact-lab/results.ts
@@ -18,6 +18,7 @@
  */
 
 import { trackOf, type TeamStanding } from "./judging"
+import { REVIEW_SIGNATURE, type TeamJudgeNote } from "./reviews"
 
 /** How a team's placing was arrived at. */
 export type ResultBasis = "announced" | "demo" | "submission"
@@ -183,6 +184,25 @@ export function toPublicRanking(ranking: RankedTeam[]): PublicRankedTeam[] {
   }))
 }
 
+/**
+ * The two streams of written feedback a team may receive, kept apart by
+ * construction (see @/lib/impact-lab/reviews): a judge's own quoted words
+ * under that judge's name, and the community's review under the community's.
+ */
+export interface TeamFeedback {
+  /** Notes a judge actually wrote, quoted (spelling/casing corrected only). */
+  judgeNotes: TeamJudgeNote[]
+  /** The approved community review, or null when none is approved yet. */
+  review: string | null
+}
+
+/** The community review as one participant receives it — text plus signer. */
+export interface TeamReviewPayload {
+  text: string
+  /** Always REVIEW_SIGNATURE — carried in-band so the label crosses the wire with the words. */
+  signedBy: string
+}
+
 /** The published result as one participant may receive it. Flat member shape — no `data` wrapper. */
 export interface MemberResultsPayload {
   success: true
@@ -193,7 +213,15 @@ export interface MemberResultsPayload {
     trackWinners: ResultsTrackWinner[]
     ranking: PublicRankedTeam[]
   }
-  yourTeam?: { teamId: string; projectName: string; card: TeamCard }
+  yourTeam?: {
+    teamId: string
+    projectName: string
+    card: TeamCard
+    /** Present only when a judge left a note on this team. */
+    judgeNotes?: TeamJudgeNote[]
+    /** Present only when the organiser has approved this team's review. */
+    review?: TeamReviewPayload
+  }
 }
 
 /**
@@ -214,7 +242,13 @@ export interface MemberResultsPayload {
  */
 export function buildMemberPayload(
   snapshot: ResultsSnapshot,
-  viewerTeamId: string | null
+  viewerTeamId: string | null,
+  /**
+   * Written feedback for the viewer's own team ONLY — the caller must never
+   * pass another team's. It rides inside `yourTeam`, so a viewer with no
+   * resolvable team can receive none of it by construction.
+   */
+  feedback?: TeamFeedback
 ): MemberResultsPayload {
   const payload: MemberResultsPayload = {
     success: true,
@@ -237,6 +271,12 @@ export function buildMemberPayload(
       teamId: viewerTeamId,
       projectName: rankingRow.projectName,
       card,
+    }
+    if (feedback && feedback.judgeNotes.length > 0) {
+      payload.yourTeam.judgeNotes = feedback.judgeNotes
+    }
+    if (feedback && feedback.review !== null) {
+      payload.yourTeam.review = { text: feedback.review, signedBy: REVIEW_SIGNATURE }
     }
   }
 

--- a/src/lib/impact-lab/reviews.ts
+++ b/src/lib/impact-lab/reviews.ts
@@ -1,0 +1,112 @@
+/**
+ * Impact Lab team feedback — provenance and presentation rules.
+ *
+ * Pure and dependency-free (no Prisma, no Next) so the rules that decide what
+ * words reach a team — and whose name those words carry — can be asserted by
+ * a script (scripts/verify-reviews.ts).
+ *
+ * Two streams of feedback reach a team, and they must never blur:
+ *
+ * 1. **Judge's note** — words a judge actually wrote on their scoresheet,
+ *    quoted with only spelling/casing corrected, shown under that judge's
+ *    name. Only one judge (Favour) wrote any; her notes appear only on the
+ *    teams she noted.
+ * 2. **Impact Lab review** — a substantive written review of the team's own
+ *    submission, signed "Claude Community Kenya". It is the community's
+ *    feedback and is labelled as exactly that, everywhere it appears. It is
+ *    never attributed to, or presented alongside anything implying, a judge.
+ *
+ * The hard rule this module exists to enforce: never attribute written words
+ * to a judge who did not write them.
+ */
+
+/** Who the community review is signed by, on every surface. */
+export const REVIEW_SIGNATURE = "Claude Community Kenya"
+
+/**
+ * The provenance line shown with every published review. One string, used by
+ * the dashboard, the results email, and the PDF/Excel exports, so no surface
+ * can quietly soften it.
+ */
+export const REVIEW_PROVENANCE =
+  "Written by the Claude Community Kenya team after reading your submission — this is the community's review, not a judge's."
+
+// ─── Judge notes ─────────────────────────────────────────────────────────────
+
+/**
+ * Spelling/casing corrections to the notes one judge (Favour) wrote by hand
+ * on her scoresheets, applied at render time so the stored record stays
+ * verbatim. Keyed on the exact stored text: only a note we have audited is
+ * ever altered, and only in the ways listed here — spelling and sentence
+ * casing, never a word added, removed, or reworded. Anything not in this
+ * table is shown exactly as the judge wrote it.
+ *
+ * `null` marks a note that is omitted entirely: the stored text "Please" is
+ * a fragment — she was clearly interrupted mid-sentence — and publishing a
+ * fragment under her name would misrepresent her more than saying nothing.
+ */
+const NOTE_CORRECTIONS = new Map<string, string | null>([
+  [
+    "Build in programatic access and after you're live get a data protection certificate",
+    "Build in programmatic access and after you're live get a data protection certificate",
+  ],
+  ["Brillant\nPlease pilot it", "Brilliant\nPlease pilot it"],
+  [
+    "Brilliant product\nFocus on what you've built and share it",
+    "Brilliant product\nFocus on what you've built and share it",
+  ],
+  ["Please talk to some medics", "Please talk to some medics"],
+  ["Create a chrome extension or mobile app", "Create a Chrome extension or mobile app"],
+  ["Please pilot!!!", "Please pilot!!!"],
+  ["Please build in the Product", "Please build in the product"],
+  ["Please", null],
+  ["Use images and a chat partner instead", "Use images and a chat partner instead"],
+  ["Please talk to businesses and investors", "Please talk to businesses and investors"],
+])
+
+/**
+ * A judge's stored note as it may be shown to the team, or `null` when
+ * nothing should be shown (empty, whitespace, or an audited fragment).
+ *
+ * Normalises line endings and trims before lookup so the correction table
+ * matches however the text was keyed in on the night.
+ */
+export function presentableJudgeNote(raw: string | null | undefined): string | null {
+  if (typeof raw !== "string") return null
+  const normalised = raw.replace(/\r\n/g, "\n").trim()
+  if (normalised === "") return null
+  const corrected = NOTE_CORRECTIONS.get(normalised)
+  if (corrected !== undefined) return corrected
+  // A note we have not audited is still the judge's own words — verbatim is
+  // always safe to attribute. Only audited corrections ever alter text.
+  return normalised
+}
+
+/** A judge's note as attached to a member payload or an email. */
+export interface TeamJudgeNote {
+  judgeName: string
+  text: string
+}
+
+// ─── Community reviews ───────────────────────────────────────────────────────
+
+/** The subset of an ImpactLabTeamReview row the publish gate needs. */
+export interface ReviewGateInput {
+  text: string
+  approvedAt: Date | string | null
+}
+
+/**
+ * The review text as it may reach a participant, or `null` when it may not.
+ *
+ * This is THE publish gate: every surface that shows a review to anyone
+ * outside the admin panel (dashboard, results email, exports) must go
+ * through it. An unapproved draft — however good — never leaves the admin
+ * panel, because the organiser has not read it yet.
+ */
+export function publishableReview(review: ReviewGateInput | null | undefined): string | null {
+  if (!review) return null
+  if (!review.approvedAt) return null
+  const text = review.text.trim()
+  return text === "" ? null : text
+}


### PR DESCRIPTION
## What this does

Every one of the 27 teams from Impact Lab: AI Mashinani now receives written feedback instead of five numbers and silence:

- **Judge's note — Favour**: her real notes, quoted under her name, for the teams she noted. Corrections are spelling/casing only, applied at render time via an exact-match table (`presentableJudgeNote`) so the stored record stays verbatim. The bare `"Please"` fragment is omitted entirely — nine notes publish, not ten.
- **Impact Lab review**: a substantive 3–4 paragraph review for every team, signed *Claude Community Kenya* with an explicit provenance line. Drafted by Claude (`claude-sonnet-5`, `generateObject`, same error discipline as `judging/assist`) from the team's own submission; the organiser reads, edits, and approves each one in a new **Team Reviews** section of the admin Results tab. **Nothing publishes unapproved** — one pure gate (`publishableReview`) guards the dashboard, the results email (send *and* preview, via one shared loader), and both exports.

**The hard rule — never attribute words to a judge who did not write them — is structural**: reviews are stored per team (`ImpactLabTeamReview`, unique `(runId, teamId)`), with no field a judge's name could ride on; judge words render only from `ImpactLabScore.feedback` under the judge who wrote them. `scripts/verify-reviews.ts` (26 assertions) asserts the correction table, the omitted fragment, the publish gate, and that the review payload carries no judge identity.

Edit protection: regenerating an edited/approved review 409s (`REVIEW_PROTECTED`) until explicitly forced, and a forced regeneration clears approval. Batch generation only fills teams with no review row — it can never overwrite work.

Migration `20260728120000_impact_lab_team_reviews` is hand-written and purely additive (`prisma migrate dev` never run; the raw-SQL partial index is untouched). Applied by the owner's process.

## Coordination with PR #92 (`feat/export-world-class`) — action needed at merge

#92 generates a per-team **"Project analysis"** at export time (`src/lib/impact-lab/export-analysis.ts`). Both texts shipping unchanged would give every team two different AI-written accounts of the same work. Resolution agreed with the coordinator:

1. **The organiser-approved review is canonical.** This branch threads it through the existing `ResultsExport` shape: `ExportSource.reviews` → `ExportTeam.communityReview` (additive in `export-data.ts`, merges cleanly with #92's additive changes there).
2. **After both merge, #92's `generateTeamAnalyses` must skip teams where `communityReview !== null`** — the analysis becomes the fallback for teams with no approved review yet. One-line filter.
3. **Labels stay distinct**: *"Impact Lab review — Claude Community Kenya"* (signed community feedback) vs #92's `ANALYSIS_PROVENANCE` (machine-written from the submission). Neither may wear the other's label.

### Files touched that #92 also rebuilds

- `src/lib/impact-lab/export-data.ts` — additive only (new `SourceReview`, `ExportSource.reviews`, `ExportTeam.communityReview`); merges cleanly.
- `src/lib/impact-lab/export-excel.ts` — one new column on the Submissions sheet + its row-height entry.
- `src/lib/impact-lab/export-pdf.ts` — one standalone `renderCommunityReview()` + one call line in `renderTeamPage` (rewritten on #92 — expect one small conflict hunk there).
- `src/app/api/admin/impact-lab/results/export/route.ts` — one extra query + `reviews` in the source object.

## Verification

- `npx tsc --noEmit` — clean
- `npm run build` — clean; route table includes `ƒ /api/admin/impact-lab/reviews`
- `npm run verify:reviews` / `verify:judging` / `verify:results` — ALL CHECKS PASSED
- ESLint on all touched files — clean
- No fixture with real participant data written anywhere; report examples use labelled invented stand-ins (submission text exists only in the production DB, which this environment does not touch).

Full report with three complete example reviews: `.superpowers/sdd/team-reviews-report.md`

@Spidey-Acer

https://claude.ai/code/session_01C7ezG1ndnTmCV1anEi3iGC
