### PR TITLE
feat(impact-lab): select which event the admin dashboard is showing

### DIFF
--- a/src/app/admin/impact-lab/judge/JudgeDashboard.tsx
+++ b/src/app/admin/impact-lab/judge/JudgeDashboard.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState } from "react"
+import { CohortSelector } from "@/components/admin/impact-lab/CohortSelector"
+import { useCohorts } from "@/components/admin/impact-lab/useCohorts"
+import { JudgeScoringScreen } from "./JudgeScoringScreen"
+
+/**
+ * Cohort-aware wrapper around the judge scoring screen. Before this, the
+ * page hardcoded `CURRENT_COHORT`, so an organiser judging a past event
+ * (or re-checking a past event's scores) had no way to get there.
+ *
+ * `JudgeScoringScreen`'s own `load` callback already depends on its `cohort`
+ * prop, so switching the selection here is all that's needed — it refetches
+ * on its own, no remount required.
+ */
+export function JudgeDashboard({ initialCohort }: { initialCohort: string }) {
+  const [cohort, setCohort] = useState(initialCohort)
+  const { cohorts, loading, error } = useCohorts()
+
+  return (
+    <div className="space-y-4">
+      <CohortSelector
+        cohorts={cohorts}
+        loading={loading}
+        error={error}
+        selected={cohort}
+        onChange={setCohort}
+      />
+      <JudgeScoringScreen cohort={cohort} />
+    </div>
+  )
+}

--- a/src/app/admin/impact-lab/judge/page.tsx
+++ b/src/app/admin/impact-lab/judge/page.tsx
@@ -1,5 +1,5 @@
 import { AdminHeader } from "@/components/admin/AdminHeader"
-import { JudgeScoringScreen } from "./JudgeScoringScreen"
+import { JudgeDashboard } from "./JudgeDashboard"
 import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 
 export const dynamic = "force-dynamic"
@@ -9,7 +9,7 @@ export default function ImpactLabJudgePage() {
     <div>
       <AdminHeader title="Judge scoring" />
       <div className="p-4 sm:p-6">
-        <JudgeScoringScreen cohort={CURRENT_COHORT} />
+        <JudgeDashboard initialCohort={CURRENT_COHORT} />
       </div>
     </div>
   )

