### PR TITLE
Tighten Claude Code permission scope — close the npm run:* blanket

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,5 +14,32 @@
         ]
       }
     ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(npx prisma generate:*)",
+      "Bash(npx prisma validate:*)",
+      "Bash(npx prisma migrate status:*)",
+      "Bash(npx prisma migrate deploy:*)",
+      "Bash(npm run dev)",
+      "Bash(npm run build)",
+      "Bash(npm run start)",
+      "Bash(npm run lint)",
+      "Bash(npm run db:generate)",
+      "Bash(npm run verify:matching)",
+      "Bash(npm run verify:submissions)",
+      "Bash(npm run verify:rematch)",
+      "Bash(npm run verify:judging)",
+      "Bash(npm run verify:results)",
+      "Bash(npm run verify:reviews)"
+    ],
+    "ask": [
+      "Bash(npx prisma migrate reset:*)",
+      "Bash(npx prisma migrate dev:*)",
+      "Bash(npx prisma db push:*)",
+      "Bash(npm run db:migrate)",
+      "Bash(npm run db:push)",
+      "Bash(npm run purge:closed-cohorts)"
+    ]
   }
 }


### PR DESCRIPTION
Tightens Claude Code permission scope in the repo's `.claude/settings.json`.

The previous config auto-approved `Bash(npm run:*)` as a blanket, which silently pre-approved destructive scripts — `purge:closed-cohorts` (clears participant phone numbers and blocklists), `db:migrate`, and `db:push` — with no prompt. Replaced with an exact safe allowlist; anything not listed, including those three, now requires explicit approval.

This gap applied to anyone running Claude Code against the repo, not just me.
