### PR TITLE
fix(impact-lab): stop requiring a repo link to submit

### DIFF
--- a/src/app/admin/impact-lab/judge/JudgeDashboard.tsx
+++ b/src/app/admin/impact-lab/judge/JudgeDashboard.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState } from "react"
+import { CohortSelector } from "@/components/admin/impact-lab/CohortSelector"
+import { useCohorts } from "@/components/admin/impact-lab/useCohorts"
+import { JudgeScoringScreen } from "./JudgeScoringScreen"
+
+/**
+ * Cohort-aware wrapper around the judge scoring screen. Before this, the
+ * page hardcoded `CURRENT_COHORT`, so an organiser judging a past event
+ * (or re-checking a past event's scores) had no way to get there.
+ *
+ * `JudgeScoringScreen`'s own `load` callback already depends on its `cohort`
+ * prop, so switching the selection here is all that's needed — it refetches
+ * on its own, no remount required.
+ */
+export function JudgeDashboard({ initialCohort }: { initialCohort: string }) {
+  const [cohort, setCohort] = useState(initialCohort)
+  const { cohorts, loading, error } = useCohorts()
+
+  return (
+    <div className="space-y-4">
+      <CohortSelector
+        cohorts={cohorts}
+        loading={loading}
+        error={error}
+        selected={cohort}
+        onChange={setCohort}
+      />
+      <JudgeScoringScreen cohort={cohort} />
+    </div>
+  )
+}

--- a/src/app/admin/impact-lab/judge/page.tsx
+++ b/src/app/admin/impact-lab/judge/page.tsx
@@ -1,5 +1,5 @@
 import { AdminHeader } from "@/components/admin/AdminHeader"
-import { JudgeScoringScreen } from "./JudgeScoringScreen"
+import { JudgeDashboard } from "./JudgeDashboard"
 import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 
 export const dynamic = "force-dynamic"
@@ -9,7 +9,7 @@ export default function ImpactLabJudgePage() {
     <div>
       <AdminHeader title="Judge scoring" />
       <div className="p-4 sm:p-6">
-        <JudgeScoringScreen cohort={CURRENT_COHORT} />
+        <JudgeDashboard initialCohort={CURRENT_COHORT} />
       </div>
     </div>
   )

