### PR TITLE
fix(impact-lab): deck-only submissions + add teammates by site account (missed #103)

### DIFF
--- a/src/app/api/impact-lab/team/roster/route.ts
+++ b/src/app/api/impact-lab/team/roster/route.ts
@@ -7,6 +7,7 @@ import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { Team } from "@/lib/matching"
+import type { Prisma } from "@/generated/prisma/client"
 
 /**
  * Team roster self-service.
@@ -22,6 +23,17 @@ import type { Team } from "@/lib/matching"
  */
 
 const bodySchema = z.object({ participantId: z.string().min(1).max(64) })
+
+// POST additionally accepts a site account that has no participant row yet
+// (a member who signed up after the leader-only registration import) —
+// resolveOrCreateParticipant below turns that into a participant row.
+const addBodySchema = z.union([
+  z.object({ participantId: z.string().min(1).max(64) }),
+  z.object({ userId: z.string().min(1).max(64) }),
+])
+
+type Target = { id: string; fullName: string }
+type TargetResolver = (tx: Prisma.TransactionClient) => Promise<Target | null>
 
 interface Resolved {
   runId: string
@@ -92,7 +104,110 @@ async function writeTeams(runId: string, mutate: (teams: Team[]) => Team[] | nul
   })
 }
 
-/** Add a participant to the caller's team, moving them off another if needed. */
+/**
+ * Look up an existing participant, or a not-yet-participant account.
+ * Called inside the same locked transaction as the roster write (see
+ * `addToTeam` below) so two leaders adding the same new account at once
+ * cannot both create a duplicate participant row — the second transaction
+ * blocks on the run-row lock until the first commits, then finds the row the
+ * first one already created.
+ */
+function resolveParticipant(participantId: string): TargetResolver {
+  return (tx) =>
+    tx.impactLabParticipant.findFirst({
+      where: { id: participantId, cohort: CURRENT_COHORT },
+      select: { id: true, fullName: true },
+    })
+}
+
+/**
+ * Resolve a site account to a participant row, creating one if this is their
+ * first appearance in the cohort. Mirrors the shape `POST /api/impact-lab/profile`
+ * uses for self-registration: `primaryRole: "Team member"` as a neutral
+ * default (they haven't filled in a profile) and no matching consent, since
+ * they didn't opt in — they're only here because a teammate is vouching for
+ * them being in the room.
+ */
+function resolveOrCreateParticipant(userId: string): TargetResolver {
+  return async (tx) => {
+    const user = await tx.user.findUnique({
+      where: { id: userId },
+      select: { email: true, firstName: true, lastName: true },
+    })
+    if (!user) return null
+
+    const email = user.email.toLowerCase()
+    const where = { cohort_email: { cohort: CURRENT_COHORT, email } }
+
+    const existing = await tx.impactLabParticipant.findUnique({
+      where,
+      select: { id: true, fullName: true },
+    })
+    if (existing) return existing
+
+    return tx.impactLabParticipant.create({
+      data: {
+        cohort: CURRENT_COHORT,
+        email,
+        fullName: `${user.firstName} ${user.lastName}`.trim(),
+        primaryRole: "Team member",
+        consentToMatch: false,
+        consentToShareContact: false,
+      },
+      select: { id: true, fullName: true },
+    })
+  }
+}
+
+type AddOutcome =
+  | { status: "ok"; target: Target }
+  | { status: "target_not_found" }
+  | { status: "no_team" }
+
+/**
+ * Resolve the target and persist the edited team list in one transaction —
+ * see `resolveOrCreateParticipant` for why resolution has to happen inside
+ * the same lock as the write.
+ */
+async function addToTeam(
+  runId: string,
+  myTeamId: string,
+  resolveTarget: TargetResolver
+): Promise<AddOutcome> {
+  return prisma.$transaction(async (tx) => {
+    await tx.$executeRaw`SELECT id FROM impact_lab_match_runs WHERE id = ${runId} FOR UPDATE`
+
+    const target = await resolveTarget(tx)
+    if (!target) return { status: "target_not_found" }
+
+    const fresh = await tx.impactLabMatchRun.findUnique({
+      where: { id: runId },
+      select: { result: true },
+    })
+    const teams = extractFrozenTeams(fresh?.result)
+    if (!teams) return { status: "no_team" }
+
+    const mine = teams.find((t) => t.id === myTeamId)
+    if (!mine) return { status: "no_team" }
+
+    if (!mine.memberIds.includes(target.id)) {
+      const next = teams.map((t) =>
+        t.id === myTeamId
+          ? { ...t, memberIds: [...t.memberIds, target.id] }
+          : { ...t, memberIds: t.memberIds.filter((id) => id !== target.id) }
+      )
+      const result = { ...(fresh?.result as object), teams: next }
+      await tx.impactLabMatchRun.update({
+        where: { id: runId },
+        data: { result: JSON.parse(JSON.stringify(result)) },
+      })
+    } // else already here — idempotent, nothing to write
+
+    return { status: "ok", target }
+  })
+}
+
+/** Add a participant (or a not-yet-participant account) to the caller's team, moving them off another if needed. */
 export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
