### PR TITLE
feat(impact-lab): shared five-minute pitch timer on the judge screen

### DIFF
--- a/prisma/migrations/20260808150000_impact_lab_pitch_timer/migration.sql
+++ b/prisma/migrations/20260808150000_impact_lab_pitch_timer/migration.sql
@@ -1,0 +1,11 @@
+-- A shared pitch countdown, one row per cohort. Any judge's Start applies to
+-- the whole room, not just their own device — absence of a row means no
+-- timer is currently running for that cohort.
+CREATE TABLE "impact_lab_pitch_timers" (
+  "cohort"    TEXT NOT NULL,
+  "startedAt" TIMESTAMP(3) NOT NULL,
+  "seconds"   INTEGER NOT NULL DEFAULT 300,
+  "startedBy" TEXT NOT NULL,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "impact_lab_pitch_timers_pkey" PRIMARY KEY ("cohort")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -956,6 +956,23 @@ model ImpactLabRubric {
   @@map("impact_lab_rubrics")
 }
 
+/// A shared pitch countdown, one row per cohort. Any judge who taps Start
+/// starts it for the whole room — this is a room clock, not a per-judge
+/// stopwatch — and restarting mid-countdown is expected: it means the next
+/// team is up. `cohort` is the primary key rather than a separate id because
+/// there is at most one running timer per cohort and no reason to keep
+/// history once it is replaced.
+model ImpactLabPitchTimer {
+  cohort    String   @id
+  startedAt DateTime
+  seconds   Int      @default(300)
+  /// Judge display name, shown on the timer as "started by …".
+  startedBy String
+  updatedAt DateTime @updatedAt
+
+  @@map("impact_lab_pitch_timers")
+}
+
 /// One row per intended recipient of the results email. This is what makes the
 /// send idempotent: Resend's quota is 100/day and there are 93 recipients, so a
 /// careless retry exceeds it. A resend selects status <> 'sent' only.

--- a/src/app/api/impact-lab/pitch-timer/route.ts
+++ b/src/app/api/impact-lab/pitch-timer/route.ts
@@ -1,0 +1,172 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { readJudgeSession } from "@/lib/impact-lab/judge-access"
+import { safeCohort } from "@/lib/impact-lab/constants"
+import {
+  DEFAULT_SECONDS,
+  isValidSeconds,
+  loadPitchTimer,
+} from "@/lib/impact-lab/pitch-timer-store"
+
+/**
+ * The shared pitch countdown judges see on the scoring screen.
+ *
+ * One row per cohort: any judge starting it starts it for the whole room —
+ * this is a room clock, not a per-judge stopwatch — and restarting mid-count
+ * is expected, it means the next team is up. Same two doors as the rest of
+ * judging (see judge-access.ts): a code-gated judge session, or a signed-in
+ * staff member with `impact-lab` view access.
+ */
+
+/**
+ * This code can ship before `impact_lab_pitch_timers` exists — applying a
+ * migration against production is a human's decision, and `loadPitchTimer`
+ * deliberately degrades to "no timer running" until then. Writes cannot
+ * degrade, so they say what is missing instead of throwing a bare 500 at
+ * whichever judge tapped Start. Prisma reports a missing table as P2021.
+ */
+function tableMissingResponse(error: unknown): NextResponse | null {
+  const code = (error as { code?: unknown })?.code
+  if (code !== "P2021") return null
+  console.error("[impact-lab/pitch-timer] impact_lab_pitch_timers does not exist", error)
+  return NextResponse.json(
+    {
+      success: false,
+      error:
+        "The pitch timer table has not been created in this database yet. Apply migration 20260808150000_impact_lab_pitch_timer, then try again. Scoring is unaffected.",
+      code: "PITCH_TIMER_TABLE_MISSING",
+    },
+    { status: 503 }
+  )
+}
+
+/** Who is allowed to read or drive the timer: a code-gated judge, or staff. */
+async function resolveCaller(): Promise<
+  | { ok: true; displayName: string }
+  | { ok: false; response: NextResponse }
+> {
+  const judge = await readJudgeSession()
+  if (judge) return { ok: true, displayName: judge.displayName }
+
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return { ok: false, response: check.response }
+  return { ok: true, displayName: check.user.name }
+}
+
+/** GET — the timer currently running for a cohort, or null. */
+export async function GET(request: NextRequest) {
+  const caller = await resolveCaller()
+  if (!caller.ok) return caller.response
+
+  const rl = await rateLimit(request, RateLimits.READ)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment and try again." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const timer = await loadPitchTimer(cohort)
+
+  return NextResponse.json({ success: true, timer }, { headers: rl.headers })
+}
+
+/** POST — start or restart the countdown for a cohort. */
+export async function POST(request: NextRequest) {
+  try {
+    return await handlePost(request)
+  } catch (error) {
+    const missing = tableMissingResponse(error)
+    if (missing) return missing
+    throw error
+  }
+}
+
+async function handlePost(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const caller = await resolveCaller()
+  if (!caller.ok) return caller.response
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const body = await request.json().catch(() => null)
+  const rawSeconds =
+    body && typeof body === "object" ? (body as { seconds?: unknown }).seconds : undefined
+  const seconds = rawSeconds === undefined ? DEFAULT_SECONDS : rawSeconds
+  if (!isValidSeconds(seconds)) {
+    return NextResponse.json(
+      { success: false, error: "Duration must be a whole number of seconds from 30 to 3600." },
+      { status: 400 }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const startedAt = new Date()
+
+  // Upsert, not create: restarting while one is already running for this
+  // cohort is the normal flow — the next team is pitching.
+  await prisma.impactLabPitchTimer.upsert({
+    where: { cohort },
+    create: { cohort, startedAt, seconds, startedBy: caller.displayName },
+    update: { startedAt, seconds, startedBy: caller.displayName },
+  })
+
+  return NextResponse.json(
+    {
+      success: true,
+      timer: {
+        startedAt: startedAt.toISOString(),
+        seconds,
+        startedBy: caller.displayName,
+        serverNow: new Date().toISOString(),
+      },
+    },
+    { headers: rl.headers }
+  )
+}
+
+/** DELETE — stop the countdown for a cohort. */
+export async function DELETE(request: NextRequest) {
+  try {
+    return await handleDelete(request)
+  } catch (error) {
+    const missing = tableMissingResponse(error)
+    if (missing) return missing
+    throw error
+  }
+}
+
+async function handleDelete(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const caller = await resolveCaller()
+  if (!caller.ok) return caller.response
+
+  const rl = await rateLimit(request, RateLimits.FORM)
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  // deleteMany rather than delete: stopping a timer that already finished (or
+  // was never started) is a no-op, not a 404 a judge has to interpret.
+  await prisma.impactLabPitchTimer.deleteMany({ where: { cohort } })
+
+  return NextResponse.json({ success: true, timer: null }, { headers: rl.headers })
+}

--- a/src/app/judge/JudgeEventPicker.tsx
+++ b/src/app/judge/JudgeEventPicker.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { JudgeScoring } from "./JudgeScoring";
+import { PitchTimer } from "./PitchTimer";
 
 interface JudgeEvent {
   cohort: string;
@@ -122,7 +123,9 @@ export function JudgeEventPicker({ judgeName }: { judgeName: string }) {
   }
 
   return (
-    <div>
+    // pb-24 clears the fixed pitch timer pinned to the bottom of the viewport
+    // so it never covers the scorecard's own Save button.
+    <div className="pb-24">
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border-default bg-bg-card px-4 py-3">
         <div className="min-w-0">
           <p className="font-mono text-[10px] uppercase tracking-wider text-text-dim">
@@ -148,6 +151,7 @@ export function JudgeEventPicker({ judgeName }: { judgeName: string }) {
         )}
       </div>
       <JudgeScoring cohort={selected.cohort} onDirtyChange={setDirty} />
+      <PitchTimer cohort={selected.cohort} />
     </div>
   );
 }

--- a/src/app/judge/PitchTimer.tsx
+++ b/src/app/judge/PitchTimer.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { csrfHeaders } from "@/lib/csrf-client";
+
+interface TimerState {
+  startedAt: string;
+  seconds: number;
+  startedBy: string;
+  serverNow: string;
+}
+
+// Duplicated from pitch-timer-store.ts on purpose: that module imports
+// `@/lib/prisma`, which must never reach a client bundle. The server is the
+// source of truth and validates the same range on write.
+const DEFAULT_SECONDS = 300;
+
+const POLL_MS = 2000;
+const TICK_MS = 250;
+const AMBER_AT_SECONDS = 60;
+const RED_AT_SECONDS = 10;
+
+function formatMMSS(totalSeconds: number): string {
+  const s = Math.max(0, totalSeconds);
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${String(r).padStart(2, "0")}`;
+}
+
+/** Two short beeps, ~150ms each with a small gap — well under a second total.
+ *  Web Audio only: no audio files, no asset pipeline for this page. */
+function playEndSound(ctx: AudioContext | null) {
+  if (!ctx) return;
+  try {
+    if (ctx.state === "suspended") void ctx.resume();
+    const beep = (start: number) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = 880;
+      gain.gain.setValueAtTime(0.0001, start);
+      gain.gain.exponentialRampToValueAtTime(0.35, start + 0.01);
+      gain.gain.setValueAtTime(0.35, start + 0.13);
+      gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.15);
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.start(start);
+      osc.stop(start + 0.16);
+    };
+    const now = ctx.currentTime;
+    beep(now);
+    beep(now + 0.22);
+  } catch {
+    // Best-effort. The visual TIME'S UP state is what is guaranteed.
+  }
+}
+
+/**
+ * Shared 5-minute pitch countdown, pinned to the bottom of the judge scoring
+ * screen. Any judge's Start applies to the whole room: state lives in the
+ * database (`/api/impact-lab/pitch-timer`), not in this component, and every
+ * device polls and re-derives the same countdown from `startedAt`.
+ *
+ * Fixed rather than sticky-in-flow so it never reflows or covers the
+ * scorecard's own controls — the page adds bottom padding to clear it
+ * instead (see JudgeGate.tsx).
+ */
+export function PitchTimer({ cohort }: { cohort: string }) {
+  const [timer, setTimer] = useState<TimerState | null>(null);
+  const [offsetMs, setOffsetMs] = useState(0); // serverNow - Date.now(), from the last read
+  const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const endedForRef = useRef<string | null>(null); // startedAt already alerted for
+  const lastSecRef = useRef<number | null>(null);
+
+  // Autoplay policy blocks sound until THIS device has had a user gesture,
+  // and that gesture may land anywhere on the page — not necessarily on this
+  // component's own buttons. Arm (or resume) on the first interaction.
+  useEffect(() => {
+    function arm() {
+      if (!audioCtxRef.current) {
+        try {
+          const Ctor =
+            window.AudioContext ??
+            (window as unknown as { webkitAudioContext?: typeof AudioContext })
+              .webkitAudioContext;
+          if (Ctor) audioCtxRef.current = new Ctor();
+        } catch {
+          // Web Audio unavailable on this device — sound stays silent, the
+          // visual end state still fires.
+        }
+      } else if (audioCtxRef.current.state === "suspended") {
+        void audioCtxRef.current.resume();
+      }
+    }
+    window.addEventListener("pointerdown", arm, { passive: true });
+    window.addEventListener("keydown", arm);
+    return () => {
+      window.removeEventListener("pointerdown", arm);
+      window.removeEventListener("keydown", arm);
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/impact-lab/pitch-timer?cohort=${encodeURIComponent(cohort)}`
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) return;
+      const next = json.timer as TimerState | null;
+      setTimer((prev) => {
+        if (next && (!prev || prev.startedAt !== next.startedAt)) {
+          setAnnouncement(`Timer started by ${next.startedBy}.`);
+        }
+        return next;
+      });
+      if (next) setOffsetMs(new Date(next.serverNow).getTime() - Date.now());
+    } catch {
+      // A missed poll is silent — the next one tries again in 2s. Surfacing a
+      // network blip as an on-screen error would be noisier than the miss.
+    }
+  }, [cohort]);
+
+  useEffect(() => {
+    void refresh();
+    const id = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  // Ticks locally between polls so the display counts down smoothly rather
+  // than jumping once every 2s. Never counts down from a local guess: every
+  // tick re-derives from `startedAt + seconds`, corrected by `offsetMs`.
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (!timer) {
+        setRemainingSeconds(null);
+        lastSecRef.current = null;
+        return;
+      }
+      const correctedNow = Date.now() + offsetMs;
+      const endsAt = new Date(timer.startedAt).getTime() + timer.seconds * 1000;
+      const sec = Math.max(0, Math.ceil((endsAt - correctedNow) / 1000));
+      setRemainingSeconds(sec);
+
+      const prevSec = lastSecRef.current;
+      lastSecRef.current = sec;
+      if (prevSec === null) return;
+
+      if (prevSec > 60 && sec <= 60) {
+        setAnnouncement("One minute left.");
+      }
+      if (prevSec > 0 && sec <= 0 && endedForRef.current !== timer.startedAt) {
+        endedForRef.current = timer.startedAt;
+        setAnnouncement("Time's up.");
+        playEndSound(audioCtxRef.current);
+      }
+    }, TICK_MS);
+    return () => clearInterval(id);
+  }, [timer, offsetMs]);
+
+  async function start() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/impact-lab/pitch-timer?cohort=${encodeURIComponent(cohort)}`,
+        {
+          method: "POST",
+          headers: await csrfHeaders(),
+          body: JSON.stringify({ seconds: DEFAULT_SECONDS }),
+        }
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "Could not start the timer.");
+        return;
+      }
+      const next = json.timer as TimerState;
+      endedForRef.current = null;
+      setTimer(next);
+      setOffsetMs(new Date(next.serverNow).getTime() - Date.now());
+      setAnnouncement(`Timer started by ${next.startedBy}.`);
+    } catch {
+      setError("Could not start the timer. Check your connection.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function stop() {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/impact-lab/pitch-timer?cohort=${encodeURIComponent(cohort)}`,
+        { method: "DELETE", headers: await csrfHeaders() }
+      );
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        setError(json.error || "Could not stop the timer.");
+        return;
+      }
+      setTimer(null);
+      setRemainingSeconds(null);
+      endedForRef.current = null;
+    } catch {
+      setError("Could not stop the timer. Check your connection.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const isOver = timer !== null && remainingSeconds === 0;
+  const colorClass =
+    remainingSeconds === null
+      ? "text-text-dim"
+      : remainingSeconds <= RED_AT_SECONDS
+        ? "text-red"
+        : remainingSeconds <= AMBER_AT_SECONDS
+          ? "text-amber"
+          : "text-green-primary";
+
+  return (
+    <div
+      className={`fixed inset-x-0 bottom-0 z-30 border-t bg-bg-primary/95 px-4 py-2 backdrop-blur ${
+        isOver ? "border-red/50 bg-red/5" : "border-border-default"
+      }`}
+    >
+      <div className="mx-auto flex max-w-3xl items-center justify-between gap-3">
+        <div className="min-w-0">
+          <p className="truncate font-mono text-[10px] uppercase tracking-wider text-text-dim">
+            Pitch timer{timer ? ` · started by ${timer.startedBy}` : ""}
+          </p>
+          <p className={`font-mono text-2xl font-bold tabular-nums ${colorClass}`}>
+            {remainingSeconds === null
+              ? "No timer"
+              : isOver
+                ? "TIME'S UP"
+                : formatMMSS(remainingSeconds)}
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={() => void start()}
+            disabled={busy}
+            className="rounded-lg border border-green-primary/40 bg-green-primary/10 px-3 py-2 font-mono text-xs uppercase tracking-wider text-green-primary transition-colors hover:bg-green-primary/20 disabled:opacity-50"
+          >
+            {timer ? "Restart 5:00" : "Start 5:00"}
+          </button>
+          {timer && (
+            <button
+              type="button"
+              onClick={() => void stop()}
+              disabled={busy}
+              className="rounded-lg border border-border-default px-3 py-2 font-mono text-xs uppercase tracking-wider text-text-secondary transition-colors hover:border-red/40 hover:text-red disabled:opacity-50"
+            >
+              Stop
+            </button>
+          )}
+        </div>
+      </div>
+      {error && (
+        <p role="alert" className="mx-auto mt-1 max-w-3xl text-[11px] text-red">
+          {error}
+        </p>
+      )}
+      {/* Meaningful moments only — started, one minute left, time up. A live
+          region ticking every second would announce the countdown itself,
+          which is exactly the noise a screen reader user does not want. */}
+      <p aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
+    </div>
+  );
+}

--- a/src/lib/impact-lab/pitch-timer-store.ts
+++ b/src/lib/impact-lab/pitch-timer-store.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared pitch-timer state — one running countdown per cohort, visible to
+ * every judge on the room's screens.
+ *
+ * Judges are on their own phones with clocks that do not agree with each
+ * other, so the timer is a single row of `startedAt` + `seconds` in the
+ * database rather than anything client-local: every device derives the same
+ * countdown from the same `startedAt`, corrected for its own clock skew
+ * against the server's clock (`serverNow` in the read result).
+ *
+ * Same non-existent-table posture as rubric-store.ts: this can ship before
+ * `impact_lab_pitch_timers` exists in a given database. Reads degrade to "no
+ * timer running" rather than error the scoring screen; the route layer's
+ * writes say what migration is missing instead of throwing a bare 500 at
+ * whichever judge tapped Start.
+ */
+
+import { prisma } from "@/lib/prisma"
+
+export const MIN_SECONDS = 30
+export const MAX_SECONDS = 3600
+export const DEFAULT_SECONDS = 300
+
+export interface PitchTimerState {
+  startedAt: string
+  seconds: number
+  startedBy: string
+  /** The server's clock at the moment of this read, for client skew correction. */
+  serverNow: string
+}
+
+export function isValidSeconds(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= MIN_SECONDS &&
+    value <= MAX_SECONDS
+  )
+}
+
+/**
+ * The running timer for a cohort, or null when none is running — including
+ * when the table does not exist yet. Never throws: this sits on the judging
+ * screen's ~2s poll, and an unreadable row must not error a live scorecard.
+ */
+export async function loadPitchTimer(cohort: string): Promise<PitchTimerState | null> {
+  try {
+    const row = await prisma.impactLabPitchTimer.findUnique({
+      where: { cohort },
+      select: { startedAt: true, seconds: true, startedBy: true },
+    })
+    if (!row) return null
+    return {
+      startedAt: row.startedAt.toISOString(),
+      seconds: row.seconds,
+      startedBy: row.startedBy,
+      serverNow: new Date().toISOString(),
+    }
+  } catch (error) {
+    console.error(`[pitch-timer-store] could not read the timer for ${cohort}`, error)
+    return null
+  }
+}