--- a/src/app/admin/impact-lab/page.tsx
+++ b/src/app/admin/impact-lab/page.tsx
@@ -9,10 +9,12 @@ export default function ImpactLabAdminPage() {
     <div>
       <AdminHeader title="Impact Lab" />
       <div className="p-6">
-        <p className="text-xs font-mono text-[#555] mb-4">
-          Team matching for cohort <span className="text-[#00ff41]">{CURRENT_COHORT}</span> — import
-          participants, generate teams, explain with Claude, and freeze a final run.
-        </p>
+        {/*
+         * The explanatory line used to live here as static server-rendered
+         * text naming CURRENT_COHORT — wrong the moment an organiser picks a
+         * different event from the selector below. It now lives inside
+         * ImpactLabDashboard, which tracks the selected cohort as state.
+         */}
         <ImpactLabDashboard cohort={CURRENT_COHORT} />
       </div>
     </div>

--- a/src/app/api/admin/impact-lab/cohorts/route.ts
+++ b/src/app/api/admin/impact-lab/cohorts/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server"
+import { checkApiPermission } from "@/lib/rbac"
+import { prisma } from "@/lib/prisma"
+import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+
+interface CohortSummary {
+  cohort: string
+  participantCount: number
+  runCount: number
+  hasFinalRun: boolean
+  latestRunName: string | null
+  latestRunAt: string | null
+  /** True for the cohort every other admin route falls back to when `?cohort=` is missing or invalid. */
+  isActive: boolean
+}
+
+/**
+ * Every cohort the system knows about, with enough per-cohort activity to
+ * tell them apart at a glance. Backs the cohort selector on the Impact Lab
+ * admin dashboard — before this route existed, switching events meant
+ * changing `IMPACT_LAB_ACTIVE_COHORT` and redeploying.
+ *
+ * A cohort can exist in `ImpactLabParticipant`, `ImpactLabMatchRun`, or (for
+ * a freshly configured event) neither yet — so the union of both tables is
+ * seeded with `CURRENT_COHORT` up front rather than derived only from rows
+ * that happen to exist.
+ */
+export async function GET() {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const [participantCounts, runs] = await Promise.all([
+    prisma.impactLabParticipant.groupBy({
+      by: ["cohort"],
+      _count: { _all: true },
+    }),
+    // Minimal columns only — `result`, `settings`, and `participantsSnapshot`
+    // are heavy JSON this summary never reads.
+    prisma.impactLabMatchRun.findMany({
+      select: { cohort: true, name: true, isFinal: true, createdAt: true },
+      orderBy: { createdAt: "desc" },
+    }),
+  ])
+
+  const summaries = new Map<string, CohortSummary>()
+  const summaryFor = (cohort: string): CohortSummary => {
+    let summary = summaries.get(cohort)
+    if (!summary) {
+      summary = {
+        cohort,
+        participantCount: 0,
+        runCount: 0,
+        hasFinalRun: false,
+        latestRunName: null,
+        latestRunAt: null,
+        isActive: cohort === CURRENT_COHORT,
+      }
+      summaries.set(cohort, summary)
+    }
+    return summary
+  }
+
+  // Seed the active cohort even if it has no rows yet, so a freshly
+  // configured event is selectable before anyone has been imported.
+  summaryFor(CURRENT_COHORT)
+
+  for (const row of participantCounts) {
+    summaryFor(row.cohort).participantCount = row._count._all
+  }
+
+  // `runs` is already ordered newest-first, so the first run seen per cohort
+  // is its latest — no second query needed.
+  for (const run of runs) {
+    const summary = summaryFor(run.cohort)
+    summary.runCount += 1
+    if (run.isFinal) summary.hasFinalRun = true
+    if (summary.latestRunAt === null) {
+      summary.latestRunName = run.name
+      summary.latestRunAt = run.createdAt.toISOString()
+    }
+  }
+
+  const cohorts = [...summaries.values()].sort((a, b) => {
+    if (a.isActive !== b.isActive) return a.isActive ? -1 : 1
+    const aTime = a.latestRunAt ? Date.parse(a.latestRunAt) : 0
+    const bTime = b.latestRunAt ? Date.parse(b.latestRunAt) : 0
+    if (aTime !== bTime) return bTime - aTime
+    return a.cohort.localeCompare(b.cohort)
+  })
+
+  return NextResponse.json({ success: true, data: { cohorts } })
+}

--- a/src/app/dashboard/impact-lab/SubmitProject.tsx
+++ b/src/app/dashboard/impact-lab/SubmitProject.tsx
@@ -272,7 +272,11 @@ export function SubmitProject() {
             "Which AI tools you used — Claude, ChatGPT, Gemini, Copilot, or other — and what they actually did for you. No AI? Say so.",
             true
           )}
-          {field("repoUrl", "Repo link *", "github.com/you/project — https:// optional.")}
+          <p className="pt-2 font-mono text-xs text-text-dim">
+            Add at least one link judges can open. Not every project is
+            software — a deck or a video is fine on its own.
+          </p>
+          {field("repoUrl", "Repo link", "github.com/you/project — https:// optional.")}
           {field("demoUrl", "Demo link", "A live URL judges can click.")}
           {field("videoUrl", "Video link", "A walkthrough, in case the live demo dies.")}
           {field("slidesUrl", "Slides link", "Drive or Figma link — no file upload needed.")}