@@ -111,7 +226,7 @@ export async function POST(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  const parsed = addBodySchema.safeParse(await request.json().catch(() => null))
   if (!parsed.success) {
     return NextResponse.json(
       { success: false, error: "Pick someone from the list." },
@@ -122,36 +237,26 @@ export async function POST(request: NextRequest) {
   const me = await resolveCaller(check.email)
   if (!me) return noTeam()
 
-  const target = await prisma.impactLabParticipant.findFirst({
-    where: { id: parsed.data.participantId, cohort: CURRENT_COHORT },
-    select: { id: true, fullName: true },
-  })
-  if (!target) {
-    return NextResponse.json(
-      { success: false, error: "That person is not registered for this hackathon." },
-      { status: 404 }
-    )
-  }
-
   const myTeamId = me.teams[me.myTeamIndex].id
+  const resolveTarget =
+    "participantId" in parsed.data
+      ? resolveParticipant(parsed.data.participantId)
+      : resolveOrCreateParticipant(parsed.data.userId)
 
-  const next = await writeTeams(me.runId, (teams) => {
-    const mine = teams.find((t) => t.id === myTeamId)
-    if (!mine) return null
-    if (mine.memberIds.includes(target.id)) return teams // already here — idempotent
+  const outcome = await addToTeam(me.runId, myTeamId, resolveTarget)
 
-    return teams.map((t) =>
-      t.id === myTeamId
-        ? { ...t, memberIds: [...t.memberIds, target.id] }
-        : { ...t, memberIds: t.memberIds.filter((id) => id !== target.id) }
-    )
-  })
-
-  if (!next) return noTeam()
+  if (outcome.status === "no_team") return noTeam()
+  if (outcome.status === "target_not_found") {
+    const error =
+      "participantId" in parsed.data
+        ? "That person is not registered for this hackathon."
+        : "That account could not be found."
+    return NextResponse.json({ success: false, error }, { status: 404 })
+  }
 
   return NextResponse.json({
     success: true,
-    message: `${target.fullName} is now on your team.`,
+    message: `${outcome.target.fullName} is now on your team.`,
   })
 }
 

--- a/src/app/api/impact-lab/team/search/route.ts
+++ b/src/app/api/impact-lab/team/search/route.ts
@@ -4,8 +4,22 @@ import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 
+// One letter would return most of the cohort and turn a teammate lookup into
+// a roster dump. Account search opens up a much larger pool (every site
+// signup, not just the ~20 registered leaders) so it needs a higher floor.
+const PARTICIPANT_MIN_QUERY_LENGTH = 2
+const ACCOUNT_MIN_QUERY_LENGTH = 3
+const RESULT_CAP = 10
+
 /**
  * Search the cohort so a team can find the person sitting with them.
+ *
+ * Registration only captured team leaders, so members who since signed up
+ * on the site have no `ImpactLabParticipant` row yet and would otherwise be
+ * invisible to their leader. Alongside the existing cohort search, this also
+ * matches site accounts (`User`) with no participant row for the current
+ * cohort — those come back as `kind: "account"` so the UI can label them as
+ * "not on the roster yet" before a leader adds them.
  *
  * Returns names only, never emails or phone numbers — this is a lookup for
  * adding a teammate, not a directory of a hundred people's contact details.
@@ -25,9 +39,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const q = (request.nextUrl.searchParams.get("q") ?? "").trim()
-  // Two characters is the floor: one letter would return most of the cohort and
-  // turn a teammate lookup into a roster dump.
-  if (q.length < 2) {
+  if (q.length < PARTICIPANT_MIN_QUERY_LENGTH) {
     return NextResponse.json({ success: true, results: [] })
   }
 
@@ -35,7 +47,7 @@ export async function GET(request: NextRequest) {
     where: { cohort: CURRENT_COHORT, fullName: { contains: q, mode: "insensitive" } },
     select: { id: true, fullName: true },
     orderBy: { fullName: "asc" },
-    take: 10,
+    take: RESULT_CAP,
   })
 
   const run = await prisma.impactLabMatchRun.findFirst({
@@ -49,12 +61,65 @@ export async function GET(request: NextRequest) {
     for (const id of team.memberIds) teamNameById.set(id, team.name)
   }
 
+  const participantResults = people.map((p) => ({
+    id: p.id,
+    fullName: p.fullName,
+    onTeam: teamNameById.get(p.id) ?? null,
+    kind: "participant" as const,
+  }))
+
+  const accountResults =
+    q.length >= ACCOUNT_MIN_QUERY_LENGTH
+      ? await searchAccounts(q, participantResults.length)
+      : []
+
   return NextResponse.json({
     success: true,
-    results: people.map((p) => ({
-      id: p.id,
-      fullName: p.fullName,
-      onTeam: teamNameById.get(p.id) ?? null,
-    })),
+    results: [...participantResults, ...accountResults].slice(0, RESULT_CAP),
   })
+}
+
+/**
+ * Site accounts matching `q` by name that have no participant row for the
+ * current cohort yet. Matched against `firstName`/`lastName` separately
+ * (there is no stored full-name column), then de-duplicated against existing
+ * participants by email so someone who is both never appears twice — the
+ * cohort search above already returns them as `"participant"`.
+ */
+async function searchAccounts(q: string, alreadyFilled: number) {
+  const budget = RESULT_CAP - alreadyFilled
+  if (budget <= 0) return []
+
+  // Over-fetch before the participant-email filter removes some candidates.
+  const candidates = await prisma.user.findMany({
+    where: {
+      active: true,
+      OR: [
+        { firstName: { contains: q, mode: "insensitive" } },
+        { lastName: { contains: q, mode: "insensitive" } },
+      ],
+    },
+    select: { id: true, firstName: true, lastName: true, email: true },
+    orderBy: { firstName: "asc" },
+    take: RESULT_CAP * 3,
+  })
+  if (candidates.length === 0) return []
+
+  const existing = await prisma.impactLabParticipant.findMany({
+    where: {
+      cohort: CURRENT_COHORT,
+      email: { in: candidates.map((u) => u.email.toLowerCase()) },
+    },
+    select: { email: true },
+  })
+  const existingEmails = new Set(existing.map((p) => p.email.toLowerCase()))
+
+  return candidates
+    .filter((u) => !existingEmails.has(u.email.toLowerCase()))
+    .slice(0, budget)
+    .map((u) => ({
+      userId: u.id,
+      fullName: `${u.firstName} ${u.lastName}`.trim(),
+      kind: "account" as const,
+    }))
 }

--- a/src/app/dashboard/impact-lab/SubmitProject.tsx
+++ b/src/app/dashboard/impact-lab/SubmitProject.tsx
@@ -255,31 +255,37 @@ export function SubmitProject() {
         )}
 
         <form onSubmit={save} className="space-y-4">
-          {field("projectName", "Project name *", "What are you calling it?")}
-          {field("pitch", "One-line pitch *", "One sentence a judge can repeat.")}
-          {field("track", "Track *", "The track whose problem you built for.")}
-          {field("problemTackled", "Problem tackled *", "The specific problem, in your words.")}
-          {field("description", "What it does *", "What a judge sees when they open it.", true)}
+          {field(
+            "slidesUrl",
+            "Pitch deck link *",
+            "The only thing you must provide. Google Slides, Canva, Drive, PDF — any link judges can open."
+          )}
+
+          <p className="pt-2 font-mono text-xs text-text-dim">
+            Everything below is optional. Fill in what helps a judge; leave the
+            rest.
+          </p>
+
+          {field("projectName", "Project name", "What are you calling it?")}
+          {field("pitch", "One-line pitch", "One sentence a judge can repeat.")}
+          {field("track", "Track", "The track whose problem you built for.")}
+          {field("problemTackled", "Problem tackled", "The specific problem, in your words.")}
+          {field("description", "What it does", "What a judge sees when they open it.", true)}
           {field(
             "worksVsMocked",
-            "What works vs what's mocked *",
+            "What works vs what's mocked",
             "Be honest — a thin real slice beats a wide fake one.",
             true
           )}
           {field(
             "claudeUsage",
-            "How you used AI *",
+            "How you used AI",
             "Which AI tools you used — Claude, ChatGPT, Gemini, Copilot, or other — and what they actually did for you. No AI? Say so.",
             true
           )}
-          <p className="pt-2 font-mono text-xs text-text-dim">
-            Add at least one link judges can open. Not every project is
-            software — a deck or a video is fine on its own.
-          </p>
           {field("repoUrl", "Repo link", "github.com/you/project — https:// optional.")}
           {field("demoUrl", "Demo link", "A live URL judges can click.")}
           {field("videoUrl", "Video link", "A walkthrough, in case the live demo dies.")}
-          {field("slidesUrl", "Slides link", "Drive or Figma link — no file upload needed.")}
           {field("screenshotUrl", "Screenshot link", "Optional image link.")}
 
           {error && (

--- a/src/app/dashboard/impact-lab/TeamRoster.tsx
+++ b/src/app/dashboard/impact-lab/TeamRoster.tsx
@@ -6,11 +6,9 @@ import { UserPlus, UserMinus, Search, Loader2 } from "lucide-react";
 import { csrfHeaders } from "@/lib/csrf-client";
 import type { TeamMemberView } from "@/lib/impact-lab/member";
 
-interface SearchHit {
-  id: string;
-  fullName: string;
-  onTeam: string | null;
-}
+type SearchHit =
+  | { kind: "participant"; id: string; fullName: string; onTeam: string | null }
+  | { kind: "account"; userId: string; fullName: string };
 
 /**
  * Roster self-service for a team.
@@ -63,15 +61,19 @@ export function TeamRoster({
     }
   }
 
-  async function mutate(participantId: string, method: "POST" | "DELETE") {
-    setBusyId(participantId);
+  async function mutate(
+    body: { participantId: string } | { userId: string },
+    method: "POST" | "DELETE"
+  ) {
+    const busyKey = "participantId" in body ? body.participantId : body.userId;
+    setBusyId(busyKey);
     setError(null);
     setNotice(null);
     try {
       const res = await fetch("/api/impact-lab/team/roster", {
         method,
         headers: await csrfHeaders(),
-        body: JSON.stringify({ participantId }),
+        body: JSON.stringify(body),
       });
       const json = await res.json();
       if (!res.ok || !json.success) {
@@ -205,26 +207,39 @@ export function TeamRoster({
             {hits.length > 0 && (
               <ul className="mt-3 divide-y divide-border-default overflow-hidden rounded-lg border border-border-default">
                 {hits.map((hit) => {
-                  const already = memberIds.has(hit.id);
+                  const key = hit.kind === "participant" ? hit.id : hit.userId;
+                  const already = hit.kind === "participant" && memberIds.has(hit.id);
                   return (
                     <li
-                      key={hit.id}
+                      key={key}
                       className="flex items-center justify-between gap-3 bg-bg-primary px-3 py-2.5"
                     >
                       <span className="min-w-0">
                         <span className="block truncate text-sm text-text-primary">
                           {hit.fullName}
                         </span>
-                        {hit.onTeam && !already && (
+                        {hit.kind === "participant" && hit.onTeam && !already && (
                           <span className="block text-xs text-amber">
                             Currently on {hit.onTeam} — adding moves them here
+                          </span>
+                        )}
+                        {hit.kind === "account" && (
+                          <span className="block text-xs text-text-dim">
+                            Has an account, not on the roster yet
                           </span>
                         )}
                       </span>
                       <button
                         type="button"
-                        disabled={already || busyId === hit.id}
-                        onClick={() => mutate(hit.id, "POST")}
+                        disabled={already || busyId === key}
+                        onClick={() =>
+                          mutate(
+                            hit.kind === "participant"
+                              ? { participantId: hit.id }
+                              : { userId: hit.userId },
+                            "POST"
+                          )
+                        }
                         className="shrink-0 rounded-md border border-green-primary/30 bg-green-primary/10 px-2.5 py-1.5 font-mono text-[11px] uppercase tracking-wider text-green-primary transition-colors hover:bg-green-primary/20 disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         {already ? (
@@ -270,7 +285,7 @@ export function TeamRoster({
                     <button
                       type="button"
                       disabled={busyId === m.id}
-                      onClick={() => mutate(m.id, "DELETE")}
+                      onClick={() => mutate({ participantId: m.id }, "DELETE")}
                       className="shrink-0 rounded-md border border-red/30 bg-red/10 px-2.5 py-1.5 font-mono text-[11px] uppercase tracking-wider text-red transition-colors hover:bg-red/20 disabled:opacity-40"
                     >
                       <UserMinus className="mr-1 inline h-3 w-3" aria-hidden="true" />

--- a/src/lib/impact-lab/submission-schema.ts
+++ b/src/lib/impact-lab/submission-schema.ts
@@ -76,24 +76,39 @@ function requiredMultilineText(max: number) {
 }
 
 /**
- * A repository link is NOT required, and a submission with no link at all is.
+ * The pitch deck is the only required field. Everything else is optional.
  *
- * The original form demanded a repo URL because the Impact Lab was a Claude
- * Code hackathon: every team shipped software and every team had a repo. That
- * does not survive a mixed cohort. Teams here include Black Soldier Fly
- * biotechnology, hardware IoT, and a media platform — a required repo link
- * locks those teams out of submitting entirely, which is a far worse failure
- * than a missing field.
+ * The original form required eight fields including a repository URL, which
+ * fitted the Impact Lab: a Claude Code hackathon where every team shipped
+ * software and every team had a repo. It does not fit a mixed startup cohort
+ * containing Black Soldier Fly biotechnology, hardware IoT and a healthcare
+ * media platform — those teams could not submit at all.
  *
- * So the rule moves from "must have a repo" to "must show us something": at
- * least one of repo, demo, video or slides. That is satisfiable by every team
- * (all 20 supplied a pitch deck at registration) while still refusing a
- * submission that gives judges nothing to look at.
- *
- * `screenshotUrl` deliberately does not count — an image is evidence about a
- * thing, not the thing.
+ * The organiser's ruling is that the deck is what judges actually score from,
+ * so it is the one thing a submission cannot be without. Teams pitch live for
+ * five minutes; the written fields are a convenience, not the evidence, and a
+ * required field that stops a team submitting at 2 AM costs more than a blank
+ * one. A team is identified by its team name, which comes from the run rather
+ * than from this form, so a sparse submission is still attributable.
  */
-const SHOWABLE_LINKS = ["repoUrl", "demoUrl", "videoUrl", "slidesUrl"] as const
+
+/** Optional single-line text; absent or whitespace-only becomes "". */
+function optionalText(max: number) {
+  return z
+    .string()
+    .max(max)
+    .optional()
+    .transform((v) => zodSanitizeString(v ?? ""))
+}
+
+/** Optional multi-line text; absent or whitespace-only becomes "". */
+function optionalMultilineText(max: number) {
+  return z
+    .string()
+    .max(max)
+    .optional()
+    .transform((v) => zodSanitizeMultilineText(max)(v ?? ""))
+}
 
 /**
  * Like `optionalUrl`, but absent becomes `""` rather than `null`.
@@ -113,26 +128,21 @@ const optionalUrlAsEmpty = z
   .refine((v) => v !== null, { message: "That link is not a valid http(s) URL" })
   .transform((v) => v ?? "")
 
-export const submissionInputSchema = z
-  .object({
-    projectName: requiredText(200),
-    pitch: requiredText(500),
-    description: requiredMultilineText(MAX_LONG_TEXT),
-    worksVsMocked: requiredMultilineText(MAX_LONG_TEXT),
-    claudeUsage: requiredMultilineText(MAX_LONG_TEXT),
-    track: requiredText(200),
-    problemTackled: requiredText(1000),
-    repoUrl: optionalUrlAsEmpty,
-    demoUrl: optionalUrl,
-    videoUrl: optionalUrl,
-    slidesUrl: optionalUrl,
-    screenshotUrl: optionalUrl,
-  })
-  .refine((v) => SHOWABLE_LINKS.some((k) => v[k]), {
-    message:
-      "Add at least one link judges can open — a repository, live demo, video, or slide deck.",
-    path: ["repoUrl"],
-  })
+export const submissionInputSchema = z.object({
+  projectName: optionalText(200),
+  pitch: optionalText(500),
+  description: optionalMultilineText(MAX_LONG_TEXT),
+  worksVsMocked: optionalMultilineText(MAX_LONG_TEXT),
+  claudeUsage: optionalMultilineText(MAX_LONG_TEXT),
+  track: optionalText(200),
+  problemTackled: optionalText(1000),
+  repoUrl: optionalUrlAsEmpty,
+  demoUrl: optionalUrl,
+  videoUrl: optionalUrl,
+  /** The one required field — see the note above. */
+  slidesUrl: requiredUrl,
+  screenshotUrl: optionalUrl,
+})
 
 export type SubmissionInput = z.infer<typeof submissionInputSchema>
 


### PR DESCRIPTION
**These two commits missed PR #103.** It was merged when its head was still the first commit, so the two below never reached `main` — and both are the ones people are waiting on.

## 1. Pitch deck is the only required field

Organiser's ruling. Project name, pitch, track, problem, description, works-vs-mocked, AI usage, repo, demo, video and screenshot are all optional now. Teams pitch live for five minutes and the deck is what judges score from, so it is the one thing a submission cannot be without.

`main` currently still enforces "at least one of repo/demo/video/slides" plus seven required text fields — so a team with only a deck link **still cannot submit** until this lands.

A sparse submission stays attributable: a team is identified by its team name, which comes from the run, not from this form.

## 2. Leaders can add teammates who signed up on the site

The cohort was seeded with leaders only — the registration form captured members as free text with phone numbers and no emails, so only 20 participant rows exist. A member signing up gets a `User` row and no participant row, which made them **invisible to their own leader's search and impossible to add**. That blocks most of the room.

Search now also matches site accounts with no participant row in this cohort, and adding one creates that row **inside the same locked transaction** that mutates the team, so two leaders adding the same person serialise rather than double-inserting.

**Names only, never emails.** Emails are read solely to de-duplicate someone who is already a participant and never reach the response — the route's original promise that this is "a teammate lookup, not a directory of a hundred people's contact details" still holds. I read the route to confirm rather than taking it on trust.

Account search requires **3** characters where the cohort search requires 2: this widens visibility from 20 cohort members to every account on the site (216), and a one-character query must not return a directory. That widening is worth reversing after the event.

## Team-leader takeover

No change needed — already worked. The control renders above the "Edit team" toggle, always visible, and reads "Take over as leader" when someone else holds it, replacing the current holder. That is exactly the absent-leader case.

## Verification

`npx tsc --noEmit` clean, `npm run build` clean.

Not exercised against production: 0 submissions exist so far, so the submit and roster paths are typechecked and built but have not been run for real.

@Spidey-Acer
