### PR TITLE
fix(impact-lab): tell the submitter whether it actually saved

### DIFF
--- a/src/app/api/impact-lab/submission/route.ts
+++ b/src/app/api/impact-lab/submission/route.ts
@@ -26,6 +26,29 @@ interface ResolvedContext {
   closeAt: Date | null
 }
 
+/**
+ * Field key → the label the submitter actually sees on the form.
+ *
+ * Validation reports the first failing field by key (`slidesUrl`), which means
+ * nothing to the person filling the form — and "A link is required" is
+ * ambiguous across five link inputs. Prefixing the label turns an unactionable
+ * error into an instruction.
+ */
+const SUBMISSION_FIELD_LABELS: Readonly<Record<string, string>> = {
+  slidesUrl: "Pitch deck link",
+  projectName: "Project name",
+  pitch: "One-line pitch",
+  description: "What it does",
+  worksVsMocked: "What works vs what's mocked",
+  claudeUsage: "How you used AI",
+  track: "Track",
+  problemTackled: "Problem tackled",
+  repoUrl: "Repo link",
+  demoUrl: "Demo link",
+  videoUrl: "Video link",
+  screenshotUrl: "Screenshot link",
+}
+
 /** Resolve the caller to a team in the cohort's final run, or null. */
 async function resolveContext(email: string): Promise<ResolvedContext | null> {
   const participant = await prisma.impactLabParticipant.findUnique({
@@ -158,8 +181,19 @@ export async function PUT(request: NextRequest) {
 
   const parsed = submissionInputSchema.safeParse(body)
   if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    const field = typeof issue?.path[0] === "string" ? issue.path[0] : ""
+    // Name the field. "A link is required" over five link inputs tells a team
+    // that something is wrong and nothing about what — at 2 AM that is the
+    // difference between fixing it and giving up.
+    const label = SUBMISSION_FIELD_LABELS[field]
+    const message = issue?.message ?? "Invalid submission"
     return NextResponse.json(
-      { success: false, error: parsed.error.issues[0]?.message ?? "Invalid submission" },
+      {
+        success: false,
+        error: label ? `${label}: ${message}` : message,
+        field: field || undefined,
+      },
       { status: 400 }
     )
   }

--- a/src/app/dashboard/impact-lab/SubmitProject.tsx
+++ b/src/app/dashboard/impact-lab/SubmitProject.tsx
@@ -8,7 +8,7 @@
  * owns team resolution, so this component never sends a team identifier.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AlertTriangle, Loader2, Send, CheckCircle } from "lucide-react";
 import { csrfHeaders } from "@/lib/csrf-client";
 import type { SubmissionView } from "@/lib/impact-lab/submission-schema";
@@ -97,6 +97,8 @@ export function SubmitProject() {
    *  null forever otherwise, so it needs its own state to escape the
    *  "Loading…" spinner and offer a retry. */
   const [loadError, setLoadError] = useState<string | null>(null);
+  /** The save-outcome banner, scrolled into view so a result is never missed. */
+  const statusRef = useRef<HTMLDivElement>(null);
 
   const load = useCallback(async () => {
     setLoadError(null);
@@ -153,6 +155,12 @@ export function SubmitProject() {
       setError("Could not save your submission.");
     } finally {
       setSaving(false);
+      // Bring the outcome into view. On a phone the submitter is at the bottom
+      // of a long form and the banner can render off-screen — a save that
+      // silently succeeded reads exactly like one that silently failed.
+      requestAnimationFrame(() =>
+        statusRef.current?.scrollIntoView({ behavior: "smooth", block: "center" })
+      );
     }
   }
 
@@ -288,18 +296,44 @@ export function SubmitProject() {
           {field("videoUrl", "Video link", "A walkthrough, in case the live demo dies.")}
           {field("screenshotUrl", "Screenshot link", "Optional image link.")}
 
-          {error && (
-            <p role="alert" className="font-mono text-xs text-red">
-              {error}
-            </p>
-          )}
+          {/* The outcome has to be impossible to miss. This sat as one line of
+              small text at the foot of a long form, which on a phone is below
+              the fold after filling it in — teams could not tell whether they
+              had submitted or not. */}
+          <div ref={statusRef} tabIndex={-1} className="scroll-mt-24">
+            {error && (
+              <div
+                role="alert"
+                className="flex items-start gap-2.5 rounded-lg border border-red/40 bg-red/10 p-4"
+              >
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-red" />
+                <div>
+                  <p className="font-mono text-sm font-semibold text-red">
+                    Not submitted
+                  </p>
+                  <p className="mt-1 font-mono text-xs text-red/90">{error}</p>
+                </div>
+              </div>
+            )}
 
-          {saved && (
-            <p role="status" className="font-mono text-xs text-green-primary">
-              <CheckCircle className="mr-1.5 inline h-3.5 w-3.5" />
-              Saved. Your teammates will see this.
-            </p>
-          )}
+            {saved && (
+              <div
+                role="status"
+                className="flex items-start gap-2.5 rounded-lg border border-green-primary/40 bg-green-primary/10 p-4"
+              >
+                <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-green-primary" />
+                <div>
+                  <p className="font-mono text-sm font-semibold text-green-primary">
+                    Submitted
+                  </p>
+                  <p className="mt-1 font-mono text-xs text-green-primary/90">
+                    Saved — your teammates and the judges can see this. You can
+                    keep editing until submissions close.
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
 
           {!readOnly && (
             <button


### PR DESCRIPTION
Teams reported "submission is failing". Submissions were in fact working — they could not **tell**.

## Two compounding problems

**The error named no field.** Zod reports the first failing key; the route forwarded only its message. A missing pitch deck therefore read as `A link is required` across five link inputs — which says something is wrong and nothing about what. The field label now prefixes the message ("Pitch deck link: A link is required").

**The outcome was one line of small text at the foot of a long form.** On a phone, after filling it in, that renders below the fold. A save that silently succeeded looked identical to one that silently failed. It is now a banner reading **Submitted** or **Not submitted**, and the page scrolls it into view when the save completes.

## Verification

`npx tsc --noEmit` clean, `npm run build` clean.

Branched from current `main` (500dfeb) so it contains every prior fix — I deployed a branch earlier that predated PR #104 and briefly reverted deck-only submissions in production. That window closed when #105 merged, but it is why this one is explicitly based on current main.

@Spidey-Acer