### PR TITLE
Post-merge audit cleanup: SEO metadata, canonicals, export contrast, event date guard

### DIFF
--- a/src/app/code-of-conduct/page.tsx
+++ b/src/app/code-of-conduct/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: "Code of Conduct | Claude Community Kenya",
   description:
     "Our community code of conduct — ensuring a welcoming, inclusive, and harassment-free experience for everyone.",
+  alternates: {
+    canonical: "https://www.claudekenya.org/code-of-conduct",
+  },
   openGraph: {
     title: "Code of Conduct | Claude Community Kenya",
     description:

--- a/src/app/events/[slug]/EventDetailContent.tsx
+++ b/src/app/events/[slug]/EventDetailContent.tsx
@@ -29,6 +29,7 @@ import {
 } from "lucide-react";
 import { EventDetailClient } from "./EventDetailClient";
 import { DemoRequestForm } from "./DemoRequestForm";
+import { isEventPast } from "@/lib/event-dates";
 
 /** Fraunces display-serif style for Pro headings. */
 const FRAUNCES: React.CSSProperties = {
@@ -84,8 +85,10 @@ export function EventDetailContent({
   const { skin } = useSkin();
   const isPro = skin === "pro";
 
+  // Status alone is not enough — it is set by hand in admin. See lib/event-dates.
   const isActionable =
-    event.status === "upcoming" || event.status === "registration-open";
+    (event.status === "upcoming" || event.status === "registration-open") &&
+    !isEventPast(event.date);
 
   // ─── Pro section heading ───────────────────────────────────────────────────
   function ProHeading({ children }: { children: React.ReactNode }) {

--- a/src/app/resources/links/page.tsx
+++ b/src/app/resources/links/page.tsx
@@ -14,6 +14,9 @@ export const metadata: Metadata = {
   title: "Curated Links | Claude Community Kenya",
   description:
     "A comprehensive directory of Claude AI resources, tools, communities, and learning materials curated for Kenyan developers.",
+  alternates: {
+    canonical: "https://www.claudekenya.org/resources/links",
+  },
   openGraph: {
     title: "Curated Links | Claude Community Kenya",
     description:

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,0 +1,24 @@
+import type { Metadata, Viewport } from "next";
+
+/**
+ * /signup is a client component, so its metadata lives here — the same shape
+ * its four sibling auth routes (login, forgot-password, reset-password,
+ * verify-email) already use.
+ *
+ * `robots: index:false` matters more than the title: an account-creation form
+ * has nothing to offer a search result, and sitemap.ts already documents auth
+ * routes as deliberately omitted on the understanding that the routes
+ * themselves carry the noindex. This was the one that didn't.
+ */
+export const metadata: Metadata = {
+  title: "Create an account | Claude Community Kenya",
+  robots: { index: false, follow: false },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#141413",
+};
+
+export default function SignupLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/src/components/karibu/KaribuEventDetail.tsx
+++ b/src/components/karibu/KaribuEventDetail.tsx
@@ -21,6 +21,7 @@ import { KaribuDemoRequestForm } from "@/components/karibu/KaribuDemoRequestForm
 import { eventCover } from "@/components/karibu/photos";
 import { EventCoverPlaceholder } from "@/components/karibu/EventCoverPlaceholder";
 import { Reveal } from "@/components/karibu/motion/Reveal";
+import { isEventPast } from "@/lib/event-dates";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 
@@ -68,7 +69,8 @@ export function KaribuEventDetail({
   const dt = parseDate(event.date);
   const registerUrl = event.registrationUrl || event.lumaUrl;
   const soldOut = event.status === "sold-out";
-  const isPast = event.status === "completed";
+  // Status alone is not enough — it is set by hand in admin. See lib/event-dates.
+  const isPast = event.status === "completed" || isEventPast(event.date);
   const cover = eventCover(event.posterUrl);
 
   return (

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -18,6 +18,7 @@ import { useSocialLinks } from "@/contexts/SocialLinksContext";
 import { eventCover } from "@/components/karibu/photos";
 import { EventCoverPlaceholder } from "@/components/karibu/EventCoverPlaceholder";
 import { Reveal } from "@/components/karibu/motion/Reveal";
+import { isEventPast } from "@/lib/event-dates";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
 const FLIP_EASE = [0.16, 1, 0.3, 1] as const;
@@ -83,17 +84,20 @@ export function KaribuEvents({ events }: { events: Event[] }) {
     return events.filter((e) => (kind === "city" ? e.city === value : e.type === value));
   }, [events, active]);
 
+  // Both halves test the date as well as the status: status is set by hand in
+  // admin, so a finished event left as UPCOMING would otherwise sit in the
+  // upcoming band and be missing from the past one. See lib/event-dates.
   const upcoming = useMemo(
     () =>
       filtered
-        .filter((e) => UPCOMING_STATUSES.includes(e.status))
+        .filter((e) => UPCOMING_STATUSES.includes(e.status) && !isEventPast(e.date))
         .sort((a, b) => a.date.localeCompare(b.date)),
     [filtered],
   );
   const past = useMemo(
     () =>
       filtered
-        .filter((e) => e.status === "completed")
+        .filter((e) => e.status === "completed" || isEventPast(e.date))
         .sort((a, b) => b.date.localeCompare(a.date)),
     [filtered],
   );

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -6,6 +6,7 @@
 import { prisma } from "@/lib/prisma"
 import { decodeHtmlEntities } from "@/lib/input-sanitization"
 import { publicUrl, variantKey } from "@/lib/gallery/r2"
+import { startOfTodayEAT } from "@/lib/event-dates"
 import type { Event } from "@/lib/types"
 import type {
   Event as PrismaEvent,
@@ -235,26 +236,6 @@ export async function getEvents(): Promise<Event[]> {
 export async function getEventBySlug(slug: string): Promise<Event | null> {
   const row = await prisma.event.findUnique({ where: { slug } })
   return row ? mapPrismaEvent(row) : null
-}
-
-/** East Africa Time is UTC+3 year-round — no DST to account for. */
-const EAT_OFFSET_MS = 3 * 60 * 60 * 1000
-
-/**
- * The instant of midnight-today in Nairobi, as a UTC Date.
- *
- * Events store `date` as the day (time lives in the separate `time` string),
- * so comparing against `now` would drop a same-day event the moment the clock
- * passed its stored midnight — the site would stop advertising tonight's
- * meetup on the morning of the meetup. Start-of-day keeps it listed until the
- * day is genuinely over.
- */
-function startOfTodayEAT(): Date {
-  const eatNow = new Date(Date.now() + EAT_OFFSET_MS)
-  return new Date(
-    Date.UTC(eatNow.getUTCFullYear(), eatNow.getUTCMonth(), eatNow.getUTCDate()) -
-      EAT_OFFSET_MS,
-  )
 }
 
 export async function getUpcomingEvents(): Promise<Event[]> {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -721,7 +721,7 @@ export function impactLabResultsEmail(data: {
             </table>
             <p style="margin:0 0 24px;font-family:monospace,monospace;font-size:11px;color:#888;">If the button doesn't work, paste this URL into your browser:<br>${esc(data.dashboardUrl)}</p>
 
-            <p style="margin:0;font-family:monospace,monospace;font-size:11px;color:#555;">Claude Community Kenya · ${APP_URL}</p>
+            <p style="margin:0;font-family:monospace,monospace;font-size:11px;color:#888;">Claude Community Kenya · ${APP_URL}</p>
           </td>
         </tr>
       </table>

--- a/src/lib/event-dates.ts
+++ b/src/lib/event-dates.ts
@@ -1,0 +1,50 @@
+/**
+ * When an event is over — one definition, shared by every surface.
+ *
+ * This exists because the answer was previously computed in four places that
+ * disagreed. `getUpcomingEvents()` filtered on the stored date; the two event
+ * detail components and the events listing each tested `status` alone. Status
+ * is set by hand in admin, so a finished event left as UPCOMING vanished from
+ * the homepage (date-filtered) while its own detail page went on offering
+ * "Register Now" — the list was date-true and the detail page was status-true.
+ *
+ * Pure and dependency-free on purpose: `lib/data.ts` imports Prisma, so a
+ * predicate living there could never be called from the client components that
+ * need it. Everything here works on both a Prisma `Date` and the
+ * "YYYY-MM-DD" string `mapPrismaEvent` hands to the view layer.
+ */
+
+/** East Africa Time is UTC+3 year-round — no DST to account for. */
+const EAT_OFFSET_MS = 3 * 60 * 60 * 1000
+
+/**
+ * The instant of midnight-today in Nairobi, as a UTC Date.
+ *
+ * Events store `date` as the day (time lives in the separate `time` string),
+ * so comparing against `now` would drop a same-day event the moment the clock
+ * passed its stored midnight — the site would stop advertising tonight's
+ * meetup on the morning of the meetup. Start-of-day keeps it listed until the
+ * day is genuinely over.
+ */
+export function startOfTodayEAT(): Date {
+  const eatNow = new Date(Date.now() + EAT_OFFSET_MS)
+  return new Date(
+    Date.UTC(eatNow.getUTCFullYear(), eatNow.getUTCMonth(), eatNow.getUTCDate()) -
+      EAT_OFFSET_MS,
+  )
+}
+
+/**
+ * True once the event's day has fully passed in Nairobi.
+ *
+ * The string form is parsed as UTC midnight to match how `mapPrismaEvent`
+ * produces it (`e.date.toISOString().split("T")[0]`), so a date-only string
+ * and the Prisma `Date` it came from always give the same answer. An
+ * unparseable date returns false — a malformed row should not silently
+ * retire a live event.
+ */
+export function isEventPast(date: string | Date): boolean {
+  const day = typeof date === "string" ? new Date(`${date}T00:00:00Z`) : date
+  if (Number.isNaN(day.getTime())) return false
+  return day < startOfTodayEAT()
+}

--- a/src/lib/impact-lab/export-theme.ts
+++ b/src/lib/impact-lab/export-theme.ts
@@ -26,8 +26,16 @@ export const SLATE_BLUE = "#6a9bcc"
 export const OLIVE = "#788c5d"
 /** Secondary text. */
 export const DIM = "#57554d"
-/** Tertiary text — captions, page furniture. */
-export const FAINT = "#8a887f"
+/**
+ * Tertiary text — captions, page furniture.
+ *
+ * Darkened from #8a887f, which rendered at 3.37:1 on PAPER, 3.10:1 on
+ * CALLOUT_BG and 2.84:1 on TRACK — below WCAG AA at every size it is used
+ * (7pt–8.5pt captions, axis labels and footers, never large text). #68665e
+ * clears 4.5:1 on all three backdrops while staying visibly lighter than
+ * DIM, so the INK > DIM > FAINT hierarchy is unchanged.
+ */
+export const FAINT = "#68665e"
 /** Mid gray — Anthropic's secondary element tone. */
 export const MID_GRAY = "#b0aea5"
 /** Subtle fill — chart tracks, zebra tints. Anthropic light gray. */


### PR DESCRIPTION
Green-lit subset of a post-merge audit against `main` @ d733850. Four commits, one logical change each. `npx tsc --noEmit` and `npm run build` pass on every one.

## SEO

**`fix(seo): per-page metadata for pages inheriting root title`**

`/signup` was the only public route with no metadata anywhere — no page export and, unlike its four sibling auth routes, no layout carrying one. It inherited the root title and the root robots policy, so an account-creation form was indexable.

`sitemap.ts` omits the auth routes on the stated understanding that "the corresponding pages also export `robots: { index: false }`". That was true of login, forgot-password, reset-password and verify-email, whose route layouts set it. It was not true of signup. Adds a layout in the same shape as login's, so the comment now describes every auth route.

Ten further routes were flagged during the audit as metadata-less. They are not: each carries full metadata — title, description and canonical — in its route layout. Only their `page.tsx` files lack it, which is not a defect. No pages added in #81–#96 are missing metadata; `/judge`, `/timer`, `/dashboard/*` and `/account/data` all set `robots: index:false`.

**`fix(seo): canonical URLs for code-of-conduct and resources/links`**

Both set an `openGraph.url` but no `alternates.canonical`, so neither emitted a canonical link tag — the last two indexable public routes without one. Uses the absolute form the sibling pages already use so the two spellings cannot drift.

## Accessibility

**`fix(a11y): contrast and labels on new result/export surfaces`**

Two colour values on the new results surfaces fell below WCAG AA. Both are palette constants — no feature logic, no layout, no copy.

- **PDF export**: `FAINT` was `#8a887f` — 3.37:1 on PAPER, 3.10:1 on CALLOUT_BG, 2.84:1 on TRACK. It carries 7pt–8.5pt captions, chart axis labels and page footers across 17 call sites in `export-pdf.ts` and `export-pdf-charts.ts`, all small text, so 4.5:1 applies and none of those pairings met it. `#68665e` clears 4.5:1 on all three backdrops and stays lighter than `DIM`, leaving the INK > DIM > FAINT hierarchy intact.
- **Results email**: the footer line was `#555` on `#0a0a0a` — 2.66:1 at 11px. The line immediately above already used `#888` (5.58:1); matched to that.

Audited and deliberately left alone: `ResultsView.tsx` measures 4.5:1 or better on all 25 of its text/background pairings under `.persona-pro` (which `layout.tsx` applies globally, so the Anthropic token set renders rather than the Terminal Noir defaults — worst pair 5.21:1). It already labels every section, gives the score bars `role="progressbar"` with min/max/now, marks decorative icons `aria-hidden`, scopes its table headers and honours `useReducedMotion`. PDF `CLAY` at 4.10:1 appears only on a 44pt heading and decorative rules, clearing the 3:1 large-text threshold.

## Links

No commit — nothing to fix. All 41 distinct internal `href`s resolve against the route tree (58 static + 19 dynamic). No broken links and no placeholder hrefs.

## Structural

**`fix: date-guard event actionability across detail and listing surfaces`**

Whether an event is over was computed in four places that disagreed. `getUpcomingEvents()` filtered on the stored date; both event detail components and the events listing tested `status` alone. Status is set by hand in admin, so a finished event left as UPCOMING can disappear from the homepage — which is date-filtered — while its own detail page goes on offering "Register Now", and the listing keeps it in the upcoming band and out of the past one.

This corrects a date-guard gap that can surface "Register Now" on a finished event. Whether it changes anything today depends on the stored status of the existing rows, which this PR does not touch.

Collapses all four onto one predicate in `lib/event-dates.ts` so they cannot drift apart again:

| Site | Change |
|---|---|
| `data.ts` | `startOfTodayEAT()` moved here, unchanged |
| `EventDetailContent.tsx` | `isActionable` now also requires `!isEventPast` |
| `KaribuEventDetail.tsx` | `isPast` now also true once the date has passed |
| `KaribuEvents.tsx` | both the upcoming and past filters date-guarded |

The module is pure so the client components can import it; `lib/data.ts` pulls in Prisma and could never have hosted it. Start-of-day-in-Nairobi semantics are preserved exactly, so a same-day event stays live for its whole day. Date-only strings parse as UTC midnight to match how `mapPrismaEvent` emits them, so a string and the Prisma `Date` it came from always agree. An unparseable date returns `false` — a malformed row should not silently retire a live event.

## Deliberately not addressed

- **The "Africa" overclaims** (`signup/page.tsx`, `ConsoleWelcome.tsx`) are left untouched by decision, not oversight.
- **An Impact Lab archive-path inconsistency** surfaced in the same audit is going to @Spidey-Acer directly rather than being fixed here, since it sits inside the active #81–#96 work.
- Nothing in this PR reverts, reworks or conflicts with the results/export/email/review surfaces.