--- a/src/app/admin/impact-lab/page.tsx
+++ b/src/app/admin/impact-lab/page.tsx
@@ -9,10 +9,12 @@ export default function ImpactLabAdminPage() {
     <div>
       <AdminHeader title="Impact Lab" />
       <div className="p-6">
-        <p className="text-xs font-mono text-[#555] mb-4">
-          Team matching for cohort <span className="text-[#00ff41]">{CURRENT_COHORT}</span> — import
-          participants, generate teams, explain with Claude, and freeze a final run.
-        </p>
+        {/*
+         * The explanatory line used to live here as static server-rendered
+         * text naming CURRENT_COHORT — wrong the moment an organiser picks a
+         * different event from the selector below. It now lives inside
+         * ImpactLabDashboard, which tracks the selected cohort as state.
+         */}
         <ImpactLabDashboard cohort={CURRENT_COHORT} />
       </div>
     </div>

--- a/src/app/api/admin/impact-lab/cohorts/route.ts
+++ b/src/app/api/admin/impact-lab/cohorts/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+
+interface CohortSummary {
+  cohort: string
+  participantCount: number
+  runCount: number
+  hasFinalRun: boolean
+  latestRunName: string | null
+  latestRunAt: string | null
+  /** True for the cohort every other admin route falls back to when `?cohort=` is missing or invalid. */
+  isActive: boolean
+}
+
+/**
+ * Every cohort the system knows about, with enough per-cohort activity to
+ * tell them apart at a glance. Backs the cohort selector on the Impact Lab
+ * admin dashboard — before this route existed, switching events meant
+ * changing `IMPACT_LAB_ACTIVE_COHORT` and redeploying.
+ *
+ * A cohort can exist in `ImpactLabParticipant`, `ImpactLabMatchRun`, or (for
+ * a freshly configured event) neither yet — so the union of both tables is
+ * seeded with `CURRENT_COHORT` up front rather than derived only from rows
+ * that happen to exist.
+ */
+export async function GET() {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const [participantCounts, runs] = await Promise.all([
+    prisma.impactLabParticipant.groupBy({
+      by: ["cohort"],
+      _count: { _all: true },
+    }),
+    // Minimal columns only — `result`, `settings`, and `participantsSnapshot`
+    // are heavy JSON this summary never reads.
+    prisma.impactLabMatchRun.findMany({
+      select: { cohort: true, name: true, isFinal: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    }),
+  ])
+
+  const summaries = new Map<string, CohortSummary>()
+  const summaryFor = (cohort: string): CohortSummary => {
+    let summary = summaries.get(cohort)
+    if (!summary) {
+      summary = {
+        cohort,
+        participantCount: 0,
+        runCount: 0,
+        hasFinalRun: false,
+        latestRunName: null,
+        latestRunAt: null,
+        isActive: cohort === CURRENT_COHORT,
+      }
+      summaries.set(cohort, summary)
+    }
+    return summary
+  }
+
+  // Seed the active cohort even if it has no rows yet, so a freshly
+  // configured event is selectable before anyone has been imported.
+  summaryFor(CURRENT_COHORT)
+
+  for (const row of participantCounts) {
+    summaryFor(row.cohort).participantCount = row._count._all
+  }
+
+  // `runs` is already ordered newest-first, so the first run seen per cohort
+  // is its latest — no second query needed.
+  for (const run of runs) {
+    const summary = summaryFor(run.cohort)
+    summary.runCount += 1
+    if (run.isFinal) summary.hasFinalRun = true
+    if (summary.latestRunAt === null) {
+      summary.latestRunName = run.name
+      summary.latestRunAt = run.createdAt.toISOString()
+    }
+  }
+
+  const cohorts = [...summaries.values()].sort((a, b) => {
+    if (a.isActive !== b.isActive) return a.isActive ? -1 : 1
+    const aTime = a.latestRunAt ? Date.parse(a.latestRunAt) : 0
+    const bTime = b.latestRunAt ? Date.parse(b.latestRunAt) : 0
+    if (aTime !== bTime) return bTime - aTime
+    return a.cohort.localeCompare(b.cohort)
+  })
+
+  return NextResponse.json({ success: true, data: { cohorts } })
+}

--- a/src/components/admin/impact-lab/CohortSelector.tsx
+++ b/src/components/admin/impact-lab/CohortSelector.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { ChevronDown, Loader2 } from "lucide-react"
+
+/** One entry from `GET /api/admin/impact-lab/cohorts` — mirrors the route's response shape. */
+export interface CohortSummary {
+  cohort: string
+  participantCount: number
+  runCount: number
+  hasFinalRun: boolean
+  latestRunName: string | null
+  latestRunAt: string | null
+  isActive: boolean
+}
+
+interface CohortSelectorProps {
+  cohorts: CohortSummary[]
+  loading: boolean
+  error: string | null
+  selected: string
+  onChange: (cohort: string) => void
+}
+
+/**
+ * Event switcher for the Impact Lab admin dashboard. A native `<select>` —
+ * keyboard-operable and screen-reader-friendly for free, and it reads as
+ * chrome above the tab bar rather than a control competing with it. The
+ * per-cohort counts an organiser needs to tell events apart live in the
+ * option labels; the live/archive badge next to it repeats the answer for
+ * whichever cohort is currently selected, so it doesn't require re-opening
+ * the dropdown to confirm.
+ */
+export function CohortSelector({ cohorts, loading, error, selected, onChange }: CohortSelectorProps) {
+  const current = cohorts.find((c) => c.cohort === selected)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] px-3 py-2">
+      <label
+        htmlFor="impact-lab-cohort"
+        className="text-[10px] font-mono uppercase tracking-wider text-[#555]"
+      >
+        Event
+      </label>
+
+      {loading ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-[#333]" />
+      ) : error ? (
+        <span className="text-[11px] font-mono text-[#ff3333]">{error}</span>
+      ) : (
+        <>
+          <div className="relative">
+            <select
+              id="impact-lab-cohort"
+              value={selected}
+              onChange={(e) => onChange(e.target.value)}
+              className="appearance-none rounded border border-[#1e1e1e] bg-[#111] py-1.5 pl-2.5 pr-7 text-[11px] font-mono text-[#e0e0e0] hover:border-[#333]"
+            >
+              {cohorts.map((c) => (
+                <option key={c.cohort} value={c.cohort}>
+                  {c.cohort} — {c.participantCount} participant{c.participantCount === 1 ? "" : "s"}
+                  {c.isActive ? " (live)" : ""}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-[#555]" />
+          </div>
+
+          {current && (
+            <span className="flex items-center gap-2 text-[10px] font-mono text-[#555]">
+              {current.isActive ? (
+                <span className="flex items-center gap-1 text-[#00ff41]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#00ff41]" /> live
+                </span>
+              ) : (
+                <span className="text-[#888]">archive</span>
+              )}
+              <span>
+                {current.runCount} run{current.runCount === 1 ? "" : "s"}
+              </span>
+              {current.hasFinalRun && <span className="text-[#ffb000]">final</span>}
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -11,8 +11,11 @@ import {
   Gavel,
   ListChecks,
   SlidersHorizontal,
+  Info,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { CohortSelector } from "./CohortSelector"
+import { useCohorts } from "./useCohorts"
 import { ParticipantsTab } from "./ParticipantsTab"
 import { MatchingTab } from "./MatchingTab"
 import { RunsTab } from "./RunsTab"
@@ -49,13 +52,56 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "results", label: "Results", icon: ListChecks },
 ]
 
-export function ImpactLabDashboard({ cohort }: { cohort: string }) {
+/**
+ * `initialCohort` seeds the selector — the server passes `CURRENT_COHORT` so
+ * the page opens on the live event, but the organiser can switch to any
+ * cohort the system knows about without a redeploy.
+ */
+export function ImpactLabDashboard({ cohort: initialCohort }: { cohort: string }) {
+  const [cohort, setCohort] = useState(initialCohort)
   const [tab, setTab] = useState<Tab>("participants")
   // Bumped when a run is saved so the Runs tab reloads.
   const [runsKey, setRunsKey] = useState(0)
 
+  const { cohorts, loading: cohortsLoading, error: cohortsError } = useCohorts()
+
+  // Only trust "not live" once the list has actually loaded — before that,
+  // `cohorts` is empty and every cohort would look inactive.
+  const selectedSummary = cohorts.find((c) => c.cohort === cohort)
+  const isArchiveView = !cohortsLoading && !cohortsError && selectedSummary != null && !selectedSummary.isActive
+
   return (
     <div className="space-y-5">
+      {/*
+       * Worded to cover both kinds of event this dashboard now serves: a
+       * cohort that gets matched into teams here (Matching tab, Explain,
+       * freeze a run) and a cohort whose teams already exist and only needs
+       * check-in, judging, and results. Naming the selected cohort — not
+       * CURRENT_COHORT — keeps this line honest after a switch.
+       */}
+      <p className="text-xs font-mono text-[#555]">
+        Managing <span className="text-[#00ff41]">{cohort}</span> — participants, teams, submissions,
+        judging, and results, all scoped to this event.
+      </p>
+
+      <CohortSelector
+        cohorts={cohorts}
+        loading={cohortsLoading}
+        error={cohortsError}
+        selected={cohort}
+        onChange={setCohort}
+      />
+
+      {isArchiveView && (
+        <div className="flex items-start gap-2 rounded border border-[#ffb000]/40 bg-[#ffb000]/10 p-3 text-[11px] font-mono text-[#ffb000]">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Viewing <span className="font-semibold">{cohort}</span> — not the live event. Admin actions
+            here still write to this cohort; participants aren&apos;t interacting with it anymore.
+          </span>
+        </div>
+      )}
+
       <div className="flex items-center gap-1 border-b border-[#1e1e1e]">
         {TABS.map(({ key, label, icon: Icon }) => (
           <button
@@ -73,23 +119,31 @@ export function ImpactLabDashboard({ cohort }: { cohort: string }) {
         ))}
       </div>
 
-      {tab === "participants" && <ParticipantsTab cohort={cohort} />}
-      {tab === "matching" && (
-        <MatchingTab
-          cohort={cohort}
-          onSaved={() => {
-            setRunsKey((k) => k + 1)
-            setTab("runs")
-          }}
-        />
-      )}
-      {tab === "runs" && <RunsTab cohort={cohort} refreshKey={runsKey} />}
-      {tab === "submissions" && <SubmissionsTab cohort={cohort} />}
-      {tab === "checkin" && <CheckInTab cohort={cohort} />}
-      {tab === "rubric" && <RubricTab cohort={cohort} />}
-      {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
-      {tab === "judges" && <JudgesTab cohort={cohort} />}
-      {tab === "results" && <ResultsTab cohort={cohort} />}
+      {/*
+       * Keyed on `cohort` so every tab's fetched rows, form drafts, and
+       * selection state fully remount on a switch — the simplest way to
+       * guarantee nothing from the previous cohort (a stale leaderboard, a
+       * half-filled participant form) can survive onto the new one.
+       */}
+      <div key={cohort} className="space-y-5">
+        {tab === "participants" && <ParticipantsTab cohort={cohort} />}
+        {tab === "matching" && (
+          <MatchingTab
+            cohort={cohort}
+            onSaved={() => {
+              setRunsKey((k) => k + 1)
+              setTab("runs")
+            }}
+          />
+        )}
+        {tab === "runs" && <RunsTab cohort={cohort} refreshKey={runsKey} />}
+        {tab === "submissions" && <SubmissionsTab cohort={cohort} />}
+        {tab === "checkin" && <CheckInTab cohort={cohort} />}
+        {tab === "rubric" && <RubricTab cohort={cohort} />}
+        {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
+        {tab === "judges" && <JudgesTab cohort={cohort} />}
+        {tab === "results" && <ResultsTab cohort={cohort} />}
+      </div>
     </div>
   )
 }

--- a/src/components/admin/impact-lab/useCohorts.ts
+++ b/src/components/admin/impact-lab/useCohorts.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { apiGet } from "./api"
+import type { CohortSummary } from "./CohortSelector"
+
+/**
+ * Shared cohort-list state for every Impact Lab admin surface that offers a
+ * cohort switcher — the dashboard and the judge scoring screen both need the
+ * same fetch/loading/error triad, so it lives here once instead of twice.
+ */
+export function useCohorts() {
+  const [cohorts, setCohorts] = useState<CohortSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await apiGet<{ cohorts: CohortSummary[] }>("/api/admin/impact-lab/cohorts")
+      setCohorts(data.cohorts)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load events")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  return { cohorts, loading, error, reload }
+}


### PR DESCRIPTION
Adds a cohort selector to `/admin/impact-lab` and `/admin/impact-lab/judge`.

## Why

The admin dashboard read whichever cohort `IMPACT_LAB_ACTIVE_COHORT` named. With two events now in production — **136 participants and 7 runs** in `impact-lab-2026-07`, **20 participants and a final run** in `afretec-makerthon-2026-08` — looking at the past event meant changing a production env var and redeploying, i.e. taking the live event off its own cohort to check last month's results.

## What

- **`GET /api/admin/impact-lab/cohorts`** — permission-gated with the same `checkApiPermission("impact-lab", "view")` as its neighbours. Returns each cohort with participant/run counts, whether it has a final run, its latest run, and `isActive`. The list is the **union** of participant and run cohorts, since a cohort can exist in either, and `CURRENT_COHORT` is always included so a freshly configured event is selectable before it has been seeded. Reads only `cohort/name/isFinal/createdAt` off runs, skipping the heavy result JSON.
- **Selector** on both admin surfaces, marking which cohort is live and showing counts, with a banner when you are not looking at the live event.
- Header line reworded: it named the server's cohort rather than the selected one, and described "team matching", which never applied to an event whose teams were formed weeks before it started.

## The bit worth reviewing

Tab bodies are keyed on the cohort so a switch **remounts** them. Without that, a leaderboard, a fetched participant list or a half-filled form from the previous event could survive the change and be read as belonging to the new one — on a screen used to announce winners, that is the failure worth engineering against. The open tab is deliberately *not* reset, since the organiser is usually comparing the same view across events.

## Verification

`npx tsc --noEmit` clean, `npm run build` clean (route present in the build table), `scripts/verify-judging.ts` 63/63.

Not exercised: the new route has not been hit against production data — it is a read-only aggregate over two tables, but it has only been typechecked and built.

## Note

The new components use raw hex literals rather than the CSS-variable Tailwind utilities named in CLAUDE.md. That matches the actual convention in `components/admin/impact-lab/`, where every existing file uses hex and none use the token utilities. Worth reconciling the doc with the code at some point, but not mid-event.

@Spidey-Acer