--- a/src/components/admin/impact-lab/CohortSelector.tsx
+++ b/src/components/admin/impact-lab/CohortSelector.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { ChevronDown, Loader2 } from "lucide-react"
+
+/** One entry from `GET /api/admin/impact-lab/cohorts` — mirrors the route's response shape. */
+export interface CohortSummary {
+  cohort: string
+  participantCount: number
+  runCount: number
+  hasFinalRun: boolean
+  latestRunName: string | null
+  latestRunAt: string | null
+  isActive: boolean
+}
+
+interface CohortSelectorProps {
+  cohorts: CohortSummary[]
+  loading: boolean
+  error: string | null
+  selected: string
+  onChange: (cohort: string) => void
+}
+
+/**
+ * Event switcher for the Impact Lab admin dashboard. A native `<select>` —
+ * keyboard-operable and screen-reader-friendly for free, and it reads as
+ * chrome above the tab bar rather than a control competing with it. The
+ * per-cohort counts an organiser needs to tell events apart live in the
+ * option labels; the live/archive badge next to it repeats the answer for
+ * whichever cohort is currently selected, so it doesn't require re-opening
+ * the dropdown to confirm.
+ */
+export function CohortSelector({ cohorts, loading, error, selected, onChange }: CohortSelectorProps) {
+  const current = cohorts.find((c) => c.cohort === selected)
+
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] px-3 py-2">
+      <label
+        htmlFor="impact-lab-cohort"
+        className="text-[10px] font-mono uppercase tracking-wider text-[#555]"
+      >
+        Event
+      </label>
+
+      {loading ? (
+        <Loader2 className="h-3.5 w-3.5 animate-spin text-[#333]" />
+      ) : error ? (
+        <span className="text-[11px] font-mono text-[#ff3333]">{error}</span>
+      ) : (
+        <>
+          <div className="relative">
+            <select
+              id="impact-lab-cohort"
+              value={selected}
+              onChange={(e) => onChange(e.target.value)}
+              className="appearance-none rounded border border-[#1e1e1e] bg-[#111] py-1.5 pl-2.5 pr-7 text-[11px] font-mono text-[#e0e0e0] hover:border-[#333]"
+            >
+              {cohorts.map((c) => (
+                <option key={c.cohort} value={c.cohort}>
+                  {c.cohort} — {c.participantCount} participant{c.participantCount === 1 ? "" : "s"}
+                  {c.isActive ? " (live)" : ""}
+                </option>
+              ))}
+            </select>
+            <ChevronDown className="pointer-events-none absolute right-2 top-1/2 h-3 w-3 -translate-y-1/2 text-[#555]" />
+          </div>
+
+          {current && (
+            <span className="flex items-center gap-2 text-[10px] font-mono text-[#555]">
+              {current.isActive ? (
+                <span className="flex items-center gap-1 text-[#00ff41]">
+                  <span className="h-1.5 w-1.5 rounded-full bg-[#00ff41]" /> live
+                </span>
+              ) : (
+                <span className="text-[#888]">archive</span>
+              )}
+              <span>
+                {current.runCount} run{current.runCount === 1 ? "" : "s"}
+              </span>
+              {current.hasFinalRun && <span className="text-[#ffb000]">final</span>}
+            </span>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -11,8 +11,11 @@ import {
   Gavel,
   ListChecks,
   SlidersHorizontal,
+  Info,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { CohortSelector } from "./CohortSelector"
+import { useCohorts } from "./useCohorts"
 import { ParticipantsTab } from "./ParticipantsTab"
 import { MatchingTab } from "./MatchingTab"
 import { RunsTab } from "./RunsTab"
@@ -49,13 +52,56 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
   { key: "results", label: "Results", icon: ListChecks },
 ]
 
-export function ImpactLabDashboard({ cohort }: { cohort: string }) {
+/**
+ * `initialCohort` seeds the selector — the server passes `CURRENT_COHORT` so
+ * the page opens on the live event, but the organiser can switch to any
+ * cohort the system knows about without a redeploy.
+ */
+export function ImpactLabDashboard({ cohort: initialCohort }: { cohort: string }) {
+  const [cohort, setCohort] = useState(initialCohort)
   const [tab, setTab] = useState<Tab>("participants")
   // Bumped when a run is saved so the Runs tab reloads.
   const [runsKey, setRunsKey] = useState(0)
 
+  const { cohorts, loading: cohortsLoading, error: cohortsError } = useCohorts()
+
+  // Only trust "not live" once the list has actually loaded — before that,
+  // `cohorts` is empty and every cohort would look inactive.
+  const selectedSummary = cohorts.find((c) => c.cohort === cohort)
+  const isArchiveView = !cohortsLoading && !cohortsError && selectedSummary != null && !selectedSummary.isActive
+
   return (
     <div className="space-y-5">
+      {/*
+       * Worded to cover both kinds of event this dashboard now serves: a
+       * cohort that gets matched into teams here (Matching tab, Explain,
+       * freeze a run) and a cohort whose teams already exist and only needs
+       * check-in, judging, and results. Naming the selected cohort — not
+       * CURRENT_COHORT — keeps this line honest after a switch.
+       */}
+      <p className="text-xs font-mono text-[#555]">
+        Managing <span className="text-[#00ff41]">{cohort}</span> — participants, teams, submissions,
+        judging, and results, all scoped to this event.
+      </p>
+
+      <CohortSelector
+        cohorts={cohorts}
+        loading={cohortsLoading}
+        error={cohortsError}
+        selected={cohort}
+        onChange={setCohort}
+      />
+
+      {isArchiveView && (
+        <div className="flex items-start gap-2 rounded border border-[#ffb000]/40 bg-[#ffb000]/10 p-3 text-[11px] font-mono text-[#ffb000]">
+          <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span>
+            Viewing <span className="font-semibold">{cohort}</span> — not the live event. Admin actions
+            here still write to this cohort; participants aren&apos;t interacting with it anymore.
+          </span>
+        </div>
+      )}
+
       <div className="flex items-center gap-1 border-b border-[#1e1e1e]">
         {TABS.map(({ key, label, icon: Icon }) => (
           <button
@@ -73,23 +119,31 @@ export function ImpactLabDashboard({ cohort }: { cohort: string }) {
         ))}
       </div>
 
-      {tab === "participants" && <ParticipantsTab cohort={cohort} />}
-      {tab === "matching" && (
-        <MatchingTab
-          cohort={cohort}
-          onSaved={() => {
-            setRunsKey((k) => k + 1)
-            setTab("runs")
-          }}
-        />
-      )}
-      {tab === "runs" && <RunsTab cohort={cohort} refreshKey={runsKey} />}
-      {tab === "submissions" && <SubmissionsTab cohort={cohort} />}
-      {tab === "checkin" && <CheckInTab cohort={cohort} />}
-      {tab === "rubric" && <RubricTab cohort={cohort} />}
-      {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
-      {tab === "judges" && <JudgesTab cohort={cohort} />}
-      {tab === "results" && <ResultsTab cohort={cohort} />}
+      {/*
+       * Keyed on `cohort` so every tab's fetched rows, form drafts, and
+       * selection state fully remount on a switch — the simplest way to
+       * guarantee nothing from the previous cohort (a stale leaderboard, a
+       * half-filled participant form) can survive onto the new one.
+       */}
+      <div key={cohort} className="space-y-5">
+        {tab === "participants" && <ParticipantsTab cohort={cohort} />}
+        {tab === "matching" && (
+          <MatchingTab
+            cohort={cohort}
+            onSaved={() => {
+              setRunsKey((k) => k + 1)
+              setTab("runs")
+            }}
+          />
+        )}
+        {tab === "runs" && <RunsTab cohort={cohort} refreshKey={runsKey} />}
+        {tab === "submissions" && <SubmissionsTab cohort={cohort} />}
+        {tab === "checkin" && <CheckInTab cohort={cohort} />}
+        {tab === "rubric" && <RubricTab cohort={cohort} />}
+        {tab === "leaderboard" && <LeaderboardTab cohort={cohort} />}
+        {tab === "judges" && <JudgesTab cohort={cohort} />}
+        {tab === "results" && <ResultsTab cohort={cohort} />}
+      </div>
     </div>
   )
 }

--- a/src/components/admin/impact-lab/useCohorts.ts
+++ b/src/components/admin/impact-lab/useCohorts.ts
@@ -1,0 +1,35 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { apiGet } from "./api"
+import type { CohortSummary } from "./CohortSelector"
+
+/**
+ * Shared cohort-list state for every Impact Lab admin surface that offers a
+ * cohort switcher — the dashboard and the judge scoring screen both need the
+ * same fetch/loading/error triad, so it lives here once instead of twice.
+ */
+export function useCohorts() {
+  const [cohorts, setCohorts] = useState<CohortSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await apiGet<{ cohorts: CohortSummary[] }>("/api/admin/impact-lab/cohorts")
+      setCohorts(data.cohorts)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load events")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  return { cohorts, loading, error, reload }
+}

--- a/src/lib/impact-lab/submission-schema.ts
+++ b/src/lib/impact-lab/submission-schema.ts
@@ -75,20 +75,64 @@ function requiredMultilineText(max: number) {
     .refine((v) => v !== "", { message: "This field is required" })
 }
 
-export const submissionInputSchema = z.object({
-  projectName: requiredText(200),
-  pitch: requiredText(500),
-  description: requiredMultilineText(MAX_LONG_TEXT),
-  worksVsMocked: requiredMultilineText(MAX_LONG_TEXT),
-  claudeUsage: requiredMultilineText(MAX_LONG_TEXT),
-  track: requiredText(200),
-  problemTackled: requiredText(1000),
-  repoUrl: requiredUrl,
-  demoUrl: optionalUrl,
-  videoUrl: optionalUrl,
-  slidesUrl: optionalUrl,
-  screenshotUrl: optionalUrl,
-})
+/**
+ * A repository link is NOT required, and a submission with no link at all is.
+ *
+ * The original form demanded a repo URL because the Impact Lab was a Claude
+ * Code hackathon: every team shipped software and every team had a repo. That
+ * does not survive a mixed cohort. Teams here include Black Soldier Fly
+ * biotechnology, hardware IoT, and a media platform — a required repo link
+ * locks those teams out of submitting entirely, which is a far worse failure
+ * than a missing field.
+ *
+ * So the rule moves from "must have a repo" to "must show us something": at
+ * least one of repo, demo, video or slides. That is satisfiable by every team
+ * (all 20 supplied a pitch deck at registration) while still refusing a
+ * submission that gives judges nothing to look at.
+ *
+ * `screenshotUrl` deliberately does not count — an image is evidence about a
+ * thing, not the thing.
+ */
+const SHOWABLE_LINKS = ["repoUrl", "demoUrl", "videoUrl", "slidesUrl"] as const
+
+/**
+ * Like `optionalUrl`, but absent becomes `""` rather than `null`.
+ *
+ * `ImpactLabSubmission.repoUrl` is a non-nullable column and this is a live
+ * event — widening it would mean a schema migration against production during
+ * demos, to gain nothing a reader can see. Every consumer already guards with
+ * `submission.repoUrl && …`, and "" is falsy, so an empty string behaves
+ * identically to null at every call site.
+ */
+const optionalUrlAsEmpty = z
+  .string()
+  .max(1000)
+  .optional()
+  .transform((v) => withScheme(v ?? ""))
+  .transform((v) => (v === "" ? "" : zodSanitizeUrl(v)))
+  .refine((v) => v !== null, { message: "That link is not a valid http(s) URL" })
+  .transform((v) => v ?? "")
+
+export const submissionInputSchema = z
+  .object({
+    projectName: requiredText(200),
+    pitch: requiredText(500),
+    description: requiredMultilineText(MAX_LONG_TEXT),
+    worksVsMocked: requiredMultilineText(MAX_LONG_TEXT),
+    claudeUsage: requiredMultilineText(MAX_LONG_TEXT),
+    track: requiredText(200),
+    problemTackled: requiredText(1000),
+    repoUrl: optionalUrlAsEmpty,
+    demoUrl: optionalUrl,
+    videoUrl: optionalUrl,
+    slidesUrl: optionalUrl,
+    screenshotUrl: optionalUrl,
+  })
+  .refine((v) => SHOWABLE_LINKS.some((k) => v[k]), {
+    message:
+      "Add at least one link judges can open — a repository, live demo, video, or slide deck.",
+    path: ["repoUrl"],
+  })
 
 export type SubmissionInput = z.infer<typeof submissionInputSchema>
 


### PR DESCRIPTION
**Blocking fix — teams cannot submit right now.**

`repoUrl` was a **required** URL on every submission. That was a correct assumption for the Impact Lab, which was a Claude Code hackathon where every team shipped software and every team had a repository.

The Afretec cohort is not that. It includes **Rethink Organic Network** (Black Soldier Fly biotechnology), **Sentries** (hardware IoT), and **Doctors Explain / Medical TV** (a healthcare media platform). Those teams have no repository and therefore **could not submit at all** — they would have been judged on a prototype they were never able to show.

## The change

The rule moves from "must have a repo" to **"must show us something"**: at least one of repo, demo, video, or slides.

- Satisfiable by all 20 teams — every one supplied a pitch deck at registration.
- Still refuses a submission judges cannot open.
- `screenshotUrl` deliberately does **not** satisfy it. An image is evidence about a thing, not the thing.

The form now says so plainly rather than marking the repo field required.

## Storage note

An absent `repoUrl` is stored as `""`, not `null`. `ImpactLabSubmission.repoUrl` is a non-nullable column, and widening it would mean a schema migration against production **during demos** for a change no reader can see. Every consumer already guards with `submission.repoUrl && …`, and `""` is falsy, so it behaves identically at every call site.

## Verification

`npx tsc --noEmit` clean, `npm run build` clean.

Not exercised: no submission has been POSTed against production — there are 0 submissions so far, so this path is typechecked and built but not yet run for real.

## Also coming to this branch

A roster change so team leaders can add members who signed up on the site but were not on the registration form (members were captured as free text with no emails, so only the 20 leaders were seeded). Will be pushed here shortly.

@Spidey-Acer