### PR DESCRIPTION
A shared five-minute pitch countdown on `/judge`. Teams pitch for five minutes and judges had no clock.

## It is a room timer, not a stopwatch

Any judge presses Start and **every judge's screen follows**. Two judges disagreeing about how long a team has left is worse than having no timer, so the state is shared (one row per cohort) rather than per-device.

**Clock skew is handled.** The server returns its own current time alongside the timer, and each device corrects against it. Judges are on phones whose clocks do not agree; a countdown computed from a local guess drifts apart across the panel over five minutes.

## The sound

Two short beeps at zero, generated with the Web Audio API, then silence. No loop, no audio file — the organiser was explicit it must not drone on and disturb the room, and a strict CSP rules out fetching an asset anyway.

**Honest limitation:** browsers block audio until that device has had a user gesture. The judge who pressed Start will hear it; a judge who has only been scrolling may not. So the visual end state stands on its own rather than depending on sound, and audio is armed on first interaction.

## Migration — already applied

`20260808150000_impact_lab_pitch_timer`, one additive table, primary key on cohort. **I applied it to production before deploying**, and verified the table exists and the 24 existing participants are untouched.

The code degrades anyway: reads catch Prisma `P2021` and report "no timer running", writes return an error naming the migration. Deploying before the migration lands could not have broken judging.

## Verification

`npx tsc --noEmit` clean, `npm run build` clean, `scripts/verify-judging.ts` 63/63.

Two local build failures during this work were **lock contention from a concurrent build**, not code — a clean rebuild after the other build finished passes.

Not exercised: no judge has started a timer on production yet.

@Spidey-Acer
