### PR TITLE
feat(impact-lab)!: multi-tenant event platform — tenancy core (sub-project 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,13 +44,7 @@ KARIBU_CANARY_PCT=100
 CRON_SECRET=
 
 # ─── Impact Lab ───────────────────────────────────────────────────────────────
-# Slug of the cohort currently running a hackathon (e.g. impact-lab-2026-07).
-# Empty/unset means no cohort is active. Drives two things:
-#   1. The six cohort-gated write endpoints (check-in, profile, submission,
-#      team/leader, team/roster) — they 403 once the running cohort's slug
-#      no longer matches this value.
-#   2. scripts/purge-closed-cohorts.ts — protects this cohort from the
-#      privacy purge. Left unset, the purge script refuses to run --apply
-#      rather than risk clearing a live cohort's phone numbers and
-#      blocked-teammate lists.
-IMPACT_LAB_ACTIVE_COHORT=
+# Which cohort is running, and its lifecycle status (DRAFT/LIVE/CLOSED/
+# ARCHIVED), now live in the database (the Event table) — set from Admin →
+# Impact Lab → Events tab, not here. No env var to configure. See
+# docs/impact-lab/16-running-another-event.md.

--- a/docs/impact-lab/16-running-another-event.md
+++ b/docs/impact-lab/16-running-another-event.md
@@ -1,9 +1,10 @@
 # 16 — Running another event on this system
 
-The Impact Lab surfaces are not tied to one hackathon. Every row in every Impact
-Lab table carries a `cohort` string, and one environment variable decides which
-cohort the site serves. Running a second event is configuration plus a seed —
-not a fork, and not a second deployment.
+The Impact Lab surfaces are not tied to one hackathon. Every event is a row in
+the `Event` table (`src/lib/impact-lab/event-store.ts`), and the admin
+dashboard is where you create, launch, close and archive one. Running a
+second event is a dashboard flow plus a seed — not a fork, not a second
+deployment, and not an env-var change.
 
 This document is the runbook. It was written while standing up the **Afretec
 Makerthon 2026** (C4DLab, University of Nairobi) alongside the July Impact Lab,
@@ -11,43 +12,33 @@ and it describes what actually had to happen.
 
 ## The one thing to understand first
 
-Two constants in `src/lib/impact-lab/constants.ts` do different jobs:
+There is no single "active cohort" any more. Each event carries its own
+lifecycle status — `DRAFT`, `LIVE`, `CLOSED`, `ARCHIVED` — set from **Admin →
+Impact Lab → Events tab**:
 
-| Constant | Meaning |
+| Action | Effect |
 |---|---|
-| `DEFAULT_COHORT` | A hardcoded fallback. The most recent cohort. Never edit it to switch events. |
-| `ACTIVE_COHORT` | `process.env.IMPACT_LAB_ACTIVE_COHORT`, or `null`. Which cohort is **live right now**. |
-| `CURRENT_COHORT` | `ACTIVE_COHORT ?? DEFAULT_COHORT`. **The cohort every surface reads.** |
+| **Create** | Adds a new event in `DRAFT`. Not yet visible to members, no writes accepted. |
+| **Launch** | Moves the event to `LIVE`. Member-facing writes for that cohort open (`guardClosedCohort` reads the event's own status). |
+| **Close** | Moves the event to `CLOSED`. Writes stop; reads stay open as a historical record. |
+| **Archive** | Moves the event to `ARCHIVED`. Drops out of the admin default-cohort picker. |
 
-`CURRENT_COHORT` is what participant lookups, team reads, submissions, judging,
-results and the admin dashboard all key on. Setting `IMPACT_LAB_ACTIVE_COHORT`
-therefore does two things at once: it points the whole site at the new event,
-and it opens member-facing writes (`guardClosedCohort` only lets writes through
-for the active cohort).
+Several events can be `LIVE` at the same time — closing one no longer takes
+any other event offline. Each member's dashboard shows every event they have
+a participant row in; each admin/judge screen defaults to the newest
+non-archived event, preferring whichever is `LIVE`.
 
-Unsetting it is the end-of-event switch: the site falls back to `DEFAULT_COHORT`
-and every member-facing write closes, leaving a read-only record.
+`DEFAULT_COHORT` (`src/lib/impact-lab/constants.ts`) still exists, but only as
+the degrade target for an environment whose tenancy migration has not run —
+never edit it to switch events, and it plays no role once the migration and
+seed are in place.
 
-> Historical note: `ACTIVE_COHORT` originally gated only writes, while every
-> read was hardcoded to `DEFAULT_COHORT`. Flipping the env var opened writes but
-> still served the old event's teams. `CURRENT_COHORT` exists to close that gap.
+### What launching costs the previous cohort
 
-`safeCohort()` — how all 21 admin API routes resolve a cohort from a query
-param — falls back to `CURRENT_COHORT` too. That matters more than it looks:
-the judge screen calls `/api/admin/impact-lab/judging` with no `cohort` param
-at all, so this fallback *is* the cohort judges score.
-
-### What switching costs the previous cohort
-
-Setting `IMPACT_LAB_ACTIVE_COHORT` points **every** read at the new event. The
-previous cohort's rows are untouched at rest, but nothing reads them any more:
-its participants sign in, are told no registration was found, and lose access to
-their team, results and reviews for the duration of the new event.
-
-That is an acceptable trade for a one-night event and it reverses by unsetting
-the variable. It is **not** an archive. Giving past participants durable
-read-only access to their own cohort is outstanding work — do not read the step
-below as claiming it is handled.
+Nothing. Because status lives per-event in the database instead of a single
+global pointer, launching a new event does not change what any other event's
+participants can read or how their team, results and reviews resolve. Closing
+an event is a decision about that event alone.
 
 ## Two kinds of event
 
@@ -70,7 +61,13 @@ meaningful match score and the admin dashboard should not imply otherwise.
 1. **Choose a cohort slug.** Must match `/^[a-z0-9][a-z0-9-]{0,59}$/`; date-suffix
    it (`afretec-makerthon-2026-08`). It appears in export filenames.
 
-2. **Get the participants in.** Either the admin import for a matching event, or
+2. **Create the event.** Admin → Impact Lab → Events tab → New event. Fill in
+   the organisation, title, dates, location and format note — this is what
+   member-facing surfaces and exports display, so it replaces what used to be
+   `IMPACT_LAB_COHORT_LABEL`. The event starts in `DRAFT`; it is not visible to
+   members and accepts no writes until you Launch it.
+
+3. **Get the participants in.** Either the admin import for a matching event, or
    a seed script for pre-formed teams. Two rules learned the hard way:
    - **Validate against the original registration export, not a derived file.**
      The Afretec seed was first built from a reconstructed PDF directory; diffing
@@ -80,16 +77,16 @@ meaningful match score and the admin dashboard should not imply otherwise.
    - **Keep participant data out of this repo.** It is public. Registration
      exports live outside the working tree; `scripts/output/` is gitignored.
 
-3. **Seed the run.** Dry-run first and read the report. `isFinal: true` is what
+4. **Seed the run.** Dry-run first and read the report. `isFinal: true` is what
    makes teams visible — a partial unique index allows only one final run per
    cohort, so re-seeding updates in place rather than creating a second.
 
-4. **Set the environment** in Vercel (no deploy needed):
-   - `IMPACT_LAB_ACTIVE_COHORT=<slug>`
-   - `IMPACT_LAB_COHORT_LABEL=<event name>` — what the self-registration card
-     calls the event. Without it the card shows the raw slug. Since any signed-in
-     account sees that card, naming the event is what stops people registering
-     for something they are not attending.
+5. **Launch the event.** Admin → Impact Lab → Events tab → Launch. This is the
+   only step that opens member-facing writes for the cohort — no Vercel change,
+   no redeploy. Other events are unaffected, whatever their status.
+
+6. **Rotate operational secrets.** These still live in Vercel, unlike the event
+   itself:
    - `JUDGE_ACCESS_CODE=<fresh code>` — **rotate this every event.** It defaults
      to a literal in `judge-access.ts`, and anyone who learned the last event's
      code can otherwise submit scores under any name they type.
@@ -98,7 +95,7 @@ meaningful match score and the admin dashboard should not imply otherwise.
      Set it to `true` when people register remotely, since without it someone
      can sign up as another registrant and read that person's team.
 
-5. **Set the judging rubric.** Rubrics are per-event — see
+7. **Set the judging rubric.** Rubrics are per-event — see
    `src/lib/impact-lab/judging-rubrics.ts` and doc 17 for the admin builder. Do
    not assume the Impact Lab rubric transfers: the Afretec panel supplied eight
    criteria with uneven maxima totalling 50 and points-based arithmetic, where
@@ -107,20 +104,21 @@ meaningful match score and the admin dashboard should not imply otherwise.
    rubric — so a new event without a rubric entry will be scored on the wrong
    criteria rather than erroring.
 
-6. **Check the event-specific copy.** The submission form carries the
+8. **Check the event-specific copy.** The submission form carries the
    assumptions of the event it was built for. For Afretec, the Claude-specific
    submission question was relabelled to ask about AI generally. Note that the
    *stored keys* stayed (`claudeUsage`, `scores.claude`) — only labels changed,
    because renaming keys orphans stored scores and breaks the export pipeline.
 
-7. **Smoke-test one real account end to end** before telling anyone to sign up:
+9. **Smoke-test one real account end to end** before telling anyone to sign up:
    log in as a seeded leader, see the team, save a submission, then score that
    submission from `/judge` with the new code and confirm the score lands on
    **this** cohort's leaderboard. That last check is the one that catches a
    cohort-resolution mistake, and it is invisible from the participant side.
 
-8. **Confirm the previous cohort went read-only.** It should: `isCohortActive`
-   is false for it, and its data is untouched.
+10. **Confirm the previous cohort is unaffected.** It should be, automatically:
+    its own status is whatever you last set it to (typically `CLOSED`), and
+    launching the new event does not touch it.
 
 ## What participants have to do
 
@@ -135,5 +133,6 @@ reconcile it except by hand.
 
 ## When the event ends
 
-Unset `IMPACT_LAB_ACTIVE_COHORT`. Rotate `JUDGE_ACCESS_CODE`. The cohort becomes
-a read-only record and the next event repeats this list.
+Admin → Impact Lab → Events tab → Close. Rotate `JUDGE_ACCESS_CODE`. The cohort
+becomes a read-only record and the next event repeats this list — no redeploy,
+and no effect on any other event that happens to still be `LIVE`.

--- a/docs/superpowers/plans/2026-08-08-event-platform-tenancy.md
+++ b/docs/superpowers/plans/2026-08-08-event-platform-tenancy.md
@@ -1,0 +1,1587 @@
+# Event Platform Tenancy (Sub-project 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `Event` a database row owned by an `Organisation`, with a dashboard-controlled lifecycle that replaces the `IMPACT_LAB_ACTIVE_COHORT` env var, membership-based event resolution for participants, and org-scoped authorization — per the approved spec at `docs/superpowers/specs/2026-08-08-event-platform-tenancy-design.md`.
+
+**Architecture:** Three new Prisma models (`Organisation`, `OrganisationMember`, `Event`) join the nine existing cohort-keyed Impact Lab tables by slug — the migration is purely additive. New pure-logic module (`event-lifecycle.ts`) + thin DB module (`event-store.ts`) + access module (`event-access.ts`) replace the env-derived `CURRENT_COHORT` constant, which is deleted in the final task so every unconverted call site fails at compile time.
+
+**Tech Stack:** Next.js 16 App Router, TypeScript strict, Prisma 7 (PostgreSQL), NextAuth v5, Zod, Tailwind v4 (Terminal Noir tokens for admin UI), `tsx` for verify/seed scripts.
+
+## Global Constraints
+
+- **Prerequisite: PR #107 must be merged to main before execution starts.** Task 11 modifies `src/lib/impact-lab/event-branding.ts` and its three export call sites, which exist only in that PR. Verify with `git log origin/main --oneline -5 | grep -i branding` before branching.
+- Work on branch `feat/event-platform-tenancy`, created from up-to-date `origin/main`. Never commit to main. Do not push or open a PR until the user says so.
+- Gate before EVERY commit: `npx tsc --noEmit` clean AND `npm run verify:events` passing (once it exists, Task 3 onward). Run `npm run build` at the milestones marked in tasks (it takes ~30s; not every step).
+- TypeScript strict; never `any`. Conventional commits `type(scope): description`.
+- All styling via Tailwind utilities + the Terminal Noir CSS variables (`--bg-card`, `--green-primary`, `--text-dim`, …) already used across `src/components/admin/impact-lab/`. No inline styles.
+- **Never run migrations or seeds against production.** Local migration + local seed only. Production application is a hand-off checklist at the end (SSH tunnel runbook, direct port 5433 — never through PgBouncer 6432).
+- **Do not delete or modify existing migration folders.** New migration folders only.
+- If `npx tsc --noEmit` shows dozens of "property does not exist on PrismaClient" errors, run `npx prisma generate` first — stale client, not real errors (known issue).
+- Existing production data is untouchable: no schema change to the nine existing Impact Lab tables, no data rewrites.
+- JSDoc on every exported function: what, why, params, returns.
+
+---
+
+### Task 1: Prisma schema — Organisation, OrganisationMember, Event
+
+**Files:**
+- Modify: `prisma/schema.prisma` (enums near line 116, User relations near line 147, new models after `ImpactLabResultsEmail` which starts at line 979)
+- Create: `prisma/migrations/<timestamp>_event_platform_tenancy/migration.sql` (generated)
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: Prisma models `Organisation`, `OrganisationMember`, `Event`; enums `OrgRole { OWNER ORGANISER }`, `EventStatus { DRAFT LIVE CLOSED ARCHIVED }`; `User.organisationMemberships` relation. Later tasks query `prisma.event`, `prisma.organisation`, `prisma.organisationMember`.
+
+- [ ] **Step 1: Add enums**
+
+In `prisma/schema.prisma`, directly after the `ImpactLabExperience` enum (ends line 116), add:
+
+```prisma
+// Tenant-tier role, orthogonal to the site-wide UserRole. Site
+// SUPER_ADMIN/ADMIN are the *platform* tier and pass every event check;
+// OrganisationMember grants access to one organisation's events only.
+enum OrgRole {
+  OWNER
+  ORGANISER
+}
+
+// Event lifecycle. Judging/submission windows are NOT statuses — they stay
+// as fine-grained flags on the match run (judgingOpen, submissionsCloseAt),
+// because Afretec needed judging and submissions open concurrently.
+enum EventStatus {
+  DRAFT // being set up; invisible to participants and judges
+  LIVE // participants form teams and submit; judges score
+  CLOSED // read-only for participants; reports and exports available
+  ARCHIVED // hidden from default listings; data retained
+}
+```
+
+- [ ] **Step 2: Add the User relation**
+
+In `model User`, after `impactLabMatchRuns   ImpactLabMatchRun[]` (line 147), add:
+
+```prisma
+  organisationMemberships OrganisationMember[]
+```
+
+- [ ] **Step 3: Add the three models**
+
+At the end of the Impact Lab section of the schema (after `model ImpactLabResultsEmail`), add:
+
+```prisma
+// ─── Event Platform Tenancy ──────────────────────────────────────────────────
+// An Event belongs to an Organisation and OWNS a unique cohort slug — the
+// join key into the nine cohort-keyed Impact Lab tables above. Those tables
+// keep their string columns; no FKs are added to them (the join is by slug,
+// matching every existing query). See the 2026-08-08 tenancy design spec.
+
+model Organisation {
+  id           String   @id @default(cuid())
+  slug         String   @unique
+  name         String
+  logoUrl      String?
+  contactEmail String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  members OrganisationMember[]
+  events  Event[]
+
+  @@map("organisations")
+}
+
+model OrganisationMember {
+  id             String   @id @default(cuid())
+  organisationId String
+  userId         String
+  role           OrgRole  @default(ORGANISER)
+  createdAt      DateTime @default(now())
+
+  organisation Organisation @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([organisationId, userId])
+  @@map("organisation_members")
+}
+
+model Event {
+  id             String      @id @default(cuid())
+  organisationId String
+  /// Authoritative registry entry for the cohort slug used across the nine
+  /// Impact Lab tables. Unique: one Event per cohort, ever.
+  cohort         String      @unique
+  name           String
+  status         EventStatus @default(DRAFT)
+
+  // Branding — replaces the code constants in event-branding.ts (Task 11).
+  titleLead   String
+  titleAccent String
+  dates       String
+  location    String
+  formatNote  String  @db.Text
+  groundRules String? @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organisation Organisation @relation(fields: [organisationId], references: [id])
+
+  @@index([organisationId])
+  @@index([status])
+  @@map("impact_lab_events")
+}
+```
+
+- [ ] **Step 4: Generate the migration**
+
+If a local database is reachable (check `prisma.config.ts` / `.env` — note the known issue that local env may point at the decommissioned Supabase):
+
+```bash
+npm run db:migrate -- --name event_platform_tenancy
+```
+
+If no local database is reachable, author the migration the way the pitch-timer migration was authored — generate SQL without a database and write it into a hand-timestamped folder:
+
+```bash
+mkdir -p prisma/migrations/20260808200000_event_platform_tenancy
+npx prisma migrate diff --from-migrations prisma/migrations --to-schema-datamodel prisma/schema.prisma --script > prisma/migrations/20260808200000_event_platform_tenancy/migration.sql
+```
+
+Then inspect the SQL: it must contain ONLY `CREATE TYPE` (2), `CREATE TABLE` (3), `CREATE INDEX`/`CREATE UNIQUE INDEX`, and `ADD CONSTRAINT ... FOREIGN KEY` statements for the new tables. **If it contains any `ALTER TABLE` on an existing table or any `DROP`, STOP — the schema edit touched something it must not. Fix the schema before continuing.**
+
+- [ ] **Step 5: Regenerate the client and type-check**
+
+```bash
+npx prisma generate
+npx tsc --noEmit
+```
+
+Expected: clean. (`prisma.event` etc. now exist on the client.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add prisma/schema.prisma prisma/migrations
+git commit -m "feat(impact-lab): add Organisation, OrganisationMember and Event models"
+```
+
+---
+
+### Task 2: Backfill seed script
+
+**Files:**
+- Create: `scripts/seed-events.ts`
+- Modify: `package.json` (scripts block, after `"seed:hackathon"`)
+
+**Interfaces:**
+- Consumes: Prisma models from Task 1.
+- Produces: two `Organisation` rows (slugs `cck`, `c4dlab`), two `Event` rows (cohorts `impact-lab-2026-07`, `afretec-makerthon-2026-08`, both `CLOSED`), `OrganisationMember` OWNER rows for every active `SUPER_ADMIN`/`ADMIN` user on `cck`. Idempotent — safe to run twice.
+
+- [ ] **Step 1: Write the seed script**
+
+Follow the house pattern from `scripts/seed-hackathon-cohort.ts`: dry-run by default, `--apply` to write, prints a summary either way. Branding values are copied **verbatim** from `src/lib/impact-lab/event-branding.ts` (`IMPACT_LAB_BRANDING`, `AFRETEC_BRANDING`) — but hardcoded here rather than imported, so the script still runs after Task 11 reshapes that module.
+
+```ts
+/**
+ * Backfill the tenancy tables with the two events that already ran.
+ *
+ * Idempotent: every write is an upsert keyed on the unique slug/cohort, so
+ * running it twice changes nothing. Dry-run by default; pass --apply to write.
+ *
+ *   npm run seed:events            # report what would change
+ *   npm run seed:events -- --apply # write
+ */
+import { PrismaClient } from "../src/generated/prisma/client"
+
+const prisma = new PrismaClient()
+const APPLY = process.argv.includes("--apply")
+
+interface OrgSeed {
+  slug: string
+  name: string
+  contactEmail: string | null
+}
+
+interface EventSeed {
+  orgSlug: string
+  cohort: string
+  name: string
+  status: "CLOSED"
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+}
+
+const ORGS: OrgSeed[] = [
+  { slug: "cck", name: "Claude Community Kenya", contactEmail: "hello@claudekenya.org" },
+  { slug: "c4dlab", name: "C4DLab, University of Nairobi", contactEmail: null },
+]
+
+const EVENTS: EventSeed[] = [
+  {
+    orgSlug: "cck",
+    cohort: "impact-lab-2026-07",
+    name: "Impact Lab: AI Mashinani",
+    status: "CLOSED",
+    titleLead: "Impact Lab:",
+    titleAccent: "AI Mashinani",
+    dates: "25–26 July 2026",
+    location: "Nairobi, Kenya",
+    formatNote:
+      "An overnight build: teams formed in the evening, built through the night, " +
+      "and judging ran from the small hours into the morning.",
+  },
+  {
+    orgSlug: "c4dlab",
+    cohort: "afretec-makerthon-2026-08",
+    name: "Afretec Makerthon 2026",
+    status: "CLOSED",
+    titleLead: "Afretec",
+    titleAccent: "Makerthon 2026",
+    dates: "8 August 2026",
+    location: "Nairobi, Kenya",
+    formatNote:
+      "Teams registered as existing startups and were formed before the event. Each team " +
+      "pitched live for five minutes and was scored by a judging panel on eight criteria out " +
+      "of 50.",
+  },
+]
+
+async function main(): Promise<void> {
+  console.log(APPLY ? "APPLY mode — writing." : "DRY RUN — pass --apply to write.")
+
+  for (const org of ORGS) {
+    const existing = await prisma.organisation.findUnique({ where: { slug: org.slug } })
+    console.log(`organisation ${org.slug}: ${existing ? "exists" : "will create"}`)
+    if (APPLY) {
+      await prisma.organisation.upsert({
+        where: { slug: org.slug },
+        create: org,
+        update: { name: org.name, contactEmail: org.contactEmail },
+      })
+    }
+  }
+
+  for (const event of EVENTS) {
+    const org = await prisma.organisation.findUnique({ where: { slug: event.orgSlug } })
+    if (!org) {
+      if (APPLY) throw new Error(`organisation ${event.orgSlug} missing — cannot seed ${event.cohort}`)
+      console.log(`event ${event.cohort}: would create under ${event.orgSlug} (org pending)`)
+      continue
+    }
+    const { orgSlug: _orgSlug, ...data } = event
+    const existing = await prisma.event.findUnique({ where: { cohort: event.cohort } })
+    console.log(`event ${event.cohort}: ${existing ? "exists" : "will create"}`)
+    if (APPLY) {
+      await prisma.event.upsert({
+        where: { cohort: event.cohort },
+        // Backfill never overwrites a status an admin may have changed since.
+        create: { ...data, organisationId: org.id },
+        update: {},
+      })
+    }
+  }
+
+  // Every active platform admin becomes an OWNER of the CCK organisation.
+  const admins = await prisma.user.findMany({
+    where: { role: { in: ["SUPER_ADMIN", "ADMIN"] }, active: true },
+    select: { id: true, email: true },
+  })
+  const cck = await prisma.organisation.findUnique({ where: { slug: "cck" } })
+  console.log(`cck OWNER memberships for ${admins.length} platform admin(s)`)
+  if (APPLY && cck) {
+    for (const admin of admins) {
+      await prisma.organisationMember.upsert({
+        where: { organisationId_userId: { organisationId: cck.id, userId: admin.id } },
+        create: { organisationId: cck.id, userId: admin.id, role: "OWNER" },
+        update: {},
+      })
+    }
+  }
+
+  console.log("Done.")
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())
+```
+
+- [ ] **Step 2: Register the npm script**
+
+In `package.json`, after `"seed:hackathon"`:
+
+```json
+    "seed:events": "tsx scripts/seed-events.ts",
+```
+
+- [ ] **Step 3: Verify against a local database if reachable**
+
+```bash
+npm run seed:events            # dry run — must not throw
+npm run seed:events -- --apply # if a local DB with the migration exists
+npm run seed:events -- --apply # second run must report "exists" everywhere
+```
+
+If no local database is reachable, `npx tsc --noEmit` clean is the gate; note in the commit body that the apply run is deferred to the deploy checklist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/seed-events.ts package.json
+git commit -m "feat(impact-lab): idempotent backfill seed for organisations and events"
+```
+
+---
+
+### Task 3: Pure lifecycle logic + the verify script
+
+**Files:**
+- Create: `src/lib/impact-lab/event-lifecycle.ts`
+- Create: `scripts/verify-events.ts`
+- Modify: `package.json` (add `"verify:events": "tsx scripts/verify-events.ts",` after `"verify:reviews"`)
+
+**Interfaces:**
+- Consumes: nothing from the DB — this module is deliberately pure so the verify script can assert it without a database.
+- Produces (exact signatures later tasks import):
+
+```ts
+export const EVENT_STATUSES: readonly ["DRAFT", "LIVE", "CLOSED", "ARCHIVED"]
+export type EventStatusValue = (typeof EVENT_STATUSES)[number]
+export function canTransition(
+  from: EventStatusValue,
+  to: EventStatusValue,
+  hasParticipants: boolean
+): { ok: true } | { ok: false; reason: string }
+export interface MemberEventRef {
+  cohort: string
+  status: EventStatusValue
+  createdAt: Date
+}
+export function orderMemberEvents<T extends MemberEventRef>(events: T[]): T[]
+export function pickMemberEvent<T extends MemberEventRef>(
+  events: T[],
+  requested?: string | null
+): T | null
+export function validCohort(input: string | null | undefined): string | null
+```
+
+- [ ] **Step 1: Write the first failing assertions**
+
+Create `scripts/verify-events.ts` in the style of `scripts/verify-judging.ts` (a plain tsx script of `assert`-style checks with a pass/fail counter — read that file's header first and copy its `check(name, condition)` harness exactly):
+
+```ts
+/**
+ * Assertions for the event tenancy logic: lifecycle transitions, member
+ * event resolution precedence, and cohort slug validation. Pure logic only —
+ * runs without a database, like verify-judging.ts.
+ *
+ *   npm run verify:events
+ */
+import {
+  canTransition,
+  orderMemberEvents,
+  pickMemberEvent,
+  validCohort,
+} from "../src/lib/impact-lab/event-lifecycle"
+
+let passed = 0
+let failed = 0
+function check(name: string, condition: boolean): void {
+  if (condition) {
+    passed += 1
+  } else {
+    failed += 1
+    console.error(`FAIL: ${name}`)
+  }
+}
+
+// ── canTransition ────────────────────────────────────────────────────────────
+check("DRAFT→LIVE allowed", canTransition("DRAFT", "LIVE", false).ok)
+check("DRAFT→LIVE allowed with participants", canTransition("DRAFT", "LIVE", true).ok)
+check("LIVE→DRAFT allowed while empty", canTransition("LIVE", "DRAFT", false).ok)
+check("LIVE→DRAFT refused once participants exist", !canTransition("LIVE", "DRAFT", true).ok)
+check("LIVE→CLOSED allowed", canTransition("LIVE", "CLOSED", true).ok)
+check("CLOSED→LIVE (reopen) allowed", canTransition("CLOSED", "LIVE", true).ok)
+check("CLOSED→ARCHIVED allowed", canTransition("CLOSED", "ARCHIVED", true).ok)
+check("ARCHIVED→CLOSED (unarchive) allowed", canTransition("ARCHIVED", "CLOSED", true).ok)
+check("DRAFT→ARCHIVED refused (archive requires CLOSED)", !canTransition("DRAFT", "ARCHIVED", false).ok)
+check("LIVE→ARCHIVED refused (archive requires CLOSED)", !canTransition("LIVE", "ARCHIVED", true).ok)
+check("ARCHIVED→LIVE refused (unarchive first)", !canTransition("ARCHIVED", "LIVE", true).ok)
+check("no-op transition refused", !canTransition("LIVE", "LIVE", true).ok)
+check("refusal carries a reason", canTransition("LIVE", "DRAFT", true).ok === false &&
+  (canTransition("LIVE", "DRAFT", true) as { ok: false; reason: string }).reason.length > 0)
+
+// ── ordering and picking ─────────────────────────────────────────────────────
+const day = (n: number): Date => new Date(2026, 0, n)
+const closedOld = { cohort: "old-closed", status: "CLOSED" as const, createdAt: day(1) }
+const closedNew = { cohort: "new-closed", status: "CLOSED" as const, createdAt: day(5) }
+const liveOld = { cohort: "old-live", status: "LIVE" as const, createdAt: day(2) }
+const liveNew = { cohort: "new-live", status: "LIVE" as const, createdAt: day(4) }
+const draft = { cohort: "a-draft", status: "DRAFT" as const, createdAt: day(9) }
+const archived = { cohort: "an-archived", status: "ARCHIVED" as const, createdAt: day(9) }
+
+const ordered = orderMemberEvents([closedOld, draft, liveOld, archived, liveNew, closedNew])
+check("DRAFT excluded from member view", !ordered.some((e) => e.cohort === "a-draft"))
+check("ARCHIVED excluded from member view", !ordered.some((e) => e.cohort === "an-archived"))
+check("LIVE events come before CLOSED", ordered[0].status === "LIVE" && ordered[1].status === "LIVE")
+check("newest LIVE first", ordered[0].cohort === "new-live")
+check("newest CLOSED first within CLOSED", ordered[2].cohort === "new-closed")
+
+check("pick: empty list → null", pickMemberEvent([]) === null)
+check("pick: single event wins", pickMemberEvent([closedOld])?.cohort === "old-closed")
+check("pick: newest LIVE by default", pickMemberEvent([closedNew, liveOld, liveNew])?.cohort === "new-live")
+check("pick: requested cohort honoured when member", pickMemberEvent([liveNew, liveOld], "old-live")?.cohort === "old-live")
+check("pick: requested cohort ignored when not a member", pickMemberEvent([liveNew], "someone-elses")?.cohort === "new-live")
+check("pick: requested DRAFT/ARCHIVED unreachable", pickMemberEvent([liveNew, draft], "a-draft")?.cohort === "new-live")
+
+// ── validCohort ──────────────────────────────────────────────────────────────
+check("validCohort accepts a real slug", validCohort("afretec-makerthon-2026-08") === "afretec-makerthon-2026-08")
+check("validCohort trims", validCohort("  impact-lab-2026-07 ") === "impact-lab-2026-07")
+check("validCohort rejects empty", validCohort("") === null)
+check("validCohort rejects null/undefined", validCohort(null) === null && validCohort(undefined) === null)
+check("validCohort rejects CR/LF injection", validCohort("x\r\nSet-Cookie: a=b") === null)
+check("validCohort rejects overlong input", validCohort("a".repeat(61)) === null)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+npx tsx scripts/verify-events.ts
+```
+
+Expected: FAIL — module `../src/lib/impact-lab/event-lifecycle` does not exist.
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/lib/impact-lab/event-lifecycle.ts`:
+
+```ts
+/**
+ * Pure event-lifecycle logic: which status transitions are legal, which
+ * events a participant can see, and cohort slug validation.
+ *
+ * No database access — everything here is assertable by scripts/verify-events.ts
+ * without infrastructure, the same split judging.ts has from its routes.
+ */
+
+export const EVENT_STATUSES = ["DRAFT", "LIVE", "CLOSED", "ARCHIVED"] as const
+export type EventStatusValue = (typeof EVENT_STATUSES)[number]
+
+/**
+ * Whether an admin may move an event between two statuses.
+ *
+ * The graph is deliberately narrow: DRAFT⇄LIVE (back only while nobody has
+ * registered — un-launching an event people joined would hide their data),
+ * LIVE⇄CLOSED (reopening a closed event is a legitimate organiser action),
+ * CLOSED⇄ARCHIVED. Archiving from anywhere else must pass through CLOSED so
+ * that "archived" always means "was properly closed first".
+ */
+export function canTransition(
+  from: EventStatusValue,
+  to: EventStatusValue,
+  hasParticipants: boolean
+): { ok: true } | { ok: false; reason: string } {
+  if (from === to) return { ok: false, reason: "The event is already in that state." }
+  if (from === "DRAFT" && to === "LIVE") return { ok: true }
+  if (from === "LIVE" && to === "DRAFT") {
+    return hasParticipants
+      ? { ok: false, reason: "People have already registered — close the event instead of un-launching it." }
+      : { ok: true }
+  }
+  if (from === "LIVE" && to === "CLOSED") return { ok: true }
+  if (from === "CLOSED" && to === "LIVE") return { ok: true }
+  if (from === "CLOSED" && to === "ARCHIVED") return { ok: true }
+  if (from === "ARCHIVED" && to === "CLOSED") return { ok: true }
+  return { ok: false, reason: `An event cannot go from ${from} to ${to}.` }
+}
+
+/** The minimum shape resolution needs; event-store rows satisfy it. */
+export interface MemberEventRef {
+  cohort: string
+  status: EventStatusValue
+  createdAt: Date
+}
+
+/**
+ * The events a participant may see, in display order: LIVE before CLOSED,
+ * newest first within each. DRAFT (not launched) and ARCHIVED (deliberately
+ * hidden) are excluded — a participant's view of an archived event is a
+ * platform-admin conversation, not a dashboard surface.
+ */
+export function orderMemberEvents<T extends MemberEventRef>(events: T[]): T[] {
+  const rank: Record<EventStatusValue, number> = { LIVE: 0, CLOSED: 1, DRAFT: 9, ARCHIVED: 9 }
+  return events
+    .filter((e) => e.status === "LIVE" || e.status === "CLOSED")
+    .sort((a, b) =>
+      rank[a.status] !== rank[b.status]
+        ? rank[a.status] - rank[b.status]
+        : b.createdAt.getTime() - a.createdAt.getTime()
+    )
+}
+
+/**
+ * The single event a member request operates on. An explicitly requested
+ * cohort wins only if the caller is actually a visible member of it —
+ * otherwise the newest visible event (LIVE first). Null when the caller
+ * belongs to no visible event, which routes surface as their existing
+ * "no team" experience.
+ */
+export function pickMemberEvent<T extends MemberEventRef>(
+  events: T[],
+  requested?: string | null
+): T | null {
+  const visible = orderMemberEvents(events)
+  if (requested) {
+    const match = visible.find((e) => e.cohort === requested)
+    if (match) return match
+  }
+  return visible[0] ?? null
+}
+
+const COHORT_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/i
+
+/**
+ * Validate user-supplied cohort input to a safe slug, or null.
+ *
+ * This is the successor to constants.ts `safeCohort`, minus the fallback:
+ * what "no cohort named" means now depends on who is asking (a member's own
+ * events, the admin default event), so callers own the fallback and this
+ * function only answers "is this string safe to put in a query and a
+ * Content-Disposition header?".
+ */
+export function validCohort(input: string | null | undefined): string | null {
+  const value = (input ?? "").trim()
+  return COHORT_PATTERN.test(value) ? value : null
+}
+```
+
+- [ ] **Step 4: Register the npm script and run to green**
+
+In `package.json`, after `"verify:reviews"`:
+
+```json
+    "verify:events": "tsx scripts/verify-events.ts",
+```
+
+```bash
+npm run verify:events
+npx tsc --noEmit
+```
+
+Expected: all assertions pass, tsc clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/impact-lab/event-lifecycle.ts scripts/verify-events.ts package.json
+git commit -m "feat(impact-lab): pure event lifecycle logic with verify script"
+```
+
+---
+
+### Task 4: Event store (DB access with degrade)
+
+**Files:**
+- Create: `src/lib/impact-lab/event-store.ts`
+- Reference (read first, do not modify): `src/lib/impact-lab/rubric-store.ts` — copy its P2021 handling style exactly.
+
+**Interfaces:**
+- Consumes: `EventStatusValue`, `pickMemberEvent`, `orderMemberEvents` from Task 3; `prisma` from `@/lib/prisma`; `DEFAULT_COHORT` from `./constants`.
+- Produces (exact signatures later tasks import):
+
+```ts
+export interface EventRecord {
+  id: string
+  organisationId: string
+  organisationName: string
+  cohort: string
+  name: string
+  status: EventStatusValue
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+  groundRules: string | null
+  createdAt: Date
+}
+export interface MemberEvent extends EventRecord {
+  participantId: string
+}
+export async function getEventByCohort(cohort: string): Promise<EventRecord | null>
+export async function listEvents(): Promise<EventRecord[]>
+export async function defaultAdminCohort(): Promise<string>
+export async function resolveAdminCohort(input: string | null | undefined): Promise<string>
+export async function resolveMemberEvents(email: string): Promise<MemberEvent[]>
+export async function resolveMemberEvent(
+  email: string,
+  requested?: string | null
+): Promise<MemberEvent | null>
+export async function eventHasParticipants(cohort: string): Promise<boolean>
+```
+
+- [ ] **Step 1: Implement the module**
+
+Create `src/lib/impact-lab/event-store.ts`:
+
+```ts
+/**
+ * Database access for the tenancy tables, with the same degrade posture as
+ * rubric-store.ts: an environment whose migration has not run yet (P2021,
+ * missing table) behaves like the pre-tenancy system instead of erroring.
+ *
+ * Every function here is a thin query; the decisions (ordering, picking,
+ * transition legality) live in event-lifecycle.ts where they are pure and
+ * verified without a database.
+ */
+
+import { prisma } from "@/lib/prisma"
+import { DEFAULT_COHORT } from "./constants"
+import {
+  orderMemberEvents,
+  pickMemberEvent,
+  type EventStatusValue,
+} from "./event-lifecycle"
+
+export interface EventRecord {
+  id: string
+  organisationId: string
+  organisationName: string
+  cohort: string
+  name: string
+  status: EventStatusValue
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+  groundRules: string | null
+  createdAt: Date
+}
+
+export interface MemberEvent extends EventRecord {
+  participantId: string
+}
+
+/** True for Prisma's "table does not exist" — the migration hasn't run here. */
+function isMissingTable(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "P2021"
+  )
+}
+
+const EVENT_SELECT = {
+  id: true,
+  organisationId: true,
+  cohort: true,
+  name: true,
+  status: true,
+  titleLead: true,
+  titleAccent: true,
+  dates: true,
+  location: true,
+  formatNote: true,
+  groundRules: true,
+  createdAt: true,
+  organisation: { select: { name: true } },
+} as const
+
+type EventRow = {
+  id: string
+  organisationId: string
+  cohort: string
+  name: string
+  status: EventStatusValue
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+  groundRules: string | null
+  createdAt: Date
+  organisation: { name: string }
+}
+
+function toRecord(row: EventRow): EventRecord {
+  const { organisation, ...rest } = row
+  return { ...rest, organisationName: organisation.name }
+}
+
+/** The event owning a cohort slug, or null (unknown cohort OR pre-migration). */
+export async function getEventByCohort(cohort: string): Promise<EventRecord | null> {
+  try {
+    const row = await prisma.event.findUnique({ where: { cohort }, select: EVENT_SELECT })
+    return row ? toRecord(row as EventRow) : null
+  } catch (error) {
+    if (isMissingTable(error)) return null
+    throw error
+  }
+}
+
+/** Every event, newest first; [] pre-migration. */
+export async function listEvents(): Promise<EventRecord[]> {
+  try {
+    const rows = await prisma.event.findMany({
+      select: EVENT_SELECT,
+      orderBy: { createdAt: "desc" },
+    })
+    return (rows as EventRow[]).map(toRecord)
+  } catch (error) {
+    if (isMissingTable(error)) return []
+    throw error
+  }
+}
+
+/**
+ * The cohort admin surfaces default to when none is named: the newest
+ * non-archived event, preferring LIVE — so during an event every admin
+ * screen opens on the running event, and afterwards on the latest record.
+ * Falls back to DEFAULT_COHORT pre-migration or on an empty table.
+ */
+export async function defaultAdminCohort(): Promise<string> {
+  const events = await listEvents()
+  const candidates = events.filter((e) => e.status !== "ARCHIVED")
+  const live = candidates.find((e) => e.status === "LIVE")
+  return live?.cohort ?? candidates[0]?.cohort ?? DEFAULT_COHORT
+}
+
+/**
+ * The cohort an admin request operates on: the validated `?cohort=` input,
+ * or the admin default. This is the successor to `safeCohort` — same
+ * injection-safety contract, database-backed fallback.
+ */
+export async function resolveAdminCohort(
+  input: string | null | undefined
+): Promise<string> {
+  const { validCohort } = await import("./event-lifecycle")
+  return validCohort(input) ?? defaultAdminCohort()
+}
+
+/**
+ * Every visible event this email holds a participant row in, LIVE first
+ * then newest. Pre-migration, degrades to "member of DEFAULT_COHORT if a
+ * participant row exists there" so existing behaviour survives an
+ * un-migrated environment.
+ */
+export async function resolveMemberEvents(email: string): Promise<MemberEvent[]> {
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { email },
+    select: { id: true, cohort: true },
+  })
+  if (participants.length === 0) return []
+
+  const events = await listEvents()
+  if (events.length === 0) {
+    // Pre-migration degrade: behave like the old CURRENT_COHORT world.
+    const fallback = participants.find((p) => p.cohort === DEFAULT_COHORT)
+    return fallback
+      ? [
+          {
+            id: "",
+            organisationId: "",
+            organisationName: "Claude Community Kenya",
+            cohort: DEFAULT_COHORT,
+            name: DEFAULT_COHORT,
+            status: "CLOSED",
+            titleLead: "",
+            titleAccent: "",
+            dates: "",
+            location: "",
+            formatNote: "",
+            groundRules: null,
+            createdAt: new Date(0),
+            participantId: fallback.id,
+          },
+        ]
+      : []
+  }
+
+  const byCohort = new Map(events.map((e) => [e.cohort, e]))
+  const memberEvents: MemberEvent[] = []
+  for (const participant of participants) {
+    const event = byCohort.get(participant.cohort)
+    if (event) memberEvents.push({ ...event, participantId: participant.id })
+  }
+  return orderMemberEvents(memberEvents)
+}
+
+/** The single event a member request operates on — see pickMemberEvent. */
+export async function resolveMemberEvent(
+  email: string,
+  requested?: string | null
+): Promise<MemberEvent | null> {
+  return pickMemberEvent(await resolveMemberEvents(email), requested)
+}
+
+/** Whether anyone has ever been registered into this cohort. */
+export async function eventHasParticipants(cohort: string): Promise<boolean> {
+  const count = await prisma.impactLabParticipant.count({ where: { cohort } })
+  return count > 0
+}
+```
+
+Note: the dynamic `import("./event-lifecycle")` inside `resolveAdminCohort` is wrong style for this codebase — use a normal top-of-file import of `validCohort` instead. (Stated here so the implementer doesn't copy the sketch literally: **import `validCohort` statically alongside the other lifecycle imports.**)
+
+- [ ] **Step 2: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: clean. (No assertions run against this module — it is thin queries over logic already verified in Task 3; the P2021 degrade shape is copied from rubric-store which is proven in production.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/impact-lab/event-store.ts
+git commit -m "feat(impact-lab): event store with pre-migration degrade"
+```
+
+---
+
+### Task 5: Event access control
+
+**Files:**
+- Create: `src/lib/impact-lab/event-access.ts`
+- Modify: `scripts/verify-events.ts` (append a section)
+
+**Interfaces:**
+- Consumes: `getEventByCohort` (Task 4); `auth` from `@/auth`; `hasPermission`, type `UserRole` from `@/lib/rbac`; `prisma`.
+- Produces:
+
+```ts
+export function hasEventAccess(
+  role: UserRole | null,
+  isOrgMember: boolean,
+  action: "view" | "create" | "edit" | "delete" | "approve"
+): boolean
+export async function checkEventAccess(
+  cohort: string,
+  action: "view" | "create" | "edit" | "delete" | "approve"
+): Promise<
+  | { authorized: true; event: EventRecord | null; user: { id: string; email: string; role: UserRole } }
+  | { authorized: false; response: NextResponse }
+>
+```
+
+- [ ] **Step 1: Append failing assertions for the pure part**
+
+Append to `scripts/verify-events.ts` (and add `hasEventAccess` to its imports, from `../src/lib/impact-lab/event-access`):
+
+```ts
+// ── hasEventAccess ───────────────────────────────────────────────────────────
+check("platform SUPER_ADMIN passes any action", hasEventAccess("SUPER_ADMIN", false, "delete"))
+check("platform ADMIN passes impact-lab actions", hasEventAccess("ADMIN", false, "approve"))
+check("MODERATOR gets view only", hasEventAccess("MODERATOR", false, "view") && !hasEventAccess("MODERATOR", false, "edit"))
+check("plain MEMBER refused without org membership", !hasEventAccess("MEMBER", false, "view"))
+check("org member passes every action on own org's event", hasEventAccess("MEMBER", true, "view") &&
+  hasEventAccess("MEMBER", true, "edit") && hasEventAccess("MEMBER", true, "approve"))
+check("no session refused", !hasEventAccess(null, false, "view"))
+check("org membership beats missing platform role", hasEventAccess(null, true, "edit") === false)
+```
+
+That last assertion pins a real decision: **org membership without a signed-in session is impossible** (membership is looked up BY session), so `role === null` always refuses regardless of the flag.
+
+Run `npm run verify:events` — expected: FAIL, module does not exist.
+
+- [ ] **Step 2: Implement**
+
+Create `src/lib/impact-lab/event-access.ts`:
+
+```ts
+/**
+ * Event-scoped authorization: the two orthogonal layers from the tenancy
+ * design. The platform tier (site UserRole via rbac.ts) says what actions a
+ * staff role may take anywhere; the tenant tier (OrganisationMember) grants
+ * an organisation's people full run of their OWN events only.
+ *
+ * Impact Lab admin routes call checkEventAccess INSTEAD of a bare
+ * checkApiPermission — the platform check is embedded here.
+ */
+
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { prisma } from "@/lib/prisma"
+import { hasPermission, type UserRole } from "@/lib/rbac"
+import { getEventByCohort, type EventRecord } from "./event-store"
+
+export type EventAction = "view" | "create" | "edit" | "delete" | "approve"
+
+/**
+ * The pure decision: platform role with the impact-lab permission passes;
+ * otherwise membership of the event's organisation passes every action
+ * (OWNER and ORGANISER are equally trusted on their own event — the split
+ * matters only for managing the organisation itself, which is sub-project 6).
+ * No session (`role === null`) always refuses: membership is derived FROM
+ * the session, so a null role with isOrgMember=true is a caller bug.
+ */
+export function hasEventAccess(
+  role: UserRole | null,
+  isOrgMember: boolean,
+  action: EventAction
+): boolean {
+  if (role === null) return false
+  if (hasPermission(role, "impact-lab", action)) return true
+  return isOrgMember
+}
+
+/**
+ * Authorize the caller for an event and return the event row so routes never
+ * fetch it twice. `event` is null when the cohort has no Event row (unknown
+ * slug, or pre-migration environment) — platform staff still pass in that
+ * case so existing admin behaviour survives; org members cannot, because
+ * without a row there is no organisation to be a member of.
+ */
+export async function checkEventAccess(
+  cohort: string,
+  action: EventAction
+): Promise<
+  | { authorized: true; event: EventRecord | null; user: { id: string; email: string; role: UserRole } }
+  | { authorized: false; response: NextResponse }
+> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return {
+      authorized: false,
+      response: NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 }),
+    }
+  }
+  const role = ((session.user as { role?: string }).role ?? "MEMBER") as UserRole
+  const user = { id: session.user.id ?? "", email: session.user.email, role }
+
+  const event = await getEventByCohort(cohort)
+
+  let isOrgMember = false
+  if (event && user.id) {
+    try {
+      const membership = await prisma.organisationMember.findUnique({
+        where: {
+          organisationId_userId: { organisationId: event.organisationId, userId: user.id },
+        },
+        select: { id: true },
+      })
+      isOrgMember = membership !== null
+    } catch {
+      // Missing table pre-migration — platform tier still decides.
+      isOrgMember = false
+    }
+  }
+
+  if (!hasEventAccess(role, isOrgMember, action)) {
+    return {
+      authorized: false,
+      response: NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 }),
+    }
+  }
+  return { authorized: true, event, user }
+}
+```
+
+- [ ] **Step 3: Run to green and commit**
+
+```bash
+npm run verify:events
+npx tsc --noEmit
+git add src/lib/impact-lab/event-access.ts scripts/verify-events.ts
+git commit -m "feat(impact-lab): two-tier event access control"
+```
+
+---
+
+### Task 6: Admin events API (list, create, update)
+
+**Files:**
+- Create: `src/app/api/admin/impact-lab/events/route.ts`
+- Reference (read first): `src/app/api/admin/impact-lab/rubric/route.ts` for the house route shape (CSRF, rate limit, audit log if used there, error style).
+
+**Interfaces:**
+- Consumes: `checkApiPermission` (rbac), `listEvents`, `getEventByCohort`, `eventHasParticipants` (Task 4), `canTransition`, `validCohort`, `EVENT_STATUSES` (Task 3), `withCsrfProtection` from `@/lib/csrf`, `prisma`, Zod.
+- Produces HTTP contract for Task 7's UI:
+  - `GET` → `{ success: true, data: { events: SerializedEvent[], organisations: { id, slug, name }[] } }` where `SerializedEvent` = `EventRecord` with `createdAt` as ISO string.
+  - `POST` body `{ organisationId, cohort, name, titleLead, titleAccent, dates, location, formatNote, groundRules? }` → `{ success: true, data: { event } }` (created as DRAFT) | 400 with named error | 409 when the cohort slug exists.
+  - `PATCH` body `{ cohort, status? , name?, titleLead?, titleAccent?, dates?, location?, formatNote?, groundRules? }` → `{ success: true, data: { event } }` | 400 with the `canTransition` reason.
+
+- [ ] **Step 1: Implement the route**
+
+```ts
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { canTransition, validCohort, EVENT_STATUSES } from "@/lib/impact-lab/event-lifecycle"
+import {
+  eventHasParticipants,
+  getEventByCohort,
+  listEvents,
+  type EventRecord,
+} from "@/lib/impact-lab/event-store"
+import { checkEventAccess } from "@/lib/impact-lab/event-access"
+
+/**
+ * Event CRUD for the admin dashboard. Creating an event needs the platform
+ * impact-lab `create` permission (org members creating their own events is
+ * sub-project 6); editing and status changes go through checkEventAccess so
+ * an organisation's members can manage their own event via the API today.
+ */
+
+function serialize(event: EventRecord) {
+  return { ...event, createdAt: event.createdAt.toISOString() }
+}
+
+const brandingFields = {
+  name: z.string().trim().min(1).max(200),
+  titleLead: z.string().trim().min(1).max(100),
+  titleAccent: z.string().trim().min(1).max(100),
+  dates: z.string().trim().min(1).max(100),
+  location: z.string().trim().min(1).max(200),
+  formatNote: z.string().trim().min(1).max(2000),
+  groundRules: z.string().trim().max(20_000).optional(),
+}
+
+const createSchema = z.strictObject({
+  organisationId: z.string().min(1),
+  cohort: z.string(),
+  ...brandingFields,
+})
+
+const patchSchema = z.strictObject({
+  cohort: z.string(),
+  status: z.enum(EVENT_STATUSES).optional(),
+  ...Object.fromEntries(
+    Object.entries(brandingFields).map(([key, schema]) => [key, schema.optional()])
+  ),
+})
+
+export async function GET() {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+  const [events, organisations] = await Promise.all([
+    listEvents(),
+    prisma.organisation
+      .findMany({ select: { id: true, slug: true, name: true }, orderBy: { name: "asc" } })
+      .catch(() => []),
+  ])
+  return NextResponse.json({
+    success: true,
+    data: { events: events.map(serialize), organisations },
+  })
+}
+
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+  const check = await checkApiPermission("impact-lab", "create")
+  if (!check.authorized) return check.response
+
+  const parsed = createSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues[0]?.message ?? "Invalid event" },
+      { status: 400 }
+    )
+  }
+  const cohort = validCohort(parsed.data.cohort)
+  if (!cohort) {
+    return NextResponse.json(
+      { success: false, error: "Cohort slug must be lowercase letters, digits and hyphens." },
+      { status: 400 }
+    )
+  }
+  if (await getEventByCohort(cohort)) {
+    return NextResponse.json(
+      { success: false, error: `An event already owns the slug "${cohort}".` },
+      { status: 409 }
+    )
+  }
+  const { organisationId, cohort: _raw, groundRules, ...branding } = parsed.data
+  await prisma.event.create({
+    data: { organisationId, cohort, status: "DRAFT", groundRules: groundRules ?? null, ...branding },
+  })
+  const event = await getEventByCohort(cohort)
+  return NextResponse.json({ success: true, data: { event: event ? serialize(event) : null } })
+}
+
+export async function PATCH(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const parsed = patchSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues[0]?.message ?? "Invalid update" },
+      { status: 400 }
+    )
+  }
+  const cohort = validCohort(parsed.data.cohort)
+  if (!cohort) {
+    return NextResponse.json({ success: false, error: "Unknown event." }, { status: 400 })
+  }
+
+  const access = await checkEventAccess(cohort, "edit")
+  if (!access.authorized) return access.response
+  if (!access.event) {
+    return NextResponse.json({ success: false, error: "Unknown event." }, { status: 404 })
+  }
+
+  const { cohort: _cohort, status, ...brandingUpdates } = parsed.data
+  if (status && status !== access.event.status) {
+    const verdict = canTransition(access.event.status, status, await eventHasParticipants(cohort))
+    if (!verdict.ok) {
+      return NextResponse.json({ success: false, error: verdict.reason }, { status: 400 })
+    }
+  }
+
+  await prisma.event.update({
+    where: { cohort },
+    data: {
+      ...(status ? { status } : {}),
+      ...Object.fromEntries(Object.entries(brandingUpdates).filter(([, v]) => v !== undefined)),
+    },
+  })
+  const event = await getEventByCohort(cohort)
+  return NextResponse.json({ success: true, data: { event: event ? serialize(event) : null } })
+}
+```
+
+Adapt to the house shape found in the rubric route reference read: if it rate-limits admin writes or writes an audit-log entry (`@/lib/audit-log`), do the same here — status changes and event creation are exactly the class of action the audit log exists for. Match its call signature precisely.
+
+- [ ] **Step 2: Gate and commit**
+
+```bash
+npx tsc --noEmit
+npm run build
+git add src/app/api/admin/impact-lab/events/route.ts
+git commit -m "feat(impact-lab): admin events API with lifecycle-guarded status changes"
+```
+
+---
+
+### Task 7: Admin UI — Events tab and selector rewire
+
+**Files:**
+- Create: `src/components/admin/impact-lab/EventsTab.tsx`
+- Modify: `src/components/admin/impact-lab/ImpactLabDashboard.tsx` (add the tab where the existing tabs are registered)
+- Modify: `src/app/api/admin/impact-lab/cohorts/route.ts` (seed from the Event table; derive `isActive` from status)
+- Reference (read first): `src/components/admin/impact-lab/CohortSelector.tsx` and its `useCohorts.ts` hook, and the existing tab pattern inside `ImpactLabDashboard.tsx` (e.g. the RubricTab added in the rubric-builder work) — copy the visual idiom, not invent one.
+
+**Interfaces:**
+- Consumes: Task 6's HTTP contract; existing `csrfHeaders` from `@/lib/csrf-client`.
+- Produces: an "Events" tab an admin uses to (a) see all events with org + status, (b) create an event (DRAFT), (c) move an event through DRAFT→LIVE→CLOSED→ARCHIVED with the server's refusal reasons surfaced verbatim.
+
+- [ ] **Step 1: Rewire the cohorts route**
+
+In `src/app/api/admin/impact-lab/cohorts/route.ts`:
+
+1. Replace `import { CURRENT_COHORT } from "@/lib/impact-lab/constants"` with `import { listEvents, defaultAdminCohort } from "@/lib/impact-lab/event-store"`.
+2. At the top of `GET`, add `const [events, activeCohort] = await Promise.all([listEvents(), defaultAdminCohort()])` (fold into the existing `Promise.all`).
+3. Replace the seed line `summaryFor(CURRENT_COHORT)` with a loop that seeds every non-archived event and enriches the summary:
+
+```ts
+  for (const event of events) {
+    if (event.status === "ARCHIVED") continue
+    const summary = summaryFor(event.cohort)
+    summary.eventName = event.name
+    summary.status = event.status
+  }
+```
+
+4. Extend `CohortSummary` with `eventName: string | null` and `status: string | null` (initialise both to `null` in `summaryFor`), and change the `isActive` initialisation from `cohort === CURRENT_COHORT` to `cohort === activeCohort`.
+5. Update the `isActive` doc comment: the fallback cohort is now the newest non-archived event (LIVE preferred), not the env var.
+
+- [ ] **Step 2: Build the Events tab**
+
+Create `src/components/admin/impact-lab/EventsTab.tsx` as a `"use client"` component following the dashboard's existing tab idiom (Terminal Noir tokens, `font-mono`, the same card/border classes as the tab you read in the reference step). Structure — all data via `GET /api/admin/impact-lab/events`, mutations via `POST`/`PATCH` with `await csrfHeaders()`:
+
+- A table of events: name, organisation name, cohort slug, status chip (color by status: `--green-primary` LIVE, `--text-dim` DRAFT, `--amber` CLOSED, `--red` ARCHIVED), created date.
+- Per row, buttons for exactly the transitions `canTransition` allows from the current status — mirror the graph client-side for which buttons to SHOW (`DRAFT: [Launch]`, `LIVE: [Close, Back to draft]`, `CLOSED: [Reopen, Archive]`, `ARCHIVED: [Unarchive]`), but the server remains the authority: render any PATCH error message verbatim next to the row (`role="alert"`).
+- A "New event" form: organisation `<select>` (from the GET payload), and text inputs for cohort slug, name, titleLead, titleAccent, dates, location, formatNote (textarea), groundRules (textarea, optional). Client-side slug hint: lowercase letters/digits/hyphens. On success, refresh the list and clear the form.
+- Loading and error states per the existing tab idiom (spinner line + `role="alert"` retry block, as in `SubmitProject.tsx`).
+
+Then register the tab in `ImpactLabDashboard.tsx` exactly the way the rubric tab is registered (same tab-list entry shape, same conditional render).
+
+- [ ] **Step 3: Gate and commit**
+
+```bash
+npx tsc --noEmit
+npm run build
+git add src/components/admin/impact-lab/EventsTab.tsx src/components/admin/impact-lab/ImpactLabDashboard.tsx src/app/api/admin/impact-lab/cohorts/route.ts
+git commit -m "feat(impact-lab): events admin tab with lifecycle controls"
+```
+
+---
+
+### Task 8: DB-backed closed-cohort guard
+
+**Files:**
+- Modify: `src/lib/impact-lab/cohort-guard.ts`
+- Modify (every caller of `guardClosedCohort` — find them with `grep -rn "guardClosedCohort" src/`; the known set): `src/app/api/impact-lab/submission/route.ts`, `src/app/api/impact-lab/team/roster/route.ts`, `src/app/api/impact-lab/team/leader/route.ts`, `src/app/api/impact-lab/team/route.ts`, `src/app/api/impact-lab/check-in/route.ts`, `src/app/api/impact-lab/profile/route.ts` — trust the grep over this list.
+
+**Interfaces:**
+- Consumes: `getEventByCohort` (Task 4), `isCohortActive` (constants — still present until Task 12).
+- Produces: `export async function guardClosedCohort(cohort: string): Promise<NextResponse | null>` — same name, now async and status-backed.
+
+- [ ] **Step 1: Rework the guard**
+
+Replace the body of `src/lib/impact-lab/cohort-guard.ts`:
+
+```ts
+import { NextResponse } from "next/server"
+import { isCohortActive } from "./constants"
+import { getEventByCohort } from "./event-store"
+
+/**
+ * Refuse member-facing writes unless the cohort's event is LIVE.
+ *
+ * The dashboard already hides these affordances, but hiding a button is a
+ * presentation choice, not a guarantee — the endpoints stay reachable to
+ * anything holding a session cookie. After an event the participant set,
+ * rosters, check-ins and submissions are the historical record of what
+ * happened, and a late write silently rewrites that record.
+ *
+ * Status comes from the Event row. Pre-migration (no row anywhere) the old
+ * env-var behaviour still answers, so an un-migrated environment keeps
+ * working exactly as before.
+ *
+ * Reads are deliberately untouched: people should still be able to see their
+ * team and what they built.
+ */
+export async function guardClosedCohort(cohort: string): Promise<NextResponse | null> {
+  const event = await getEventByCohort(cohort)
+  const open = event ? event.status === "LIVE" : isCohortActive(cohort)
+  if (open) return null
+  return NextResponse.json(
+    {
+      success: false,
+      error:
+        "This event has closed. Your team and submission are kept as a record and can no longer be changed.",
+    },
+    { status: 403 },
+  )
+}
+```
+
+- [ ] **Step 2: Await every call site**
+
+In each caller, change `const closed = guardClosedCohort(...)` to `const closed = await guardClosedCohort(...)`. tsc enforces completeness: an un-awaited call now assigns a `Promise` and the `if (closed) return closed` misuse fails the `NextResponse | null` narrowing — run `npx tsc --noEmit` and fix every error it names.
+
+- [ ] **Step 3: Gate and commit**
+
+```bash
+npx tsc --noEmit
+git add src/lib/impact-lab/cohort-guard.ts src/app/api/impact-lab
+git commit -m "feat(impact-lab): closed-cohort guard reads event status from the database"
+```
+
+---
+
+### Task 9: Member surfaces resolve by membership
+
+**Files (the member sweep — every file here imports `CURRENT_COHORT` or `CURRENT_COHORT_LABEL` today):**
+- Modify: `src/app/api/impact-lab/submission/route.ts`
+- Modify: `src/app/api/impact-lab/team/route.ts`
+- Modify: `src/app/api/impact-lab/team/search/route.ts`
+- Modify: `src/app/api/impact-lab/team/roster/route.ts`
+- Modify: `src/app/api/impact-lab/team/leader/route.ts`
+- Modify: `src/app/api/impact-lab/results/route.ts`
+- Modify: `src/app/api/impact-lab/profile/route.ts`
+- Modify: `src/app/api/impact-lab/check-in/route.ts`
+- Modify: `src/app/dashboard/page.tsx`
+- Modify: `src/app/dashboard/impact-lab/page.tsx`
+
+**Interfaces:**
+- Consumes: `resolveMemberEvent`, `resolveMemberEvents` (Task 4), `validCohort` (Task 3), existing `checkMemberAccess` from `./member` (unchanged — it authenticates; event resolution is a separate step after it).
+- Produces: every member route operates on `memberEvent.cohort` instead of `CURRENT_COHORT`; GET responses gain `eventName: string` and `eventCohort: string` so the dashboard can display which event it is showing.
+
+**The transformation rule, applied per file.** Each member route today has the shape:
+
+```ts
+const check = await checkMemberAccess()
+if (!check.authorized) return check.response
+// ...queries keyed by { cohort: CURRENT_COHORT, ... }
+```
+
+It becomes:
+
+```ts
+const check = await checkMemberAccess()
+if (!check.authorized) return check.response
+const memberEvent = await resolveMemberEvent(
+  check.email,
+  validCohort(new URL(request.url).searchParams.get("cohort"))
+)
+if (!memberEvent) {
+  // exactly the route's existing "not a participant / no team" response
+}
+// ...queries keyed by { cohort: memberEvent.cohort, ... }
+```
+
+Notes that make this mechanical rather than judgment:
+1. Routes whose handler signature lacks `request` gain it (`export async function GET(request: NextRequest)`); POST/PUT handlers read the optional cohort from the query string too (not the body — bodies are already Zod-strict and must not gain a field).
+2. `resolveMemberEvent` already returns the caller's `participantId` — routes that currently look up the participant row by `cohort_email` (e.g. `resolveContext` in the submission route) use `memberEvent.participantId` and `memberEvent.cohort` and DELETE their own participant lookup. In the submission route, `resolveContext(email)` becomes `resolveContext(memberEvent)` keeping its run/team logic.
+3. Where a route treats "no participant row" as a distinct state (e.g. profile returning a self-registration prompt), `resolveMemberEvent === null` maps to that same state.
+4. The profile/self-registration surface used `CURRENT_COHORT_LABEL` to name the live event. It now uses `memberEvent.name` — and for the not-yet-registered case (no membership anywhere), it names the newest LIVE event: add and use `export async function openRegistrationEvent(): Promise<EventRecord | null>` in `event-store.ts` returning the newest LIVE event or null, and show the registration invitation ONLY when it is non-null (this reproduces today's "no event live → read-only, no invitation" behaviour, which was the point of the env var being unset).
+5. `src/app/dashboard/impact-lab/page.tsx` (server component): fetch `resolveMemberEvents(session.email)`; when >1, render a plain event switcher — a row of `<Link href="?cohort=<slug>">` chips above the existing content, current one highlighted — and pass the picked event's `cohort` down to the client components, which append it as `?cohort=` on their API calls. When 0 or 1, render exactly as today (no switcher).
+6. Worked example — the submission route GET, fully transformed:
+
+```ts
+export async function GET(request: NextRequest) {
+  const check = await checkMemberAccess()
+  if (!check.authorized) return check.response
+
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
+    return NextResponse.json({ success: true, status: "no_team" })
+  }
+
+  const context = await resolveContext(memberEvent)
+  if (!context) {
+    return NextResponse.json({ success: true, status: "no_team", eventName: memberEvent.name })
+  }
+
+  const existing = await prisma.impactLabSubmission.findUnique({
+    where: { runId_teamId: { runId: context.runId, teamId: context.teamId } },
+  })
+
+  return NextResponse.json({
+    success: true,
+    status: submissionWindow(context.closeAt, new Date()),
+    teamName: context.teamName,
+    eventName: memberEvent.name,
+    eventCohort: memberEvent.cohort,
+    closeAt: context.closeAt ? context.closeAt.toISOString() : null,
+    submission: existing ? await toView(existing) : undefined,
+  })
+}
+```
+
+with `resolveContext` reduced to:
+
+```ts
+async function resolveContext(memberEvent: MemberEvent): Promise<ResolvedContext | null> {
+  const run = await prisma.impactLabMatchRun.findFirst({
+    where: { cohort: memberEvent.cohort, isFinal: true },
+    orderBy: { createdAt: "desc" },
+    select: { id: true, result: true, submissionsCloseAt: true },
+  })
+  if (!run) return null
+  const teams = extractFrozenTeams(run.result)
+  if (!teams) return null
+  const teamRef = findTeamFor(teams, memberEvent.participantId)
+  if (!teamRef) return null
+  return {
+    participantId: memberEvent.participantId,
+    runId: run.id,
+    teamId: teamRef.teamId,
+    teamName: teamRef.teamName,
+    closeAt: run.submissionsCloseAt,
+  }
+}
+```
+
+(`lastEditedName` in the same file keeps a cohort-scoped lookup — pass it `memberEvent.cohort` as a parameter instead of reading `CURRENT_COHORT`.)
+
+- [ ] **Step 1:** Transform the eight API routes per the rule above, running `npx tsc --noEmit` after each file.
+- [ ] **Step 2:** Transform the two dashboard pages (note 5), plus whichever client components under `src/app/dashboard/impact-lab/` need the `cohort` prop threaded (tsc + grep for their fetch calls will name them).
+- [ ] **Step 3:** Gate: `npx tsc --noEmit` and `npm run build` clean; `grep -rn "CURRENT_COHORT" src/app/api/impact-lab src/app/dashboard` returns ONLY the pitch-timer route (Task 10's).
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/api/impact-lab src/app/dashboard src/lib/impact-lab/event-store.ts
+git commit -m "feat(impact-lab): member surfaces resolve their event by membership"
+```
+
+---
+
+### Task 10: Admin and judge surfaces stop reading the env default
+
+**Files (the admin sweep — from `grep -rln "CURRENT_COHORT\|safeCohort\|COHORT_LABEL" src/`):**
+- Modify: all 21 routes under `src/app/api/admin/impact-lab/` still importing from `constants` (judging + its 5 subroutes, results + its 4 subroutes, participants + its 2 subroutes, submissions + export, reviews, rematch, runs, notify, explain, match, rubric)
+- Modify: `src/app/api/impact-lab/judge-events/route.ts`
+- Modify: `src/app/api/impact-lab/pitch-timer/route.ts`
+- Modify: `src/app/admin/impact-lab/page.tsx`, `src/app/admin/impact-lab/judge/page.tsx`, `src/app/admin/impact-lab/judge/JudgeDashboard.tsx`, `src/components/admin/impact-lab/ImpactLabDashboard.tsx` (whatever the grep shows in each — mostly labels and default props)
+- Modify: `src/app/judge/PitchTimer.tsx` and its parent judge screen (thread the cohort prop)
+
+**Interfaces:**
+- Consumes: `resolveAdminCohort` (Task 4), `validCohort` (Task 3), `defaultAdminCohort` (Task 4).
+- Produces: no route or page under admin/judge reads `CURRENT_COHORT`, `CURRENT_COHORT_LABEL`, or `safeCohort`.
+
+**Transformation rules:**
+
+1. **Admin API routes.** Every occurrence of `const cohort = safeCohort(<expr>)` becomes `const cohort = await resolveAdminCohort(<expr>)`, with the import swapped from `constants` to `event-store`. The `<expr>` (query param read) is unchanged. Handlers already async — no signature changes. Where a route used `CURRENT_COHORT` directly with no param read, it becomes `await defaultAdminCohort()`.
+2. **Judge events route.** Replace the `CURRENT_COHORT`-first ordering (lines 111–114) with LIVE-events-first: fetch `const events = await listEvents()` once, build `const liveCohorts = new Set(events.filter(e => e.status === "LIVE").map(e => e.cohort))`, then partition on `liveCohorts.has(e.cohort)`. Additionally, when `events.length > 0`, drop runs whose cohort's event is missing or is `DRAFT`/`ARCHIVED` from the open list (visibility per the spec); when `events.length === 0` (pre-migration), keep today's behaviour untouched.
+3. **Pitch timer.** The route's cohort comes from the judge's picked event, not a global: accept `?cohort=` (GET) / body `cohort` (POST), validated with `validCohort`, falling back to `await defaultAdminCohort()`. In the judge screen, pass the picked event's cohort into `<PitchTimer cohort={...} />` and append it to both fetches inside `PitchTimer.tsx`.
+4. **Admin pages/components.** Where `CURRENT_COHORT` seeds an initial selector value in a server component, use `await defaultAdminCohort()`. Where `CURRENT_COHORT_LABEL` renders a heading, use the event's `name` from the cohorts payload (Task 7 added `eventName` to it) with the slug as fallback.
+
+- [ ] **Step 1:** Sweep the 21 admin routes (rule 1), `npx tsc --noEmit` after each few files.
+- [ ] **Step 2:** Judge events ordering + visibility (rule 2).
+- [ ] **Step 3:** Pitch timer cohort threading (rule 3).
+- [ ] **Step 4:** Admin pages and components (rule 4).
+- [ ] **Step 5:** Gate: `npx tsc --noEmit`, `npm run build`, and `grep -rn "CURRENT_COHORT\|safeCohort" src/ --include="*.ts" --include="*.tsx" | grep -v "lib/impact-lab/constants"` returns nothing.
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app src/components
+git commit -m "feat(impact-lab): admin and judge surfaces resolve events from the database"
+```
+
+---
+
+### Task 11: Branding becomes DB-backed  *(requires PR #107 merged)*
+
+**Files:**
+- Modify: `src/lib/impact-lab/event-branding.ts`
+- Modify: the three export call sites of `brandingForCohort` (on the post-#107 main: `src/lib/impact-lab/export-data.ts`, `src/lib/impact-lab/export-pdf.ts`, `src/lib/impact-lab/export-excel.ts` — confirm with `grep -rn "brandingForCohort" src/`)
+
+**Interfaces:**
+- Consumes: `getEventByCohort` (Task 4).
+- Produces: `export async function brandingForCohort(cohort: string): Promise<EventBranding>` — same name and semantics, now async; the `EventBranding` interface, `IMPACT_LAB_BRANDING`, `AFRETEC_BRANDING`, and `REPORT_PRODUCER` exports are unchanged.
+
+- [ ] **Step 1: Make the resolver DB-backed**
+
+In `event-branding.ts`, replace the `BRANDING_BY_COHORT` lookup at the bottom (the constants above it stay exactly as they are — they are now the fallback layer, the evolution the module's own doc comment anticipates):
+
+```ts
+import { getEventByCohort } from "./event-store"
+
+/** Code-constant fallbacks for the two events that predate the Event table. */
+const BRANDING_BY_COHORT: Readonly<Record<string, EventBranding>> = {
+  "afretec-makerthon-2026-08": AFRETEC_BRANDING,
+}
+
+/**
+ * The branding a cohort's exports print, from the Event row when one exists.
+ *
+ * Never throws on an unknown cohort — an organiser generating a report mid
+ * event must not hit an error page because a slug was typed differently
+ * somewhere. Resolution order: Event row → per-cohort code constant →
+ * Impact Lab default.
+ */
+export async function brandingForCohort(cohort: string): Promise<EventBranding> {
+  const event = await getEventByCohort(cohort)
+  if (event) {
+    return {
+      titleLead: event.titleLead,
+      titleAccent: event.titleAccent,
+      title: event.name,
+      dates: event.dates,
+      host: event.organisationName,
+      location: event.location,
+      formatNote: event.formatNote,
+      ...(event.organisationName !== REPORT_PRODUCER
+        ? { platformNote: `Run on the Impact Lab platform by ${REPORT_PRODUCER}` }
+        : {}),
+    }
+  }
+  return BRANDING_BY_COHORT[cohort] ?? IMPACT_LAB_BRANDING
+}
+```
+
+(`REPORT_PRODUCER` is declared above in this module — move its declaration above this function if it currently sits below.)
+
+- [ ] **Step 2: Await the call sites**
+
+`grep -rn "brandingForCohort" src/` — at each call site, add `await` (all three exporters are already async server-side code paths; tsc names any that aren't).
+
+- [ ] **Step 3: Gate and commit**
+
+```bash
+npx tsc --noEmit
+npm run build
+git add src/lib/impact-lab
+git commit -m "feat(impact-lab): export branding resolves from the Event row"
+```
+
+---
+
+### Task 12: Retire the env-var constants
+
+**Files:**
+- Modify: `src/lib/impact-lab/constants.ts` (shrink to `DEFAULT_COHORT` only)
+- Modify: `src/lib/impact-lab/cohort-guard.ts` (drop the `isCohortActive` fallback import — replace `isCohortActive(cohort)` with `false`; pre-migration environments are gone once this ships together with the migration)
+- Modify: `docs/impact-lab/16-running-another-event.md` (the runbook)
+- Modify: whatever else `npx tsc --noEmit` names.
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `constants.ts` exports exactly one symbol, `DEFAULT_COHORT` (still the event-store fallback for pre-migration degrade). `ACTIVE_COHORT`, `CURRENT_COHORT`, `CURRENT_COHORT_LABEL`, `isCohortActive`, `safeCohort` no longer exist — any surviving consumer is a compile error, which is the point.
+
+- [ ] **Step 1: Shrink constants.ts**
+
+Replace the whole file with:
+
+```ts
+/**
+ * The pre-tenancy fallback cohort. Every "which event?" question is now
+ * answered from the Event table (src/lib/impact-lab/event-store.ts); this
+ * slug remains only as the degrade target for an environment whose tenancy
+ * migration has not run yet.
+ */
+export const DEFAULT_COHORT = "impact-lab-2026-07"
+```
+
+- [ ] **Step 2: Fix what the compiler names**
+
+```bash
+npx tsc --noEmit
+```
+
+Every error is an unconverted consumer of the deleted symbols. Convert each with the matching rule from Tasks 8–10 (member surface → `resolveMemberEvent`; admin surface → `resolveAdminCohort`/`defaultAdminCohort`; guard fallback → `false` per the file list above). Do NOT re-add any deleted export to silence an error.
+
+- [ ] **Step 3: Update the runbook**
+
+In `docs/impact-lab/16-running-another-event.md`, replace the `IMPACT_LAB_ACTIVE_COHORT`/`IMPACT_LAB_COHORT_LABEL`/redeploy instructions with the dashboard flow: Admin → Impact Lab → Events tab → create event (DRAFT) → Launch when ready → Close after → Archive later. State explicitly that several events can be LIVE at once and that closing one event no longer takes anything else offline.
+
+- [ ] **Step 4: Full gate**
+
+```bash
+npm run verify:events
+npm run verify:judging
+npx tsc --noEmit
+npm run build
+grep -rn "IMPACT_LAB_ACTIVE_COHORT\|IMPACT_LAB_COHORT_LABEL\|CURRENT_COHORT\|safeCohort\|isCohortActive" src/
+```
+
+Expected: both verify scripts pass, tsc and build clean, grep returns nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src docs
+git commit -m "feat(impact-lab)!: retire IMPACT_LAB_ACTIVE_COHORT — events live in the database"
+```
+
+(The `!` is deliberate: deploying this without the migration + seed breaks event resolution — see the deploy checklist.)
+
+---
+
+## Deploy checklist (hand-off — NOT part of plan execution)
+
+Executed by the driver session with the user, after the PR is reviewed and merged. In order, because step 4 depends on 1–3:
+
+1. **Migrate production** over the SSH tunnel to the DB VPS (direct port 5433, never PgBouncer 6432), per the established runbook: `npx prisma migrate deploy` with the tunnel URL.
+2. **Seed production**: `npm run seed:events` (dry-run, inspect) then `-- --apply`, same tunnel.
+3. **Merge deploys** the code via Vercel auto-deploy from main.
+4. **Remove the env vars** in Vercel: `IMPACT_LAB_ACTIVE_COHORT`, `IMPACT_LAB_COHORT_LABEL` (they are dead code after Task 12; removing them avoids a false belief they still do something). Redeploy is triggered by the merge anyway.
+5. **Smoke-check**: admin Events tab lists both backfilled events as CLOSED; the July and August dashboards still render read-only; report export still prints Afretec branding for the August cohort.
+
+## Self-review record
+
+- **Spec coverage:** models/backfill → Tasks 1–2; lifecycle + no-redeploy status → Tasks 3, 6, 7; membership resolution incl. multi-event picker → Task 9; judge filter + admin default → Task 10; `checkEventAccess` two-tier auth → Tasks 5–6; DB-backed `guardClosedCohort` → Task 8; async DB-backed `brandingForCohort` → Task 11; `CURRENT_COHORT` deletion + runbook → Task 12; verify script → Tasks 3, 5, 12. P2021 degrade → Tasks 4, 5, 8, 11 (via store).
+- **Known deviations from spec, both narrowings not omissions:** the spec's "org members manage via existing admin panel" is API-level only (page-level RBAC unchanged — spec §6 says CCK staff operate the UI until sub-project 6). `resolveMemberEvents`' pre-migration degrade returns a stub record for `DEFAULT_COHORT` membership so un-migrated environments behave exactly as today.
+- **Type consistency:** `EventStatusValue`/`EventRecord`/`MemberEvent`/`EventAction` names and shapes checked across Tasks 3–11; `guardClosedCohort` async signature consistent between Tasks 8 and 12.

--- a/docs/superpowers/plans/2026-08-08-event-platform-tenancy.md
+++ b/docs/superpowers/plans/2026-08-08-event-platform-tenancy.md
@@ -19,6 +19,7 @@
 - **Do not delete or modify existing migration folders.** New migration folders only.
 - If `npx tsc --noEmit` shows dozens of "property does not exist on PrismaClient" errors, run `npx prisma generate` first — stale client, not real errors (known issue).
 - Existing production data is untouchable: no schema change to the nine existing Impact Lab tables, no data rewrites.
+- **Naming: the tenancy event model is `ImpactLabEvent`** (Prisma enum `ImpactLabEventStatus`, client accessor `prisma.impactLabEvent`) — the schema already has an unrelated community-meetup `Event` model and `EventStatus` enum, which must never be touched. Table names (`impact_lab_events`) and columns are unaffected by this naming.
 - JSDoc on every exported function: what, why, params, returns.
 
 ---
@@ -31,7 +32,7 @@
 
 **Interfaces:**
 - Consumes: nothing (first task).
-- Produces: Prisma models `Organisation`, `OrganisationMember`, `Event`; enums `OrgRole { OWNER ORGANISER }`, `EventStatus { DRAFT LIVE CLOSED ARCHIVED }`; `User.organisationMemberships` relation. Later tasks query `prisma.event`, `prisma.organisation`, `prisma.organisationMember`.
+- Produces: Prisma models `Organisation`, `OrganisationMember`, `ImpactLabEvent`; enums `OrgRole { OWNER ORGANISER }`, `ImpactLabEventStatus { DRAFT LIVE CLOSED ARCHIVED }`; `User.organisationMemberships` relation. Later tasks query `prisma.impactLabEvent`, `prisma.organisation`, `prisma.organisationMember`.
 
 - [ ] **Step 1: Add enums**
 
@@ -49,7 +50,9 @@ enum OrgRole {
 // Event lifecycle. Judging/submission windows are NOT statuses — they stay
 // as fine-grained flags on the match run (judgingOpen, submissionsCloseAt),
 // because Afretec needed judging and submissions open concurrently.
-enum EventStatus {
+// "ImpactLab" prefix because the schema already has an unrelated
+// community-meetup EventStatus enum.
+enum ImpactLabEventStatus {
   DRAFT // being set up; invisible to participants and judges
   LIVE // participants form teams and submit; judges score
   CLOSED // read-only for participants; reports and exports available
@@ -86,7 +89,7 @@ model Organisation {
   updatedAt    DateTime @updatedAt
 
   members OrganisationMember[]
-  events  Event[]
+  events  ImpactLabEvent[]
 
   @@map("organisations")
 }
@@ -105,14 +108,14 @@ model OrganisationMember {
   @@map("organisation_members")
 }
 
-model Event {
+model ImpactLabEvent {
   id             String      @id @default(cuid())
   organisationId String
   /// Authoritative registry entry for the cohort slug used across the nine
   /// Impact Lab tables. Unique: one Event per cohort, ever.
   cohort         String      @unique
   name           String
-  status         EventStatus @default(DRAFT)
+  status         ImpactLabEventStatus @default(DRAFT)
 
   // Branding — replaces the code constants in event-branding.ts (Task 11).
   titleLead   String
@@ -157,7 +160,7 @@ npx prisma generate
 npx tsc --noEmit
 ```
 
-Expected: clean. (`prisma.event` etc. now exist on the client.)
+Expected: clean. (`prisma.impactLabEvent` etc. now exist on the client.)
 
 - [ ] **Step 6: Commit**
 
@@ -273,10 +276,10 @@ async function main(): Promise<void> {
       continue
     }
     const { orgSlug: _orgSlug, ...data } = event
-    const existing = await prisma.event.findUnique({ where: { cohort: event.cohort } })
+    const existing = await prisma.impactLabEvent.findUnique({ where: { cohort: event.cohort } })
     console.log(`event ${event.cohort}: ${existing ? "exists" : "will create"}`)
     if (APPLY) {
-      await prisma.event.upsert({
+      await prisma.impactLabEvent.upsert({
         where: { cohort: event.cohort },
         // Backfill never overwrites a status an admin may have changed since.
         create: { ...data, organisationId: org.id },
@@ -722,7 +725,7 @@ function toRecord(row: EventRow): EventRecord {
 /** The event owning a cohort slug, or null (unknown cohort OR pre-migration). */
 export async function getEventByCohort(cohort: string): Promise<EventRecord | null> {
   try {
-    const row = await prisma.event.findUnique({ where: { cohort }, select: EVENT_SELECT })
+    const row = await prisma.impactLabEvent.findUnique({ where: { cohort }, select: EVENT_SELECT })
     return row ? toRecord(row as EventRow) : null
   } catch (error) {
     if (isMissingTable(error)) return null
@@ -733,7 +736,7 @@ export async function getEventByCohort(cohort: string): Promise<EventRecord | nu
 /** Every event, newest first; [] pre-migration. */
 export async function listEvents(): Promise<EventRecord[]> {
   try {
-    const rows = await prisma.event.findMany({
+    const rows = await prisma.impactLabEvent.findMany({
       select: EVENT_SELECT,
       orderBy: { createdAt: "desc" },
     })
@@ -1107,7 +1110,7 @@ export async function POST(request: NextRequest) {
     )
   }
   const { organisationId, cohort: _raw, groundRules, ...branding } = parsed.data
-  await prisma.event.create({
+  await prisma.impactLabEvent.create({
     data: { organisationId, cohort, status: "DRAFT", groundRules: groundRules ?? null, ...branding },
   })
   const event = await getEventByCohort(cohort)
@@ -1144,7 +1147,7 @@ export async function PATCH(request: NextRequest) {
     }
   }
 
-  await prisma.event.update({
+  await prisma.impactLabEvent.update({
     where: { cohort },
     data: {
       ...(status ? { status } : {}),

--- a/docs/superpowers/plans/2026-08-08-event-platform-tenancy.md
+++ b/docs/superpowers/plans/2026-08-08-event-platform-tenancy.md
@@ -197,7 +197,10 @@ Follow the house pattern from `scripts/seed-hackathon-cohort.ts`: dry-run by def
  */
 import { PrismaClient } from "../src/generated/prisma/client"
 
-const prisma = new PrismaClient()
+// Prisma 7 driver adapter — copy the exact construction idiom from
+// prisma/seed.ts (PrismaPg adapter over DATABASE_URL); bare `new
+// PrismaClient()` does not work in this repo.
+const prisma = new PrismaClient(/* house adapter idiom */)
 const APPLY = process.argv.includes("--apply")
 
 interface OrgSeed {

--- a/docs/superpowers/specs/2026-08-08-event-platform-tenancy-design.md
+++ b/docs/superpowers/specs/2026-08-08-event-platform-tenancy-design.md
@@ -1,0 +1,275 @@
+# Multi-tenant event platform — design
+
+**Date:** 2026-08-08
+**Status:** Approved (approach C: full multi-tenancy now)
+**Scope of this spec:** the overall architecture, and detailed requirements for
+**sub-project 1: tenancy core**. Sub-projects 2–6 are summarised for context and
+get their own specs.
+
+## Why
+
+The Impact Lab platform just ran its second event — the Afretec Makerthon
+(8 August 2026, hosted by C4DLab, University of Nairobi) — on machinery built
+for its first. It worked, but every event-specific fact had to be found and
+generalised mid-event: the rubric, the judge event picker, the admin cohort
+selector, the submission field rules, the report branding. The post-mortem
+found structural gaps no amount of per-event patching fixes:
+
+- **45% of teams were never judged** because submission was a de facto judging
+  gate nobody announced — the platform had no way to state or enforce an
+  event's own ground rules.
+- **Switching events requires editing an env var and redeploying**
+  (`IMPACT_LAB_ACTIVE_COHORT`), and doing so takes the previous event offline.
+  Two events cannot be live at once.
+- **Event configuration lives in code constants** (`judging-rubrics.ts`,
+  `event-branding.ts`), so a new event means a developer, a PR, and a deploy.
+- **Feedback coverage was 7 of 33 scorecards** — organisers had no tooling to
+  turn scores into feedback teams actually receive.
+
+The destination, per the founder's decision, is **a product other organisers
+use**: any organisation runs its own hackathon on the platform, with CCK as
+the platform operator. The late-August deadline needs only CCK self-serving
+its own event through the admin UI — but the data and authorization model is
+built multi-tenant from day one so that opening up to external organisers is
+additive, not a rewrite.
+
+## Goals
+
+1. An `Event` is a database row an admin creates, configures, and takes
+   through its lifecycle from the dashboard — no env vars, no deploys.
+2. Every event belongs to an `Organisation`. Authorization is scoped: an
+   organisation's members manage only their own events; platform admins (CCK
+   staff) manage all.
+3. Multiple events can be live simultaneously.
+4. Existing production data (two cohorts, nine tables) is untouched — the
+   migration is purely additive.
+
+## Non-goals (for sub-project 1)
+
+- Per-event config editing UI (tracks, submission fields, rubric wiring,
+  judge codes) — **sub-project 2**.
+- Event-creation wizard and the Claude setup advisor — **sub-project 3**.
+- Participant comms / non-submitter chasing — **sub-project 4**.
+- Claude-drafted team feedback and report narrative — **sub-project 5**.
+- A standalone organiser portal for external organisers (signup, invites,
+  onboarding) — **sub-project 6, post-August**. Until then, org-scoped events
+  are managed from the existing admin panel by CCK staff.
+
+## Architecture
+
+### New models (Prisma)
+
+```prisma
+enum OrgRole {
+  OWNER
+  ORGANISER
+}
+
+enum EventStatus {
+  DRAFT     // being set up; invisible to participants and judges
+  LIVE      // participants can form teams and submit; judges can score
+  CLOSED    // read-only for participants; reports and exports available
+  ARCHIVED  // hidden from default listings; data retained
+}
+
+model Organisation {
+  id           String   @id @default(cuid())
+  slug         String   @unique
+  name         String
+  logoUrl      String?
+  contactEmail String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  members OrganisationMember[]
+  events  Event[]
+
+  @@map("organisations")
+}
+
+model OrganisationMember {
+  id             String   @id @default(cuid())
+  organisationId String
+  userId         String
+  role           OrgRole  @default(ORGANISER)
+  createdAt      DateTime @default(now())
+
+  organisation Organisation @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([organisationId, userId])
+  @@map("organisation_members")
+}
+
+model Event {
+  id             String      @id @default(cuid())
+  organisationId String
+  /// The join key into the nine cohort-keyed Impact Lab tables. Unique —
+  /// Event is the authoritative registry of cohort slugs.
+  cohort         String      @unique
+  name           String
+  status         EventStatus @default(DRAFT)
+
+  // Branding — replaces the code constants in event-branding.ts.
+  titleLead   String
+  titleAccent String
+  dates       String
+  location    String
+  formatNote  String  @db.Text
+  groundRules String? @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organisation Organisation @relation(fields: [organisationId], references: [id])
+
+  @@index([organisationId])
+  @@index([status])
+  @@map("impact_lab_events")
+}
+```
+
+Sub-project 2 adds config columns to `Event` (`tracks Json?`,
+`submissionFields Json?`, `judgeCodeHash String?`) in its own migration.
+
+### The cohort string stays — Event owns it, nothing rewrites it
+
+The cohort string is embedded in nine Impact Lab tables (participants, match
+runs, scorecards, submissions, rubric overrides, pitch timer, …). **They all
+keep their `cohort` columns unchanged.** `Event.cohort` (unique) becomes the
+registry those strings resolve through. No foreign keys are added to the nine
+tables in this sub-project — the join is by slug, matching how every existing
+query already works. FKs can be introduced later if drift ever becomes a real
+problem (YAGNI until then).
+
+### Backfill (part of the migration's seed step)
+
+| Organisation | Events |
+|---|---|
+| `cck` — Claude Community Kenya | `impact-lab-2026-07` (CLOSED) |
+| `c4dlab` — C4DLab, University of Nairobi | `afretec-makerthon-2026-08` (CLOSED) |
+
+Branding values are copied verbatim from the constants in
+`src/lib/impact-lab/event-branding.ts`. Existing CCK admin users
+(`SUPER_ADMIN`/`ADMIN`) are added as `OWNER` members of the CCK organisation.
+C4DLab gets no members yet — platform admins manage its event, which is
+exactly the operator relationship the Afretec weekend actually had.
+
+Backfill runs as an idempotent seed script (`scripts/seed-events.ts`,
+dry-run by default, `--apply` to write), following the house pattern from
+`seed-hackathon-cohort.ts`.
+
+### Event lifecycle replaces the env var
+
+`IMPACT_LAB_ACTIVE_COHORT` and `IMPACT_LAB_COHORT_LABEL` are retired.
+Status transitions happen from the admin dashboard (platform admin or org
+member) with no redeploy.
+
+**Refinement from the presented design:** the approved sketch had five
+statuses including `JUDGING`. The spec uses four. Judging and submission
+windows are already fine-grained flags on the match run (`judgingOpen`,
+`submissionsCloseAt`) — a `JUDGING` status would be a second source of truth
+for the same fact, and the Afretec event needed judging and submissions open
+*concurrently*, which a linear status can't express. `LIVE` covers the whole
+active period; the run flags say what is open within it.
+
+What each status gates:
+
+- **DRAFT** — excluded from participant resolution, the judge event picker,
+  and public surfaces. Visible only in admin.
+- **LIVE** — full behaviour as today: team formation, submissions (subject to
+  `submissionsCloseAt`), judging (subject to `judgingOpen`).
+- **CLOSED** — all participant and judge writes rejected (the existing
+  `guardClosedCohort` becomes DB-backed: it reads the event's status instead
+  of a hardcoded list). Reads, reports, exports still work.
+- **ARCHIVED** — as CLOSED, and hidden from default admin/judge listings.
+
+### Resolution — "which event?" without a global constant
+
+This is the one place existing behaviour genuinely changes, so it is the most
+heavily tested part of sub-project 1.
+
+- **Participants** (`/dashboard/impact-lab`, member API routes): resolved by
+  membership, not by a global. Look up the caller's participant rows (keyed by
+  email) across all `LIVE` events, newest first. Zero rows → the current
+  "no team" experience. One row → that event (the overwhelmingly common
+  case). Multiple rows → an event picker, mirroring the judge picker shipped
+  for Afretec.
+- **Judges**: already solved — the judge event picker lists final runs with
+  judging open; its query gains a `status: LIVE` filter.
+- **Admin**: already solved — the cohort selector from PR #102 becomes an
+  event selector backed by the `Event` table. The default selection changes
+  from `CURRENT_COHORT` (env-derived) to the most recently created
+  non-archived event.
+- **`CURRENT_COHORT` is deleted** at the end of sub-project 1, along with
+  `safeCohort`'s env-based fallback. Any call site that cannot name its event
+  by then is a bug this refactor is designed to surface at compile time.
+- **`brandingForCohort()`** becomes async and DB-backed (reading the Event
+  row) with the existing code constants as fallback — the exact evolution its
+  own doc comment anticipates. Callers (the three export paths) already run
+  server-side and async.
+
+### Authorization — two orthogonal layers
+
+Site roles (`UserRole`) are untouched and become the **platform tier**:
+`SUPER_ADMIN`/`ADMIN` (CCK staff) pass every event check. `OrganisationMember`
+is the **tenant tier**: membership grants access to that organisation's events
+only.
+
+One new helper in `src/lib/impact-lab/event-access.ts`:
+
+```ts
+/** Authorizes the caller for an event: platform admin, or member of the
+ *  event's organisation. Returns the event row on success so callers never
+ *  fetch it twice. */
+async function checkEventAccess(eventIdOrCohort: string):
+  Promise<{ authorized: true; event: Event } | { authorized: false; response: NextResponse }>
+```
+
+Every admin Impact Lab API route swaps its bare `checkApiPermission("impact-lab", …)`
+call for `checkApiPermission` **plus** `checkEventAccess` — platform
+permission says *what actions* the role allows; event access says *which
+events* it allows them on. Public participant/judge routes are unchanged:
+they authorize by session membership and judge cookie as today.
+
+### Error handling
+
+House patterns, unchanged:
+
+- Missing tables (P2021) before the migration reaches an environment →
+  degrade: resolution helpers fall back to the code-constant behaviour and
+  admin config surfaces return 503 naming the migration, as `rubric-store.ts`
+  does today.
+- Resolution helpers never throw on unknown cohorts — an event row that
+  doesn't exist resolves to safe fallbacks (Impact Lab branding, no access),
+  never an error page mid-event.
+- Status transitions validate server-side (no LIVE → DRAFT once participants
+  exist; ARCHIVED requires CLOSED first).
+
+### Testing
+
+- `scripts/verify-events.ts` — assertion script in the style of
+  `verify-judging.ts` (63 assertions): resolution precedence (zero / one /
+  many live events per participant), status gating per surface, backfill
+  idempotency, access-check matrix (platform admin × org member × outsider ×
+  each status).
+- Gate before every commit: `npx tsc --noEmit` and `npm run build` clean.
+- Migration rehearsed against a local database with the production schema
+  before it goes anywhere near the VPS; applied to production over the SSH
+  tunnel (direct port, not PgBouncer) per the established runbook.
+
+## Sub-project sequence
+
+1. **Tenancy core** *(this spec)* — models, migration, backfill, lifecycle,
+   resolution, access control, env-var retirement.
+2. **Event config** — tracks, ground-rules display, submission-field config
+   (the "deck-only" Afretec lesson as a per-event setting), per-event judge
+   codes, rubric wiring; freeze rules per the table in the approved design.
+3. **Creation wizard + Claude setup advisor** — propose-only, server
+   revalidates, per the rubric-extract pattern.
+4. **Activation** — participant comms, non-submitter chasing, Claude drafts.
+5. **Claude authoring** — team feedback drafts, report narrative.
+6. **Organiser portal** — external organisers, invites, onboarding
+   *(post-August)*.
+
+**Late-August MVP = sub-projects 1–3.**

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "verify:judging": "tsx scripts/verify-judging.ts",
     "verify:results": "tsx scripts/verify-results.ts",
     "verify:reviews": "tsx scripts/verify-reviews.ts",
+    "verify:events": "tsx scripts/verify-events.ts",
     "import:manual-teams": "tsx scripts/import-manual-teams.ts",
     "seed:hackathon": "tsx scripts/seed-hackathon-cohort.ts",
     "seed:events": "tsx scripts/seed-events.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "verify:reviews": "tsx scripts/verify-reviews.ts",
     "import:manual-teams": "tsx scripts/import-manual-teams.ts",
     "seed:hackathon": "tsx scripts/seed-hackathon-cohort.ts",
+    "seed:events": "tsx scripts/seed-events.ts",
     "backfill:gallery": "tsx scripts/backfill-gallery-r2.ts",
     "purge:closed-cohorts": "tsx scripts/purge-closed-cohorts.ts"
   },

--- a/prisma/migrations/20260808200000_event_platform_tenancy/migration.sql
+++ b/prisma/migrations/20260808200000_event_platform_tenancy/migration.sql
@@ -1,0 +1,73 @@
+-- CreateEnum
+CREATE TYPE "OrgRole" AS ENUM ('OWNER', 'ORGANISER');
+
+-- CreateEnum
+CREATE TYPE "ImpactLabEventStatus" AS ENUM ('DRAFT', 'LIVE', 'CLOSED', 'ARCHIVED');
+
+-- CreateTable
+CREATE TABLE "organisations" (
+    "id" TEXT NOT NULL,
+    "slug" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "logoUrl" TEXT,
+    "contactEmail" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "organisations_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "organisation_members" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "role" "OrgRole" NOT NULL DEFAULT 'ORGANISER',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "organisation_members_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "impact_lab_events" (
+    "id" TEXT NOT NULL,
+    "organisationId" TEXT NOT NULL,
+    "cohort" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "status" "ImpactLabEventStatus" NOT NULL DEFAULT 'DRAFT',
+    "titleLead" TEXT NOT NULL,
+    "titleAccent" TEXT NOT NULL,
+    "dates" TEXT NOT NULL,
+    "location" TEXT NOT NULL,
+    "formatNote" TEXT NOT NULL,
+    "groundRules" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "impact_lab_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organisations_slug_key" ON "organisations"("slug");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "organisation_members_organisationId_userId_key" ON "organisation_members"("organisationId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "impact_lab_events_cohort_key" ON "impact_lab_events"("cohort");
+
+-- CreateIndex
+CREATE INDEX "impact_lab_events_organisationId_idx" ON "impact_lab_events"("organisationId");
+
+-- CreateIndex
+CREATE INDEX "impact_lab_events_status_idx" ON "impact_lab_events"("status");
+
+-- AddForeignKey
+ALTER TABLE "organisation_members" ADD CONSTRAINT "organisation_members_organisationId_fkey" FOREIGN KEY ("organisationId") REFERENCES "organisations"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "organisation_members" ADD CONSTRAINT "organisation_members_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "impact_lab_events" ADD CONSTRAINT "impact_lab_events_organisationId_fkey" FOREIGN KEY ("organisationId") REFERENCES "organisations"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,6 +115,31 @@ enum ImpactLabExperience {
   ADVANCED
 }
 
+// Tenant-tier role, orthogonal to the site-wide UserRole. Site
+// SUPER_ADMIN/ADMIN are the *platform* tier and pass every event check;
+// OrganisationMember grants access to one organisation's events only.
+enum OrgRole {
+  OWNER
+  ORGANISER
+}
+
+// Event lifecycle. Judging/submission windows are NOT statuses — they stay
+// as fine-grained flags on the match run (judgingOpen, submissionsCloseAt),
+// because Afretec needed judging and submissions open concurrently.
+//
+// Named ImpactLabEventStatus (not EventStatus) because the site-wide
+// community-meetup `Event` model already owns an `EventStatus` enum
+// (UPCOMING/REGISTRATION_OPEN/SOLD_OUT/COMPLETED/CANCELLED, schema.prisma:51)
+// — Prisma does not allow two declarations with the same name. Table/column
+// names (@@map) are unaffected; only the Prisma-side identifiers changed
+// from the task-1 brief. See task-1-report.md.
+enum ImpactLabEventStatus {
+  DRAFT // being set up; invisible to participants and judges
+  LIVE // participants form teams and submit; judges score
+  CLOSED // read-only for participants; reports and exports available
+  ARCHIVED // hidden from default listings; data retained
+}
+
 // ─── Users & Auth ────────────────────────────────────────────────────────────
 
 model User {
@@ -145,6 +170,7 @@ model User {
   demoRequests         DemoRequest[]
   onboardingSessions   OnboardingSession[]
   impactLabMatchRuns   ImpactLabMatchRun[]
+  organisationMemberships OrganisationMember[]
 
   @@map("users")
 }
@@ -992,4 +1018,69 @@ model ImpactLabResultsEmail {
   @@unique([runId, participantId])
   @@index([runId, status])
   @@map("impact_lab_results_emails")
+}
+
+// ─── Event Platform Tenancy ──────────────────────────────────────────────────
+// An Event belongs to an Organisation and OWNS a unique cohort slug — the
+// join key into the nine cohort-keyed Impact Lab tables above. Those tables
+// keep their string columns; no FKs are added to them (the join is by slug,
+// matching every existing query). See the 2026-08-08 tenancy design spec.
+
+model Organisation {
+  id           String   @id @default(cuid())
+  slug         String   @unique
+  name         String
+  logoUrl      String?
+  contactEmail String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  members OrganisationMember[]
+  events  ImpactLabEvent[]
+
+  @@map("organisations")
+}
+
+model OrganisationMember {
+  id             String   @id @default(cuid())
+  organisationId String
+  userId         String
+  role           OrgRole  @default(ORGANISER)
+  createdAt      DateTime @default(now())
+
+  organisation Organisation @relation(fields: [organisationId], references: [id], onDelete: Cascade)
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([organisationId, userId])
+  @@map("organisation_members")
+}
+
+// Named ImpactLabEvent (not Event) — the site-wide community-meetup `Event`
+// model already owns that name (schema.prisma:294). Table name is still
+// impact_lab_events per @@map below, matching the task-1 brief verbatim.
+model ImpactLabEvent {
+  id             String               @id @default(cuid())
+  organisationId String
+  /// Authoritative registry entry for the cohort slug used across the nine
+  /// Impact Lab tables. Unique: one Event per cohort, ever.
+  cohort         String               @unique
+  name           String
+  status         ImpactLabEventStatus @default(DRAFT)
+
+  // Branding — replaces the code constants in event-branding.ts (Task 11).
+  titleLead   String
+  titleAccent String
+  dates       String
+  location    String
+  formatNote  String  @db.Text
+  groundRules String? @db.Text
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  organisation Organisation @relation(fields: [organisationId], references: [id])
+
+  @@index([organisationId])
+  @@index([status])
+  @@map("impact_lab_events")
 }

--- a/scripts/purge-closed-cohorts.ts
+++ b/scripts/purge-closed-cohorts.ts
@@ -26,36 +26,21 @@
  *   npm run purge:closed-cohorts -- --apply   # actually clears
  *   npm run purge:closed-cohorts -- --cohort impact-lab-2026-07
  *
- * The active cohort (IMPACT_LAB_ACTIVE_COHORT) is skipped unless you name it
- * explicitly with --cohort, so running this mid-event cannot wipe the phone
- * numbers the organisers are relying on to reach people in the room.
+ * Every LIVE event's cohort is skipped unless you name it explicitly with
+ * --cohort, so running this mid-event cannot wipe the phone numbers the
+ * organisers are relying on to reach people in the room. LIVE status comes
+ * from the Event table (several events can be LIVE at once) rather than a
+ * single env var, so more than one cohort can be protected at a time.
  */
 
 import { PrismaClient } from "../src/generated/prisma/client"
 import { PrismaPg } from "@prisma/adapter-pg"
-import { ACTIVE_COHORT } from "../src/lib/impact-lab/constants"
+import { listEvents } from "../src/lib/impact-lab/event-store"
 
 const apply = process.argv.includes("--apply")
 const cohortFlagIndex = process.argv.indexOf("--cohort")
 const cohortFilter =
   cohortFlagIndex !== -1 ? process.argv[cohortFlagIndex + 1] ?? null : null
-
-// Fail closed, not open. Without ACTIVE_COHORT, `cohort !== ACTIVE_COHORT`
-// degrades to `cohort !== null`, which every real cohort satisfies — the
-// live cohort would be purged right along with the closed ones, logging
-// only a quiet "No active cohort set". An explicit --cohort is a different
-// case: the operator has already named exactly what to purge, so there is
-// nothing left to protect against.
-if (apply && !ACTIVE_COHORT && !cohortFilter) {
-  console.error(
-    "Refusing --apply: IMPACT_LAB_ACTIVE_COHORT is not set, so this script " +
-      "cannot tell which cohort is still live and must be protected from the " +
-      "purge. Set IMPACT_LAB_ACTIVE_COHORT to the live cohort slug before " +
-      "running --apply, or pass --cohort <slug> to purge one specific cohort " +
-      "explicitly.",
-  )
-  process.exit(1)
-}
 
 /** Mask an email for the report — enough to identify a row, not enough to be a leak. */
 function maskEmail(email: string): string {
@@ -89,6 +74,27 @@ async function main() {
 }
 
 async function run(prisma: PrismaClient) {
+  const events = await listEvents()
+  const liveCohorts = new Set(events.filter((e) => e.status === "LIVE").map((e) => e.cohort))
+
+  // Fail closed, not open. A genuinely empty liveCohorts set is
+  // indistinguishable from "the tenancy migration has not run here yet"
+  // (listEvents degrades to [] in both cases) — purging without an explicit
+  // --cohort in that state could wipe a live cohort's phone numbers right
+  // along with the closed ones. An explicit --cohort is a different case:
+  // the operator has already named exactly what to purge, so there is
+  // nothing left to protect against.
+  if (apply && liveCohorts.size === 0 && !cohortFilter) {
+    console.error(
+      "Refusing --apply: no event is LIVE (or the tenancy migration has not " +
+        "run here), so this script cannot tell which cohort must be protected " +
+        "from the purge. Pass --cohort <slug> to purge one specific cohort " +
+        "explicitly.",
+    )
+    process.exitCode = 1
+    return
+  }
+
   const cohortRows = await prisma.impactLabParticipant.groupBy({
     by: ["cohort"],
     _count: { _all: true },
@@ -98,14 +104,14 @@ async function run(prisma: PrismaClient) {
     .map((c) => c.cohort)
     .filter((cohort) => {
       if (cohortFilter) return cohort === cohortFilter
-      return cohort !== ACTIVE_COHORT
+      return !liveCohorts.has(cohort)
     })
     .sort()
 
-  if (ACTIVE_COHORT && !cohortFilter) {
-    console.log(`Active cohort (skipped): ${ACTIVE_COHORT}`)
-  } else if (!ACTIVE_COHORT) {
-    console.log("No active cohort set (IMPACT_LAB_ACTIVE_COHORT unset).")
+  if (liveCohorts.size > 0 && !cohortFilter) {
+    console.log(`Live cohort(s) (skipped): ${[...liveCohorts].sort().join(", ")}`)
+  } else if (liveCohorts.size === 0) {
+    console.log("No LIVE event.")
   }
 
   if (candidates.length === 0) {

--- a/scripts/seed-events.ts
+++ b/scripts/seed-events.ts
@@ -1,0 +1,130 @@
+/**
+ * Backfill the tenancy tables with the two events that already ran.
+ *
+ * Idempotent: every write is an upsert keyed on the unique slug/cohort, so
+ * running it twice changes nothing. Dry-run by default; pass --apply to write.
+ *
+ *   npm run seed:events            # report what would change
+ *   npm run seed:events -- --apply # write
+ */
+import { PrismaClient } from "../src/generated/prisma/client"
+import { PrismaPg } from "@prisma/adapter-pg"
+
+const adapter = new PrismaPg({ connectionString: process.env.DATABASE_URL! })
+const prisma = new PrismaClient({ adapter })
+const APPLY = process.argv.includes("--apply")
+
+interface OrgSeed {
+  slug: string
+  name: string
+  contactEmail: string | null
+}
+
+interface EventSeed {
+  orgSlug: string
+  cohort: string
+  name: string
+  status: "CLOSED"
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+}
+
+const ORGS: OrgSeed[] = [
+  { slug: "cck", name: "Claude Community Kenya", contactEmail: "hello@claudekenya.org" },
+  { slug: "c4dlab", name: "C4DLab, University of Nairobi", contactEmail: null },
+]
+
+const EVENTS: EventSeed[] = [
+  {
+    orgSlug: "cck",
+    cohort: "impact-lab-2026-07",
+    name: "Impact Lab: AI Mashinani",
+    status: "CLOSED",
+    titleLead: "Impact Lab:",
+    titleAccent: "AI Mashinani",
+    dates: "25–26 July 2026",
+    location: "Nairobi, Kenya",
+    formatNote:
+      "An overnight build: teams formed in the evening, built through the night, " +
+      "and judging ran from the small hours into the morning.",
+  },
+  {
+    orgSlug: "c4dlab",
+    cohort: "afretec-makerthon-2026-08",
+    name: "Afretec Makerthon 2026",
+    status: "CLOSED",
+    titleLead: "Afretec",
+    titleAccent: "Makerthon 2026",
+    dates: "8 August 2026",
+    location: "Nairobi, Kenya",
+    formatNote:
+      "Teams registered as existing startups and were formed before the event. Each team " +
+      "pitched live for five minutes and was scored by a judging panel on eight criteria out " +
+      "of 50.",
+  },
+]
+
+async function main(): Promise<void> {
+  console.log(APPLY ? "APPLY mode — writing." : "DRY RUN — pass --apply to write.")
+
+  for (const org of ORGS) {
+    const existing = await prisma.organisation.findUnique({ where: { slug: org.slug } })
+    console.log(`organisation ${org.slug}: ${existing ? "exists" : "will create"}`)
+    if (APPLY) {
+      await prisma.organisation.upsert({
+        where: { slug: org.slug },
+        create: org,
+        update: { name: org.name, contactEmail: org.contactEmail },
+      })
+    }
+  }
+
+  for (const event of EVENTS) {
+    const org = await prisma.organisation.findUnique({ where: { slug: event.orgSlug } })
+    if (!org) {
+      if (APPLY) throw new Error(`organisation ${event.orgSlug} missing — cannot seed ${event.cohort}`)
+      console.log(`event ${event.cohort}: would create under ${event.orgSlug} (org pending)`)
+      continue
+    }
+    const { orgSlug: _orgSlug, ...data } = event
+    const existing = await prisma.impactLabEvent.findUnique({ where: { cohort: event.cohort } })
+    console.log(`event ${event.cohort}: ${existing ? "exists" : "will create"}`)
+    if (APPLY) {
+      await prisma.impactLabEvent.upsert({
+        where: { cohort: event.cohort },
+        // Backfill never overwrites a status an admin may have changed since.
+        create: { ...data, organisationId: org.id },
+        update: {},
+      })
+    }
+  }
+
+  // Every active platform admin becomes an OWNER of the CCK organisation.
+  const admins = await prisma.user.findMany({
+    where: { role: { in: ["SUPER_ADMIN", "ADMIN"] }, active: true },
+    select: { id: true, email: true },
+  })
+  const cck = await prisma.organisation.findUnique({ where: { slug: "cck" } })
+  console.log(`cck OWNER memberships for ${admins.length} platform admin(s)`)
+  if (APPLY && cck) {
+    for (const admin of admins) {
+      await prisma.organisationMember.upsert({
+        where: { organisationId_userId: { organisationId: cck.id, userId: admin.id } },
+        create: { organisationId: cck.id, userId: admin.id, role: "OWNER" },
+        update: {},
+      })
+    }
+  }
+
+  console.log("Done.")
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(() => prisma.$disconnect())

--- a/scripts/verify-events.ts
+++ b/scripts/verify-events.ts
@@ -11,6 +11,7 @@ import {
   pickMemberEvent,
   validCohort,
 } from "../src/lib/impact-lab/event-lifecycle"
+import { hasEventAccess } from "../src/lib/impact-lab/event-access"
 
 let passed = 0
 let failed = 0
@@ -69,6 +70,16 @@ check("validCohort rejects empty", validCohort("") === null)
 check("validCohort rejects null/undefined", validCohort(null) === null && validCohort(undefined) === null)
 check("validCohort rejects CR/LF injection", validCohort("x\r\nSet-Cookie: a=b") === null)
 check("validCohort rejects overlong input", validCohort("a".repeat(61)) === null)
+
+// ── hasEventAccess ───────────────────────────────────────────────────────────
+check("platform SUPER_ADMIN passes any action", hasEventAccess("SUPER_ADMIN", false, "delete"))
+check("platform ADMIN passes impact-lab actions", hasEventAccess("ADMIN", false, "approve"))
+check("MODERATOR gets view only", hasEventAccess("MODERATOR", false, "view") && !hasEventAccess("MODERATOR", false, "edit"))
+check("plain MEMBER refused without org membership", !hasEventAccess("MEMBER", false, "view"))
+check("org member passes every action on own org's event", hasEventAccess("MEMBER", true, "view") &&
+  hasEventAccess("MEMBER", true, "edit") && hasEventAccess("MEMBER", true, "approve"))
+check("no session refused", !hasEventAccess(null, false, "view"))
+check("org membership beats missing platform role", hasEventAccess(null, true, "edit") === false)
 
 console.log(`\n${passed} passed, ${failed} failed`)
 if (failed > 0) process.exit(1)

--- a/scripts/verify-events.ts
+++ b/scripts/verify-events.ts
@@ -1,0 +1,74 @@
+/**
+ * Assertions for the event tenancy logic: lifecycle transitions, member
+ * event resolution precedence, and cohort slug validation. Pure logic only —
+ * runs without a database, like verify-judging.ts.
+ *
+ *   npm run verify:events
+ */
+import {
+  canTransition,
+  orderMemberEvents,
+  pickMemberEvent,
+  validCohort,
+} from "../src/lib/impact-lab/event-lifecycle"
+
+let passed = 0
+let failed = 0
+function check(name: string, condition: boolean): void {
+  if (condition) {
+    passed += 1
+  } else {
+    failed += 1
+    console.error(`FAIL: ${name}`)
+  }
+}
+
+// ── canTransition ────────────────────────────────────────────────────────────
+check("DRAFT→LIVE allowed", canTransition("DRAFT", "LIVE", false).ok)
+check("DRAFT→LIVE allowed with participants", canTransition("DRAFT", "LIVE", true).ok)
+check("LIVE→DRAFT allowed while empty", canTransition("LIVE", "DRAFT", false).ok)
+check("LIVE→DRAFT refused once participants exist", !canTransition("LIVE", "DRAFT", true).ok)
+check("LIVE→CLOSED allowed", canTransition("LIVE", "CLOSED", true).ok)
+check("CLOSED→LIVE (reopen) allowed", canTransition("CLOSED", "LIVE", true).ok)
+check("CLOSED→ARCHIVED allowed", canTransition("CLOSED", "ARCHIVED", true).ok)
+check("ARCHIVED→CLOSED (unarchive) allowed", canTransition("ARCHIVED", "CLOSED", true).ok)
+check("DRAFT→ARCHIVED refused (archive requires CLOSED)", !canTransition("DRAFT", "ARCHIVED", false).ok)
+check("LIVE→ARCHIVED refused (archive requires CLOSED)", !canTransition("LIVE", "ARCHIVED", true).ok)
+check("ARCHIVED→LIVE refused (unarchive first)", !canTransition("ARCHIVED", "LIVE", true).ok)
+check("no-op transition refused", !canTransition("LIVE", "LIVE", true).ok)
+check("refusal carries a reason", canTransition("LIVE", "DRAFT", true).ok === false &&
+  (canTransition("LIVE", "DRAFT", true) as { ok: false; reason: string }).reason.length > 0)
+
+// ── ordering and picking ─────────────────────────────────────────────────────
+const day = (n: number): Date => new Date(2026, 0, n)
+const closedOld = { cohort: "old-closed", status: "CLOSED" as const, createdAt: day(1) }
+const closedNew = { cohort: "new-closed", status: "CLOSED" as const, createdAt: day(5) }
+const liveOld = { cohort: "old-live", status: "LIVE" as const, createdAt: day(2) }
+const liveNew = { cohort: "new-live", status: "LIVE" as const, createdAt: day(4) }
+const draft = { cohort: "a-draft", status: "DRAFT" as const, createdAt: day(9) }
+const archived = { cohort: "an-archived", status: "ARCHIVED" as const, createdAt: day(9) }
+
+const ordered = orderMemberEvents([closedOld, draft, liveOld, archived, liveNew, closedNew])
+check("DRAFT excluded from member view", !ordered.some((e) => e.cohort === "a-draft"))
+check("ARCHIVED excluded from member view", !ordered.some((e) => e.cohort === "an-archived"))
+check("LIVE events come before CLOSED", ordered[0].status === "LIVE" && ordered[1].status === "LIVE")
+check("newest LIVE first", ordered[0].cohort === "new-live")
+check("newest CLOSED first within CLOSED", ordered[2].cohort === "new-closed")
+
+check("pick: empty list → null", pickMemberEvent([]) === null)
+check("pick: single event wins", pickMemberEvent([closedOld])?.cohort === "old-closed")
+check("pick: newest LIVE by default", pickMemberEvent([closedNew, liveOld, liveNew])?.cohort === "new-live")
+check("pick: requested cohort honoured when member", pickMemberEvent([liveNew, liveOld], "old-live")?.cohort === "old-live")
+check("pick: requested cohort ignored when not a member", pickMemberEvent([liveNew], "someone-elses")?.cohort === "new-live")
+check("pick: requested DRAFT/ARCHIVED unreachable", pickMemberEvent([liveNew, draft], "a-draft")?.cohort === "new-live")
+
+// ── validCohort ──────────────────────────────────────────────────────────────
+check("validCohort accepts a real slug", validCohort("afretec-makerthon-2026-08") === "afretec-makerthon-2026-08")
+check("validCohort trims", validCohort("  impact-lab-2026-07 ") === "impact-lab-2026-07")
+check("validCohort rejects empty", validCohort("") === null)
+check("validCohort rejects null/undefined", validCohort(null) === null && validCohort(undefined) === null)
+check("validCohort rejects CR/LF injection", validCohort("x\r\nSet-Cookie: a=b") === null)
+check("validCohort rejects overlong input", validCohort("a".repeat(61)) === null)
+
+console.log(`\n${passed} passed, ${failed} failed`)
+if (failed > 0) process.exit(1)

--- a/src/app/admin/impact-lab/judge/JudgeDashboard.tsx
+++ b/src/app/admin/impact-lab/judge/JudgeDashboard.tsx
@@ -7,8 +7,8 @@ import { JudgeScoringScreen } from "./JudgeScoringScreen"
 
 /**
  * Cohort-aware wrapper around the judge scoring screen. Before this, the
- * page hardcoded `CURRENT_COHORT`, so an organiser judging a past event
- * (or re-checking a past event's scores) had no way to get there.
+ * page hardcoded a single default cohort, so an organiser judging a past
+ * event (or re-checking a past event's scores) had no way to get there.
  *
  * `JudgeScoringScreen`'s own `load` callback already depends on its `cohort`
  * prop, so switching the selection here is all that's needed — it refetches

--- a/src/app/admin/impact-lab/judge/page.tsx
+++ b/src/app/admin/impact-lab/judge/page.tsx
@@ -1,15 +1,16 @@
 import { AdminHeader } from "@/components/admin/AdminHeader"
 import { JudgeDashboard } from "./JudgeDashboard"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { defaultAdminCohort } from "@/lib/impact-lab/event-store"
 
 export const dynamic = "force-dynamic"
 
-export default function ImpactLabJudgePage() {
+export default async function ImpactLabJudgePage() {
+  const cohort = await defaultAdminCohort()
   return (
     <div>
       <AdminHeader title="Judge scoring" />
       <div className="p-4 sm:p-6">
-        <JudgeDashboard initialCohort={CURRENT_COHORT} />
+        <JudgeDashboard initialCohort={cohort} />
       </div>
     </div>
   )

--- a/src/app/admin/impact-lab/page.tsx
+++ b/src/app/admin/impact-lab/page.tsx
@@ -1,21 +1,23 @@
 import { AdminHeader } from "@/components/admin/AdminHeader"
 import { ImpactLabDashboard } from "@/components/admin/impact-lab/ImpactLabDashboard"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { defaultAdminCohort } from "@/lib/impact-lab/event-store"
 
 export const dynamic = "force-dynamic"
 
-export default function ImpactLabAdminPage() {
+export default async function ImpactLabAdminPage() {
+  const cohort = await defaultAdminCohort()
   return (
     <div>
       <AdminHeader title="Impact Lab" />
       <div className="p-6">
         {/*
          * The explanatory line used to live here as static server-rendered
-         * text naming CURRENT_COHORT — wrong the moment an organiser picks a
-         * different event from the selector below. It now lives inside
-         * ImpactLabDashboard, which tracks the selected cohort as state.
+         * text naming the default cohort — wrong the moment an organiser
+         * picks a different event from the selector below. It now lives
+         * inside ImpactLabDashboard, which tracks the selected cohort as
+         * state.
          */}
-        <ImpactLabDashboard cohort={CURRENT_COHORT} />
+        <ImpactLabDashboard cohort={cohort} />
       </div>
     </div>
   )

--- a/src/app/api/admin/impact-lab/cohorts/route.ts
+++ b/src/app/api/admin/impact-lab/cohorts/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { listEvents, defaultAdminCohort } from "@/lib/impact-lab/event-store"
 
 interface CohortSummary {
   cohort: string
@@ -10,6 +10,10 @@ interface CohortSummary {
   hasFinalRun: boolean
   latestRunName: string | null
   latestRunAt: string | null
+  /** The owning event's display name, or null for a cohort with no Event row (pre-tenancy data). */
+  eventName: string | null
+  /** The owning event's lifecycle status, or null for a cohort with no Event row. */
+  status: string | null
   /** True for the cohort every other admin route falls back to when `?cohort=` is missing or invalid. */
   isActive: boolean
 }
@@ -22,14 +26,14 @@ interface CohortSummary {
  *
  * A cohort can exist in `ImpactLabParticipant`, `ImpactLabMatchRun`, or (for
  * a freshly configured event) neither yet — so the union of both tables is
- * seeded with `CURRENT_COHORT` up front rather than derived only from rows
- * that happen to exist.
+ * seeded with every non-archived event up front rather than derived only
+ * from rows that happen to exist.
  */
 export async function GET() {
   const check = await checkApiPermission("impact-lab", "view")
   if (!check.authorized) return check.response
 
-  const [participantCounts, runs] = await Promise.all([
+  const [participantCounts, runs, events, activeCohort] = await Promise.all([
     prisma.impactLabParticipant.groupBy({
       by: ["cohort"],
       _count: { _all: true },
@@ -40,6 +44,8 @@ export async function GET() {
       select: { cohort: true, name: true, isFinal: true, createdAt: true },
       orderBy: { createdAt: "desc" },
     }),
+    listEvents(),
+    defaultAdminCohort(),
   ])
 
   const summaries = new Map<string, CohortSummary>()
@@ -53,16 +59,26 @@ export async function GET() {
         hasFinalRun: false,
         latestRunName: null,
         latestRunAt: null,
-        isActive: cohort === CURRENT_COHORT,
+        eventName: null,
+        status: null,
+        isActive: cohort === activeCohort,
       }
       summaries.set(cohort, summary)
     }
     return summary
   }
 
-  // Seed the active cohort even if it has no rows yet, so a freshly
-  // configured event is selectable before anyone has been imported.
-  summaryFor(CURRENT_COHORT)
+  // Seed every non-archived event even if it has no rows yet, so a freshly
+  // configured event is selectable before anyone has been imported. Archived
+  // events are left out of the seed — they still surface if legacy
+  // participant/run rows reference them, but don't clutter the selector on
+  // their own.
+  for (const event of events) {
+    if (event.status === "ARCHIVED") continue
+    const summary = summaryFor(event.cohort)
+    summary.eventName = event.name
+    summary.status = event.status
+  }
 
   for (const row of participantCounts) {
     summaryFor(row.cohort).participantCount = row._count._all

--- a/src/app/api/admin/impact-lab/cohorts/route.ts
+++ b/src/app/api/admin/impact-lab/cohorts/route.ts
@@ -21,8 +21,8 @@ interface CohortSummary {
 /**
  * Every cohort the system knows about, with enough per-cohort activity to
  * tell them apart at a glance. Backs the cohort selector on the Impact Lab
- * admin dashboard — before this route existed, switching events meant
- * changing `IMPACT_LAB_ACTIVE_COHORT` and redeploying.
+ * admin dashboard — before events lived in the database, switching events
+ * meant changing an env var and redeploying.
  *
  * A cohort can exist in `ImpactLabParticipant`, `ImpactLabMatchRun`, or (for
  * a freshly configured event) neither yet — so the union of both tables is

--- a/src/app/api/admin/impact-lab/events/route.ts
+++ b/src/app/api/admin/impact-lab/events/route.ts
@@ -1,0 +1,255 @@
+import { NextRequest, NextResponse } from "next/server"
+import { z } from "zod"
+import { prisma } from "@/lib/prisma"
+import { withCsrfProtection } from "@/lib/csrf"
+import { checkApiPermission } from "@/lib/rbac"
+import { rateLimit } from "@/lib/rate-limit"
+import { logAudit, getRequestMetadata } from "@/lib/audit-log"
+import { canTransition, validCohort, EVENT_STATUSES } from "@/lib/impact-lab/event-lifecycle"
+import {
+  eventHasParticipants,
+  getEventByCohort,
+  listEvents,
+  type EventRecord,
+} from "@/lib/impact-lab/event-store"
+import { checkEventAccess } from "@/lib/impact-lab/event-access"
+
+/**
+ * Event CRUD for the admin dashboard. Creating an event needs the platform
+ * impact-lab `create` permission (org members creating their own events is
+ * sub-project 6); editing and status changes go through checkEventAccess so
+ * an organisation's members can manage their own event via the API today.
+ *
+ * Writes follow the house shape set by the rubric route
+ * (src/app/api/admin/impact-lab/rubric/route.ts): CSRF check, rate limit
+ * keyed to the acting user, then an audit-log entry — event creation and
+ * status transitions are exactly the action class the audit log exists for.
+ */
+
+function serialize(event: EventRecord) {
+  return { ...event, createdAt: event.createdAt.toISOString() }
+}
+
+const createSchema = z.strictObject({
+  organisationId: z.string().min(1),
+  cohort: z.string(),
+  name: z.string().trim().min(1).max(200),
+  titleLead: z.string().trim().min(1).max(100),
+  titleAccent: z.string().trim().min(1).max(100),
+  dates: z.string().trim().min(1).max(100),
+  location: z.string().trim().min(1).max(200),
+  formatNote: z.string().trim().min(1).max(2000),
+  groundRules: z.string().trim().max(20_000).optional(),
+})
+
+const patchSchema = z.strictObject({
+  cohort: z.string(),
+  status: z.enum(EVENT_STATUSES).optional(),
+  name: z.string().trim().min(1).max(200).optional(),
+  titleLead: z.string().trim().min(1).max(100).optional(),
+  titleAccent: z.string().trim().min(1).max(100).optional(),
+  dates: z.string().trim().min(1).max(100).optional(),
+  location: z.string().trim().min(1).max(200).optional(),
+  formatNote: z.string().trim().min(1).max(2000).optional(),
+  groundRules: z.string().trim().max(20_000).optional(),
+})
+
+/** GET — every event plus the organisations available to assign one to. */
+export async function GET() {
+  const check = await checkApiPermission("impact-lab", "view")
+  if (!check.authorized) return check.response
+
+  const [events, organisations] = await Promise.all([
+    listEvents(),
+    prisma.organisation
+      .findMany({ select: { id: true, slug: true, name: true }, orderBy: { name: "asc" } })
+      .catch(() => []),
+  ])
+  return NextResponse.json({
+    success: true,
+    data: { events: events.map(serialize), organisations },
+  })
+}
+
+/** POST — create a DRAFT event under an organisation. */
+export async function POST(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const check = await checkApiPermission("impact-lab", "create")
+  if (!check.authorized) return check.response
+
+  const rl = await rateLimit(request, {
+    maxRequests: 40,
+    windowInSeconds: 300,
+    identifier: () => `impact-lab-events:${check.user.id}`,
+  })
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const parsed = createSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues[0]?.message ?? "Invalid event" },
+      { status: 400 }
+    )
+  }
+  const cohort = validCohort(parsed.data.cohort)
+  if (!cohort) {
+    return NextResponse.json(
+      { success: false, error: "Cohort slug must be lowercase letters, digits and hyphens." },
+      { status: 400 }
+    )
+  }
+  if (await getEventByCohort(cohort)) {
+    return NextResponse.json(
+      { success: false, error: `An event already owns the slug "${cohort}".` },
+      { status: 409 }
+    )
+  }
+
+  const { organisationId, name, titleLead, titleAccent, dates, location, formatNote, groundRules } =
+    parsed.data
+
+  try {
+    await prisma.impactLabEvent.create({
+      data: {
+        organisationId,
+        cohort,
+        status: "DRAFT",
+        name,
+        titleLead,
+        titleAccent,
+        dates,
+        location,
+        formatNote,
+        groundRules: groundRules ?? null,
+      },
+    })
+  } catch (error) {
+    const code = (error as { code?: string })?.code
+    // A second organiser can race the getEventByCohort check above with the
+    // same slug — the unique constraint is the real guard, this just turns
+    // it into the same 409 rather than an unhandled 500.
+    if (code === "P2002") {
+      return NextResponse.json(
+        { success: false, error: `An event already owns the slug "${cohort}".` },
+        { status: 409 }
+      )
+    }
+    if (code === "P2003") {
+      return NextResponse.json({ success: false, error: "Unknown organisation." }, { status: 400 })
+    }
+    throw error
+  }
+
+  await logAudit({
+    userId: check.user.id,
+    userName: check.user.name,
+    userEmail: check.user.email,
+    action: "CREATE",
+    entity: "ImpactLabEvent",
+    entityId: cohort,
+    changes: { cohort, organisationId, name, status: "DRAFT" },
+    ...getRequestMetadata(request),
+  })
+
+  const event = await getEventByCohort(cohort)
+  return NextResponse.json({ success: true, data: { event: event ? serialize(event) : null } })
+}
+
+/** PATCH — edit branding and/or move an event through its lifecycle. */
+export async function PATCH(request: NextRequest) {
+  const csrfError = withCsrfProtection(request)
+  if (csrfError) return csrfError
+
+  const parsed = patchSchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json(
+      { success: false, error: parsed.error.issues[0]?.message ?? "Invalid update" },
+      { status: 400 }
+    )
+  }
+  const cohort = validCohort(parsed.data.cohort)
+  if (!cohort) {
+    return NextResponse.json({ success: false, error: "Unknown event." }, { status: 400 })
+  }
+
+  const access = await checkEventAccess(cohort, "edit")
+  if (!access.authorized) return access.response
+  if (!access.event) {
+    return NextResponse.json({ success: false, error: "Unknown event." }, { status: 404 })
+  }
+
+  const rl = await rateLimit(request, {
+    maxRequests: 40,
+    windowInSeconds: 300,
+    identifier: () => `impact-lab-events:${access.user.id}`,
+  })
+  if (!rl.success) {
+    return NextResponse.json(
+      { success: false, error: "Too many requests. Wait a moment." },
+      { status: 429, headers: rl.headers }
+    )
+  }
+
+  const { status, name, titleLead, titleAccent, dates, location, formatNote, groundRules } =
+    parsed.data
+
+  if (status && status !== access.event.status) {
+    const verdict = canTransition(access.event.status, status, await eventHasParticipants(cohort))
+    if (!verdict.ok) {
+      return NextResponse.json({ success: false, error: verdict.reason }, { status: 400 })
+    }
+  }
+
+  // Passing `undefined` for an untouched field is deliberate, not an
+  // omission — Prisma drops undefined properties from the update, so this
+  // reads as "only the fields the caller sent" without a manual filter.
+  await prisma.impactLabEvent.update({
+    where: { cohort },
+    data: {
+      status,
+      name,
+      titleLead,
+      titleAccent,
+      dates,
+      location,
+      formatNote,
+      groundRules,
+    },
+  })
+
+  await logAudit({
+    userId: access.user.id,
+    userEmail: access.user.email,
+    action: "UPDATE",
+    entity: "ImpactLabEvent",
+    entityId: cohort,
+    changes: {
+      cohort,
+      ...(status && status !== access.event.status
+        ? { statusFrom: access.event.status, statusTo: status }
+        : {}),
+      updatedFields: Object.entries({
+        name,
+        titleLead,
+        titleAccent,
+        dates,
+        location,
+        formatNote,
+        groundRules,
+      })
+        .filter(([, v]) => v !== undefined)
+        .map(([k]) => k),
+    },
+    ...getRequestMetadata(request),
+  })
+
+  const event = await getEventByCohort(cohort)
+  return NextResponse.json({ success: true, data: { event: event ? serialize(event) : null } })
+}

--- a/src/app/api/admin/impact-lab/events/route.ts
+++ b/src/app/api/admin/impact-lab/events/route.ts
@@ -30,6 +30,29 @@ function serialize(event: EventRecord) {
   return { ...event, createdAt: event.createdAt.toISOString() }
 }
 
+/**
+ * This route can ship before `impact_lab_events` exists — GET already
+ * degrades (listEvents/organisations both catch missing-table), but a write
+ * cannot degrade, so it says what is missing instead of throwing a bare 500
+ * at an organiser who would have no way to interpret it. Same idiom as the
+ * rubric route's tableMissingResponse. Prisma reports a missing table as
+ * P2021.
+ */
+function tableMissingResponse(error: unknown): NextResponse | null {
+  const code = (error as { code?: unknown })?.code
+  if (code !== "P2021") return null
+  console.error("[impact-lab/events] impact_lab_events does not exist", error)
+  return NextResponse.json(
+    {
+      success: false,
+      error:
+        "The events table has not been created in this database yet. Apply migration 20260808200000_event_platform_tenancy, then try again.",
+      code: "EVENTS_TABLE_MISSING",
+    },
+    { status: 503 }
+  )
+}
+
 const createSchema = z.strictObject({
   organisationId: z.string().min(1),
   cohort: z.string(),
@@ -73,6 +96,16 @@ export async function GET() {
 
 /** POST — create a DRAFT event under an organisation. */
 export async function POST(request: NextRequest) {
+  try {
+    return await handlePost(request)
+  } catch (error) {
+    const missing = tableMissingResponse(error)
+    if (missing) return missing
+    throw error
+  }
+}
+
+async function handlePost(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 
@@ -164,6 +197,16 @@ export async function POST(request: NextRequest) {
 
 /** PATCH — edit branding and/or move an event through its lifecycle. */
 export async function PATCH(request: NextRequest) {
+  try {
+    return await handlePatch(request)
+  } catch (error) {
+    const missing = tableMissingResponse(error)
+    if (missing) return missing
+    throw error
+  }
+}
+
+async function handlePatch(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
   if (csrfError) return csrfError
 

--- a/src/app/api/admin/impact-lab/explain/route.ts
+++ b/src/app/api/admin/impact-lab/explain/route.ts
@@ -6,7 +6,7 @@ import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { runMatching, normalizeParticipants } from "@/lib/matching"
 import { explainWithAi } from "@/lib/matching/ai-explanations"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
     // Defaults are fine.
   }
 
-  const cohort = safeCohort(body.cohort)
+  const cohort = await resolveAdminCohort(body.cohort)
 
   let settings
   try {

--- a/src/app/api/admin/impact-lab/judging/assist/route.ts
+++ b/src/app/api/admin/impact-lab/judging/assist/route.ts
@@ -7,7 +7,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { readJudgeSession } from "@/lib/impact-lab/judge-access"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 
 /**
@@ -93,7 +93,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   // The criteria in the prompt must be the ones this cohort's judges are
   // actually filling in — observations against criteria that are not on their
   // sheet are worse than no observations, because they read as authoritative.

--- a/src/app/api/admin/impact-lab/judging/audit/route.ts
+++ b/src/app/api/admin/impact-lab/judging/audit/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { checkApiPermission } from "@/lib/rbac"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { scoreTotal, totalOutOf } from "@/lib/impact-lab/judging"
 import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "view")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   // Every total below is in this rubric's units, so the rubric travels with the
   // response — a mean of 48.3 is a different verdict out of 50 than out of 100.
   const rubric = await resolveRubric(cohort)

--- a/src/app/api/admin/impact-lab/judging/export/route.ts
+++ b/src/app/api/admin/impact-lab/judging/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { toCsv } from "@/lib/impact-lab/csv"
 import {
@@ -55,7 +55,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "view")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const rubric = await resolveRubric(cohort)
   const headers = headersFor(rubric)
 

--- a/src/app/api/admin/impact-lab/judging/preview/route.ts
+++ b/src/app/api/admin/impact-lab/judging/preview/route.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { standings, totalOutOf, type ScoreSheet } from "@/lib/impact-lab/judging"
 import { resolveRubric } from "@/lib/impact-lab/rubric-store"
@@ -49,7 +49,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(parsed.data.cohort)
+  const cohort = await resolveAdminCohort(parsed.data.cohort)
   // Both averages below are in this rubric's units, so it travels with them.
   const rubric = await resolveRubric(cohort)
   const rubricMeta = { rubricLabel: rubric.label, totalOutOf: totalOutOf(rubric) }

--- a/src/app/api/admin/impact-lab/judging/route.ts
+++ b/src/app/api/admin/impact-lab/judging/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { readJudgeSession } from "@/lib/impact-lab/judge-access"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   scoreTotal,
@@ -131,7 +131,7 @@ export async function GET(request: NextRequest) {
   const judge = await resolveJudge()
   if (!judge.ok) return judge.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   // `resolveRubric`, not `rubricForCohort`: an organiser-authored rubric for
   // this cohort overrides the code constant, and this response is where the
   // judging screen gets the criteria it renders. Falls back to the constant.
@@ -223,7 +223,7 @@ export async function POST(request: NextRequest) {
   // resolves to IS the validation: which criteria exist and what each one's
   // scale is. Validating first and looking up the rubric afterwards is how the
   // 1–5 ceiling came to reject a legitimate 10.
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const rubric = await resolveRubric(cohort)
 
   const parsed = buildScoreSchema(rubric).safeParse(

--- a/src/app/api/admin/impact-lab/judging/writeup/route.ts
+++ b/src/app/api/admin/impact-lab/judging/writeup/route.ts
@@ -6,7 +6,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   AFRETEC_RUBRIC,
@@ -205,7 +205,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
@@ -302,7 +302,7 @@ async function handlePost(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const rubric = await resolveRubric(cohort)
 
   const run = await prisma.impactLabMatchRun.findFirst({

--- a/src/app/api/admin/impact-lab/match/route.ts
+++ b/src/app/api/admin/impact-lab/match/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { runMatching } from "@/lib/matching"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
@@ -38,7 +38,7 @@ export async function POST(request: NextRequest) {
     // Empty body is fine — run with defaults.
   }
 
-  const cohort = safeCohort(body.cohort)
+  const cohort = await resolveAdminCohort(body.cohort)
 
   let settings
   try {

--- a/src/app/api/admin/impact-lab/notify/route.ts
+++ b/src/app/api/admin/impact-lab/notify/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { rateLimit } from "@/lib/rate-limit"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { impactLabAccountEmail, sendEmailBatch, type BatchEmailItem } from "@/lib/email"
 
 // A full-cohort blast is ~125 emails = 2 Resend batch calls; give the function
@@ -80,7 +80,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: "Validation failed" }, { status: 400 })
   }
 
-  const cohort = safeCohort(parsed.data.cohort)
+  const cohort = await resolveAdminCohort(parsed.data.cohort)
 
   const participants = await prisma.impactLabParticipant.findMany({
     where: { cohort },

--- a/src/app/api/admin/impact-lab/participants/export/route.ts
+++ b/src/app/api/admin/impact-lab/participants/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { toCsv } from "@/lib/impact-lab/csv"
 
 const HEADERS = [
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = safeCohort(searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(searchParams.get("cohort"))
 
   const participants = await prisma.impactLabParticipant.findMany({
     where: { cohort },

--- a/src/app/api/admin/impact-lab/participants/import/route.ts
+++ b/src/app/api/admin/impact-lab/participants/import/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit } from "@/lib/rate-limit"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
 
 // A large import must finish in one function invocation — give it headroom
@@ -60,7 +60,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(parsed.data.cohort)
+  const cohort = await resolveAdminCohort(parsed.data.cohort)
   const errors: { row: number; error: string }[] = []
 
   // Validate every row; dedupe by email (last occurrence wins) so a repeated

--- a/src/app/api/admin/impact-lab/participants/route.ts
+++ b/src/app/api/admin/impact-lab/participants/route.ts
@@ -3,7 +3,7 @@ import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { withCsrfProtection } from "@/lib/csrf"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { participantDraftSchema } from "@/lib/impact-lab/participant-schema"
 
 export async function GET(request: NextRequest) {
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = safeCohort(searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(searchParams.get("cohort"))
 
   const participants = await prisma.impactLabParticipant.findMany({
     where: { cohort },
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url)
-  const cohort = safeCohort(searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(searchParams.get("cohort"))
 
   const validation = participantDraftSchema.safeParse(body)
   if (!validation.success) {

--- a/src/app/api/admin/impact-lab/rematch/route.ts
+++ b/src/app/api/admin/impact-lab/rematch/route.ts
@@ -6,7 +6,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { computeRematch, type MatchResult } from "@/lib/matching"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { toRematchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
@@ -59,7 +59,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(validation.data.cohort)
+  const cohort = await resolveAdminCohort(validation.data.cohort)
   const write = validation.data.write === true
 
   const run = await prisma.impactLabMatchRun.findFirst({

--- a/src/app/api/admin/impact-lab/results/export/route.ts
+++ b/src/app/api/admin/impact-lab/results/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { ScoreSheet } from "@/lib/impact-lab/judging"
 import {
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const format = request.nextUrl.searchParams.get("format")
   if (format !== "xlsx" && format !== "pdf") {
     return NextResponse.json(

--- a/src/app/api/admin/impact-lab/results/notify/route.ts
+++ b/src/app/api/admin/impact-lab/results/notify/route.ts
@@ -5,7 +5,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { isResultsSnapshot } from "@/lib/impact-lab/results"
 import { loadTeamFeedback } from "@/lib/impact-lab/results-input"
@@ -103,7 +103,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
@@ -160,7 +160,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: "Invalid request body." }, { status: 400 })
   }
 
-  const cohort = safeCohort(parsed.data.cohort)
+  const cohort = await resolveAdminCohort(parsed.data.cohort)
   const run = await loadPublishedRun(cohort)
   if (!run.ok) {
     return NextResponse.json({ success: false, error: run.error }, { status: run.status })

--- a/src/app/api/admin/impact-lab/results/preview-email/route.ts
+++ b/src/app/api/admin/impact-lab/results/preview-email/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { checkApiPermission } from "@/lib/rbac"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { buildResultsInputFromRun, loadTeamFeedback } from "@/lib/impact-lab/results-input"
 import { buildSnapshot, isResultsSnapshot, type ResultsInput, type ResultsSnapshot } from "@/lib/impact-lab/results"
@@ -52,7 +52,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const teamId = (request.nextUrl.searchParams.get("teamId") ?? "").trim()
   if (teamId === "" || teamId.length > 64) {
     return NextResponse.json(

--- a/src/app/api/admin/impact-lab/results/publish/route.ts
+++ b/src/app/api/admin/impact-lab/results/publish/route.ts
@@ -5,7 +5,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { buildResultsInputFromRun } from "@/lib/impact-lab/results-input"
 import { buildSnapshot, type ResultsInput } from "@/lib/impact-lab/results"
 
@@ -46,7 +46,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(parsed.data.cohort)
+  const cohort = await resolveAdminCohort(parsed.data.cohort)
   const existing = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
     orderBy: { createdAt: "desc" },

--- a/src/app/api/admin/impact-lab/reviews/route.ts
+++ b/src/app/api/admin/impact-lab/reviews/route.ts
@@ -7,7 +7,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   JUDGING_CRITERIA,
@@ -269,7 +269,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const run = await loadFinalRun(cohort)
   if (!run) {
     return NextResponse.json({ success: true, data: { teams: [] } })
@@ -369,7 +369,7 @@ async function handlePost(request: NextRequest) {
   }
   const body = parsed.data
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const run = await loadFinalRun(cohort)
   if (!run) {
     return NextResponse.json(

--- a/src/app/api/admin/impact-lab/rubric/route.ts
+++ b/src/app/api/admin/impact-lab/rubric/route.ts
@@ -5,7 +5,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit } from "@/lib/rate-limit"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { rubricForCohort } from "@/lib/impact-lab/judging-rubrics"
 import {
   checkRubricDeletable,
@@ -67,7 +67,7 @@ export async function GET(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "view")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
 
   const [stored, state] = await Promise.all([loadRubric(cohort), rubricFreezeState(cohort)])
   const rubric = stored ?? rubricForCohort(cohort)
@@ -153,7 +153,7 @@ async function handlePut(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   const rubric = parsed.data
 
   const verdict = await checkRubricEditable(cohort, rubric)
@@ -242,7 +242,7 @@ async function handleDelete(request: NextRequest) {
   const check = await checkApiPermission("impact-lab", "edit")
   if (!check.authorized) return check.response
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
 
   const existing = await prisma.impactLabRubric.findUnique({
     where: { cohort },

--- a/src/app/api/admin/impact-lab/runs/route.ts
+++ b/src/app/api/admin/impact-lab/runs/route.ts
@@ -5,7 +5,7 @@ import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { runMatching, type MatchResult } from "@/lib/matching"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { toMatchParticipant } from "@/lib/impact-lab/mappers"
 import { resolveSettings } from "@/lib/impact-lab/settings"
 import { resultSignature } from "@/lib/impact-lab/signature"
@@ -113,7 +113,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = safeCohort(searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(searchParams.get("cohort"))
 
   // Only the fields the summary needs — skip the heavy participantsSnapshot and
   // settings JSONB (the list computes three numbers from `result`).
@@ -175,7 +175,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(validation.data.cohort)
+  const cohort = await resolveAdminCohort(validation.data.cohort)
 
   let settings
   try {

--- a/src/app/api/admin/impact-lab/submissions/export/route.ts
+++ b/src/app/api/admin/impact-lab/submissions/export/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { toCsv } from "@/lib/impact-lab/csv"
 import {
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = safeCohort(searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(searchParams.get("cohort"))
 
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },

--- a/src/app/api/admin/impact-lab/submissions/route.ts
+++ b/src/app/api/admin/impact-lab/submissions/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server"
 import { checkApiPermission } from "@/lib/rbac"
 import { prisma } from "@/lib/prisma"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { missingTeams } from "@/lib/impact-lab/submission-state"
 
@@ -14,7 +14,7 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const { searchParams } = new URL(request.url)
-  const cohort = safeCohort(searchParams.get("cohort"))
+  const cohort = await resolveAdminCohort(searchParams.get("cohort"))
 
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },

--- a/src/app/api/impact-lab/check-in/route.ts
+++ b/src/app/api/impact-lab/check-in/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()

--- a/src/app/api/impact-lab/check-in/route.ts
+++ b/src/app/api/impact-lab/check-in/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess } from "@/lib/impact-lab/member"
 
 /**
@@ -24,15 +25,30 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "No hackathon registration found for your account.",
+        code: "NOT_REGISTERED",
+      },
+      { status: 404 }
+    )
+  }
+
+  const closed = await guardClosedCohort(memberEvent.cohort)
+  if (closed) return closed
+
   const participant = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email: check.email } },
-    select: { id: true, checkedInAt: true },
+    where: { id: memberEvent.participantId },
+    select: { checkedInAt: true },
   })
   if (!participant) {
     return NextResponse.json(
@@ -49,7 +65,7 @@ export async function POST(request: NextRequest) {
     participant.checkedInAt ??
     (
       await prisma.impactLabParticipant.update({
-        where: { id: participant.id },
+        where: { id: memberEvent.participantId },
         data: { checkedInAt: new Date(), checkedInBy: "self" },
         select: { checkedInAt: true },
       })

--- a/src/app/api/impact-lab/judge-events/route.ts
+++ b/src/app/api/impact-lab/judge-events/route.ts
@@ -3,7 +3,7 @@ import { prisma } from "@/lib/prisma"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { readJudgeSession } from "@/lib/impact-lab/judge-access"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { listEvents } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { totalOutOf } from "@/lib/impact-lab/judging"
 import { resolveRubric } from "@/lib/impact-lab/rubric-store"
@@ -85,11 +85,28 @@ export async function GET(request: NextRequest) {
 
   const open = [...latestByCohort.values()].filter((r) => r.judgingClosedAt === null)
 
+  const tenantEvents = await listEvents()
+  const eventByCohort = new Map(tenantEvents.map((e) => [e.cohort, e]))
+
+  // Visibility: once the tenancy table is populated, a run only reaches a
+  // judge if its cohort has a tenancy record that is neither DRAFT (not open
+  // yet) nor ARCHIVED (wrapped) — a run without any matching event is orphaned
+  // and should not surface either. Pre-migration, `tenantEvents` is empty
+  // because the table doesn't exist yet, so nothing is filtered: every open
+  // run stays visible, the same as before this table existed.
+  const visible =
+    tenantEvents.length === 0
+      ? open
+      : open.filter((r) => {
+          const event = eventByCohort.get(r.cohort)
+          return event !== undefined && event.status !== "DRAFT" && event.status !== "ARCHIVED"
+        })
+
   // `resolveRubric` rather than the code constant, so the name and denominator
   // a judge picks by are the same ones the scoring screen will show them. One
   // lookup per open event, in parallel — there are a handful, not hundreds.
   const events: JudgeEvent[] = await Promise.all(
-    open.map(async (run) => {
+    visible.map(async (run) => {
       const rubric = await resolveRubric(run.cohort)
       return {
         cohort: run.cohort,
@@ -103,15 +120,22 @@ export async function GET(request: NextRequest) {
     })
   )
 
-  // The live event first — at a single-event hackathon the judge should never
-  // have to choose. Everything else stays newest first, which is the order the
-  // runs already arrived in. Partitioned rather than sorted with a comparator
-  // that returns 0 for every other pair, which would leave the rest of the
-  // ordering resting on sort stability.
-  const ordered = [
-    ...events.filter((e) => e.cohort === CURRENT_COHORT),
-    ...events.filter((e) => e.cohort !== CURRENT_COHORT),
-  ]
+  // The LIVE event(s) first — at a single-event hackathon the judge should
+  // never have to choose. Everything else stays newest first, which is the
+  // order the runs already arrived in. Partitioned rather than sorted with a
+  // comparator that returns 0 for every other pair, which would leave the
+  // rest of the ordering resting on sort stability. Pre-migration there is no
+  // tenancy status to partition on, so the newest-first order is left as-is.
+  const liveCohorts = new Set(
+    tenantEvents.filter((e) => e.status === "LIVE").map((e) => e.cohort)
+  )
+  const ordered =
+    tenantEvents.length === 0
+      ? events
+      : [
+          ...events.filter((e) => liveCohorts.has(e.cohort)),
+          ...events.filter((e) => !liveCohorts.has(e.cohort)),
+        ]
 
   return NextResponse.json(
     { success: true, events: ordered },

--- a/src/app/api/impact-lab/pitch-timer/route.ts
+++ b/src/app/api/impact-lab/pitch-timer/route.ts
@@ -4,7 +4,8 @@ import { withCsrfProtection } from "@/lib/csrf"
 import { checkApiPermission } from "@/lib/rbac"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { readJudgeSession } from "@/lib/impact-lab/judge-access"
-import { safeCohort } from "@/lib/impact-lab/constants"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { defaultAdminCohort } from "@/lib/impact-lab/event-store"
 import {
   DEFAULT_SECONDS,
   isValidSeconds,
@@ -69,7 +70,7 @@ export async function GET(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = validCohort(request.nextUrl.searchParams.get("cohort")) ?? (await defaultAdminCohort())
   const timer = await loadPitchTimer(cohort)
 
   return NextResponse.json({ success: true, timer }, { headers: rl.headers })
@@ -112,7 +113,7 @@ async function handlePost(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = validCohort(request.nextUrl.searchParams.get("cohort")) ?? (await defaultAdminCohort())
   const startedAt = new Date()
 
   // Upsert, not create: restarting while one is already running for this
@@ -163,7 +164,7 @@ async function handleDelete(request: NextRequest) {
     )
   }
 
-  const cohort = safeCohort(request.nextUrl.searchParams.get("cohort"))
+  const cohort = validCohort(request.nextUrl.searchParams.get("cohort")) ?? (await defaultAdminCohort())
   // deleteMany rather than delete: stopping a timer that already finished (or
   // was never started) is a no-op, not a 404 a judge has to interpret.
   await prisma.impactLabPitchTimer.deleteMany({ where: { cohort } })

--- a/src/app/api/impact-lab/profile/route.ts
+++ b/src/app/api/impact-lab/profile/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { openRegistrationEvent, resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import {
   checkMemberAccess,
   memberProfileSchema,
@@ -11,18 +12,27 @@ import {
 } from "@/lib/impact-lab/member"
 
 /**
- * A member's own hackathon matching profile for the active cohort, matched by
- * session email. GET/PUT operate on a row the admin Luma import created; POST
- * lets a signed-in member create that row themselves when no import exists —
- * see the POST doc below for why that's safe to open up.
+ * A member's own hackathon matching profile for their event, matched by
+ * session email. GET/PUT operate on a row the admin Luma import created (or
+ * a self-registration created); POST lets a signed-in member create that row
+ * themselves when no import exists — see the POST doc below for why that's
+ * safe to open up.
  */
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
+    return NextResponse.json({ success: true, registered: false })
+  }
+
   const row = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email: check.email } },
+    where: { id: memberEvent.participantId },
   })
   if (!row) {
     return NextResponse.json({ success: true, registered: false })
@@ -32,6 +42,8 @@ export async function GET() {
     success: true,
     registered: true,
     profile: toMemberProfile(row),
+    eventName: memberEvent.name,
+    eventCohort: memberEvent.cohort,
   })
 }
 
@@ -47,11 +59,26 @@ export async function PUT(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
+
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
+    return NextResponse.json(
+      {
+        success: false,
+        registered: false,
+        error: "No hackathon registration found for this account.",
+      },
+      { status: 404 }
+    )
+  }
+
+  const closed = await guardClosedCohort(memberEvent.cohort)
+  if (closed) return closed
 
   let body: unknown
   try {
@@ -69,24 +96,8 @@ export async function PUT(request: NextRequest) {
     )
   }
 
-  const where = { cohort_email: { cohort: CURRENT_COHORT, email: check.email } }
-  const existing = await prisma.impactLabParticipant.findUnique({
-    where,
-    select: { id: true },
-  })
-  if (!existing) {
-    return NextResponse.json(
-      {
-        success: false,
-        registered: false,
-        error: "No hackathon registration found for this account.",
-      },
-      { status: 404 }
-    )
-  }
-
   const updated = await prisma.impactLabParticipant.update({
-    where,
+    where: { id: memberEvent.participantId },
     data: parsed.data,
   })
 
@@ -98,15 +109,17 @@ export async function PUT(request: NextRequest) {
 }
 
 /**
- * Self-registration: a signed-in, verified member with no participant row for
- * the active cohort creates one for themselves. Until now, the admin Luma
- * import was the only allowlist into ImpactLabParticipant — this opens that
- * door to anyone who can sign in. That's contained two ways: being a
- * participant grants nothing by itself — a team leader still has to find and
- * add you via /api/impact-lab/team/search before you're on a team — and the
- * door only exists while a cohort is live. guardClosedCohort below is the
- * whole safety story; once IMPACT_LAB_ACTIVE_COHORT is unset this 403s like
- * every other member write.
+ * Self-registration: a signed-in, verified member with no participant row in
+ * any visible event creates one for the event currently open for
+ * registration — the newest LIVE event, per `openRegistrationEvent`. Until
+ * now, the admin Luma import was the only allowlist into
+ * ImpactLabParticipant — this opens that door to anyone who can sign in.
+ * That's contained two ways: being a participant grants nothing by itself —
+ * a team leader still has to find and add you via
+ * /api/impact-lab/team/search before you're on a team — and the door only
+ * exists while an event is LIVE. `openRegistrationEvent` finding nothing (or
+ * `guardClosedCohort` catching a race right before the write) is the whole
+ * safety story; once nothing is LIVE this 403s like every other member write.
  *
  * Re-submits (double-click, retry after a flaky network) must not 500 or
  * duplicate a row: a plain find-then-create has a race window, so on a
@@ -125,11 +138,19 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
+
+  const openEvent = await openRegistrationEvent()
+  if (!openEvent) {
+    return NextResponse.json(
+      { success: false, error: "There is no hackathon open for registration right now." },
+      { status: 403 }
+    )
+  }
+
+  const closed = await guardClosedCohort(openEvent.cohort)
+  if (closed) return closed
 
   let body: unknown
   try {
@@ -147,7 +168,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const where = { cohort_email: { cohort: CURRENT_COHORT, email: check.email } }
+  const where = { cohort_email: { cohort: openEvent.cohort, email: check.email } }
 
   const existing = await prisma.impactLabParticipant.findUnique({ where })
   if (existing) {
@@ -163,7 +184,7 @@ export async function POST(request: NextRequest) {
     // email comes from the verified session, never the body — nothing here
     // lets a caller register someone else's address.
     created = await prisma.impactLabParticipant.create({
-      data: { ...parsed.data, cohort: CURRENT_COHORT, email: check.email },
+      data: { ...parsed.data, cohort: openEvent.cohort, email: check.email },
     })
   } catch (error) {
     if ((error as { code?: string }).code === "P2002") {

--- a/src/app/api/impact-lab/profile/route.ts
+++ b/src/app/api/impact-lab/profile/route.ts
@@ -47,7 +47,7 @@ export async function PUT(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()
@@ -125,7 +125,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   buildMemberPayload,
@@ -20,6 +21,13 @@ import { presentableJudgeNote, publishableReview } from "@/lib/impact-lab/review
  * (`@/lib/impact-lab/results`), not assembled here, so the privacy properties
  * can be asserted directly against that function rather than trusted of this
  * route's wiring.
+ *
+ * A caller who is not a participant in any visible event resolves to no
+ * event at all, which reads the same as "not published yet" — there is
+ * nothing to check publication against. A caller who IS a participant but was
+ * never placed on a team (`viewerTeamId` stays null) still sees the public
+ * overall results, just without a `yourTeam` card — the route's existing
+ * behaviour for someone with no resolvable team.
  */
 export async function GET(request: NextRequest) {
   const rl = await rateLimit(request, RateLimits.READ)
@@ -33,30 +41,35 @@ export async function GET(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
+    return NextResponse.json({ success: true, published: false })
+  }
+
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: CURRENT_COHORT, isFinal: true },
+    where: { cohort: memberEvent.cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { id: true, result: true, resultsPublishedAt: true, resultsSnapshot: true },
   })
 
   // Never leak an unpublished snapshot — including its mere existence.
   if (!run?.resultsPublishedAt || !run.resultsSnapshot) {
-    return NextResponse.json({ success: true, published: false })
+    return NextResponse.json({
+      success: true,
+      published: false,
+      eventName: memberEvent.name,
+      eventCohort: memberEvent.cohort,
+    })
   }
 
   const snapshot = run.resultsSnapshot as unknown as ResultsSnapshot
 
-  const participant = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email: check.email } },
-    select: { id: true },
-  })
-
-  let viewerTeamId: string | null = null
-  if (participant) {
-    const teams = extractFrozenTeams(run.result)
-    const team = teams?.find((t) => t.memberIds.includes(participant.id))
-    viewerTeamId = team?.id ?? null
-  }
+  const teams = extractFrozenTeams(run.result)
+  const team = teams?.find((t) => t.memberIds.includes(memberEvent.participantId))
+  const viewerTeamId = team?.id ?? null
 
   // Written feedback for the viewer's own team only — queried by teamId, so
   // no other team's words are ever even loaded. Two separate streams with
@@ -86,5 +99,9 @@ export async function GET(request: NextRequest) {
     feedback = { judgeNotes, review: publishableReview(reviewRow) }
   }
 
-  return NextResponse.json(buildMemberPayload(snapshot, viewerTeamId, feedback))
+  return NextResponse.json({
+    ...buildMemberPayload(snapshot, viewerTeamId, feedback),
+    eventName: memberEvent.name,
+    eventCohort: memberEvent.cohort,
+  })
 }

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -1,8 +1,9 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
+import { DEFAULT_COHORT } from "@/lib/impact-lab/constants"
 import { validCohort } from "@/lib/impact-lab/event-lifecycle"
-import { resolveMemberEvent } from "@/lib/impact-lab/event-store"
+import { listEvents, resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   buildMemberPayload,
@@ -12,7 +13,8 @@ import {
 import { presentableJudgeNote, publishableReview } from "@/lib/impact-lab/reviews"
 
 /**
- * The published result, for one participant.
+ * The published result, for one participant — or, published results being
+ * member-visible in general, for any signed-in verified member.
  *
  * `perTeam` holds every team's private card, so the whole map must never reach
  * the client — only the caller's own entry is attached. Judge counts and judge
@@ -22,11 +24,15 @@ import { presentableJudgeNote, publishableReview } from "@/lib/impact-lab/review
  * can be asserted directly against that function rather than trusted of this
  * route's wiring.
  *
- * A caller who is not a participant in any visible event resolves to no
- * event at all, which reads the same as "not published yet" — there is
- * nothing to check publication against. A caller who IS a participant but was
- * never placed on a team (`viewerTeamId` stays null) still sees the public
- * overall results, just without a `yourTeam` card — the route's existing
+ * A caller who is a participant in some visible event checks publication
+ * against their own event, same as every other member route. A caller who is
+ * NOT a participant anywhere still gets a display event to check against —
+ * the requested `?cohort=`, or the newest visible one — because published
+ * results were always visible to any member, participant or not; multi-event
+ * only adds the question of which event's results to show. Either way,
+ * `viewerTeamId` stays null for a caller with no resolvable team (no
+ * participant row, or a participant row not on any team), which reads the
+ * same public overall results with no `yourTeam` card — the route's existing
  * behaviour for someone with no resolvable team.
  */
 export async function GET(request: NextRequest) {
@@ -41,34 +47,54 @@ export async function GET(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const memberEvent = await resolveMemberEvent(
-    check.email,
-    validCohort(new URL(request.url).searchParams.get("cohort"))
-  )
-  if (!memberEvent) {
-    return NextResponse.json({ success: true, published: false })
+  const requestedCohort = validCohort(new URL(request.url).searchParams.get("cohort"))
+  const memberEvent = await resolveMemberEvent(check.email, requestedCohort)
+
+  // The event to check publication against, and its name for the response —
+  // the caller's own event when they're a participant somewhere, else the
+  // requested (if visible) or newest visible event, so a non-participant
+  // member can still read the published leaderboard.
+  let displayCohort: string
+  let displayName: string | undefined
+  if (memberEvent) {
+    displayCohort = memberEvent.cohort
+    displayName = memberEvent.name
+  } else {
+    const events = await listEvents()
+    const visible = events.filter((e) => e.status === "LIVE" || e.status === "CLOSED")
+    const requestedMatch = requestedCohort
+      ? visible.find((e) => e.cohort === requestedCohort)
+      : undefined
+    const display = requestedMatch ?? visible[0]
+    displayCohort = display?.cohort ?? DEFAULT_COHORT
+    displayName = display?.name
   }
 
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: memberEvent.cohort, isFinal: true },
+    where: { cohort: displayCohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { id: true, result: true, resultsPublishedAt: true, resultsSnapshot: true },
   })
 
   // Never leak an unpublished snapshot — including its mere existence.
+  // eventName falls back to the raw slug rather than being omitted — same
+  // "ugly but never wrong" convention CURRENT_COHORT_LABEL used — so this
+  // branch and the published one below always agree on the shape.
   if (!run?.resultsPublishedAt || !run.resultsSnapshot) {
     return NextResponse.json({
       success: true,
       published: false,
-      eventName: memberEvent.name,
-      eventCohort: memberEvent.cohort,
+      eventName: displayName ?? displayCohort,
+      eventCohort: displayCohort,
     })
   }
 
   const snapshot = run.resultsSnapshot as unknown as ResultsSnapshot
 
   const teams = extractFrozenTeams(run.result)
-  const team = teams?.find((t) => t.memberIds.includes(memberEvent.participantId))
+  const team = memberEvent
+    ? teams?.find((t) => t.memberIds.includes(memberEvent.participantId))
+    : undefined
   const viewerTeamId = team?.id ?? null
 
   // Written feedback for the viewer's own team only — queried by teamId, so
@@ -101,7 +127,7 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     ...buildMemberPayload(snapshot, viewerTeamId, feedback),
-    eventName: memberEvent.name,
-    eventCohort: memberEvent.cohort,
+    eventName: displayName ?? displayCohort,
+    eventCohort: displayCohort,
   })
 }

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -78,8 +78,8 @@ export async function GET(request: NextRequest) {
 
   // Never leak an unpublished snapshot — including its mere existence.
   // eventName falls back to the raw slug rather than being omitted — same
-  // "ugly but never wrong" convention CURRENT_COHORT_LABEL used — so this
-  // branch and the published one below always agree on the shape.
+  // "ugly but never wrong" convention the old cohort-label constant used —
+  // so this branch and the published one below always agree on the shape.
   if (!run?.resultsPublishedAt || !run.resultsSnapshot) {
     return NextResponse.json({
       success: true,

--- a/src/app/api/impact-lab/submission/route.ts
+++ b/src/app/api/impact-lab/submission/route.ts
@@ -143,7 +143,7 @@ export async function PUT(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()

--- a/src/app/api/impact-lab/submission/route.ts
+++ b/src/app/api/impact-lab/submission/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent, type MemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   submissionInputSchema,
@@ -49,16 +50,10 @@ const SUBMISSION_FIELD_LABELS: Readonly<Record<string, string>> = {
   screenshotUrl: "Screenshot link",
 }
 
-/** Resolve the caller to a team in the cohort's final run, or null. */
-async function resolveContext(email: string): Promise<ResolvedContext | null> {
-  const participant = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email } },
-    select: { id: true },
-  })
-  if (!participant) return null
-
+/** Resolve the caller's team in their event's final run, or null. */
+async function resolveContext(memberEvent: MemberEvent): Promise<ResolvedContext | null> {
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: CURRENT_COHORT, isFinal: true },
+    where: { cohort: memberEvent.cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { id: true, result: true, submissionsCloseAt: true },
   })
@@ -67,11 +62,11 @@ async function resolveContext(email: string): Promise<ResolvedContext | null> {
   const teams = extractFrozenTeams(run.result)
   if (!teams) return null
 
-  const teamRef = findTeamFor(teams, participant.id)
+  const teamRef = findTeamFor(teams, memberEvent.participantId)
   if (!teamRef) return null
 
   return {
-    participantId: participant.id,
+    participantId: memberEvent.participantId,
     runId: run.id,
     teamId: teamRef.teamId,
     teamName: teamRef.teamName,
@@ -80,15 +75,15 @@ async function resolveContext(email: string): Promise<ResolvedContext | null> {
 }
 
 /** Display name for whoever last edited, falling back to the email's local part. */
-async function lastEditedName(email: string): Promise<string> {
+async function lastEditedName(email: string, cohort: string): Promise<string> {
   const row = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email } },
+    where: { cohort_email: { cohort, email } },
     select: { fullName: true },
   })
   return row?.fullName ?? email.split("@")[0]
 }
 
-async function toView(row: ImpactLabSubmission): Promise<SubmissionView> {
+async function toView(row: ImpactLabSubmission, cohort: string): Promise<SubmissionView> {
   return {
     projectName: row.projectName,
     pitch: row.pitch,
@@ -102,18 +97,26 @@ async function toView(row: ImpactLabSubmission): Promise<SubmissionView> {
     videoUrl: row.videoUrl,
     slidesUrl: row.slidesUrl,
     screenshotUrl: row.screenshotUrl,
-    lastEditedByName: await lastEditedName(row.lastEditedByEmail),
+    lastEditedByName: await lastEditedName(row.lastEditedByEmail, cohort),
     updatedAt: row.updatedAt.toISOString(),
   }
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const context = await resolveContext(check.email)
-  if (!context) {
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
     return NextResponse.json({ success: true, status: "no_team" })
+  }
+
+  const context = await resolveContext(memberEvent)
+  if (!context) {
+    return NextResponse.json({ success: true, status: "no_team", eventName: memberEvent.name })
   }
 
   const existing = await prisma.impactLabSubmission.findUnique({
@@ -124,8 +127,10 @@ export async function GET() {
     success: true,
     status: submissionWindow(context.closeAt, new Date()),
     teamName: context.teamName,
+    eventName: memberEvent.name,
+    eventCohort: memberEvent.cohort,
     closeAt: context.closeAt ? context.closeAt.toISOString() : null,
-    submission: existing ? await toView(existing) : undefined,
+    submission: existing ? await toView(existing, memberEvent.cohort) : undefined,
   })
 }
 
@@ -143,13 +148,28 @@ export async function PUT(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const context = await resolveContext(check.email)
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: "You are not on a team yet — please speak to an organiser.",
+        code: "NO_TEAM",
+      },
+      { status: 403 }
+    )
+  }
+
+  const closed = await guardClosedCohort(memberEvent.cohort)
+  if (closed) return closed
+
+  const context = await resolveContext(memberEvent)
   if (!context) {
     return NextResponse.json(
       {
@@ -204,7 +224,7 @@ export async function PUT(request: NextRequest) {
     where: { runId_teamId: { runId: context.runId, teamId: context.teamId } },
     create: {
       ...parsed.data,
-      cohort: CURRENT_COHORT,
+      cohort: memberEvent.cohort,
       runId: context.runId,
       teamId: context.teamId,
       teamName: context.teamName,
@@ -217,5 +237,5 @@ export async function PUT(request: NextRequest) {
     },
   })
 
-  return NextResponse.json({ success: true, submission: await toView(saved) })
+  return NextResponse.json({ success: true, submission: await toView(saved, memberEvent.cohort) })
 }

--- a/src/app/api/impact-lab/team/leader/route.ts
+++ b/src/app/api/impact-lab/team/leader/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { Team } from "@/lib/matching"
 
@@ -32,25 +33,25 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const participant = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email: check.email } },
-    select: { id: true, fullName: true },
-  })
-  if (!participant) {
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
     return NextResponse.json(
       { success: false, error: "No hackathon registration found for your account.", code: "NO_TEAM" },
       { status: 403 }
     )
   }
 
+  const closed = await guardClosedCohort(memberEvent.cohort)
+  if (closed) return closed
+
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: CURRENT_COHORT, isFinal: true },
+    where: { cohort: memberEvent.cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { id: true },
   })
@@ -74,11 +75,11 @@ export async function POST(request: NextRequest) {
     const teams = extractFrozenTeams(fresh?.result)
     if (!teams) return null
 
-    const mine = teams.find((t) => t.memberIds.includes(participant.id))
+    const mine = teams.find((t) => t.memberIds.includes(memberEvent.participantId))
     if (!mine) return null
 
     const next: (Team & { leaderId?: string })[] = teams.map((t) =>
-      t.id === mine.id ? { ...t, leaderId: participant.id } : t
+      t.id === mine.id ? { ...t, leaderId: memberEvent.participantId } : t
     )
 
     await tx.impactLabMatchRun.update({
@@ -99,8 +100,13 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  const participant = await prisma.impactLabParticipant.findUnique({
+    where: { id: memberEvent.participantId },
+    select: { fullName: true },
+  })
+
   return NextResponse.json({
     success: true,
-    message: `${participant.fullName} is now the team leader.`,
+    message: `${participant?.fullName ?? check.email.split("@")[0]} is now the team leader.`,
   })
 }

--- a/src/app/api/impact-lab/team/leader/route.ts
+++ b/src/app/api/impact-lab/team/leader/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()

--- a/src/app/api/impact-lab/team/roster/route.ts
+++ b/src/app/api/impact-lab/team/roster/route.ts
@@ -3,8 +3,9 @@ import { z } from "zod"
 import { prisma } from "@/lib/prisma"
 import { withCsrfProtection } from "@/lib/csrf"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
 import { guardClosedCohort } from "@/lib/impact-lab/cohort-guard"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent, type MemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { Team } from "@/lib/matching"
 import type { Prisma } from "@/generated/prisma/client"
@@ -42,15 +43,9 @@ interface Resolved {
   meId: string
 }
 
-async function resolveCaller(email: string): Promise<Resolved | null> {
-  const participant = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email } },
-    select: { id: true },
-  })
-  if (!participant) return null
-
+async function resolveCaller(memberEvent: MemberEvent): Promise<Resolved | null> {
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: CURRENT_COHORT, isFinal: true },
+    where: { cohort: memberEvent.cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { id: true, result: true },
   })
@@ -59,10 +54,10 @@ async function resolveCaller(email: string): Promise<Resolved | null> {
   const teams = extractFrozenTeams(run.result)
   if (!teams) return null
 
-  const myTeamIndex = teams.findIndex((t) => t.memberIds.includes(participant.id))
+  const myTeamIndex = teams.findIndex((t) => t.memberIds.includes(memberEvent.participantId))
   if (myTeamIndex < 0) return null
 
-  return { runId: run.id, teams, myTeamIndex, meId: participant.id }
+  return { runId: run.id, teams, myTeamIndex, meId: memberEvent.participantId }
 }
 
 function noTeam(): NextResponse {
@@ -112,10 +107,10 @@ async function writeTeams(runId: string, mutate: (teams: Team[]) => Team[] | nul
  * blocks on the run-row lock until the first commits, then finds the row the
  * first one already created.
  */
-function resolveParticipant(participantId: string): TargetResolver {
+function resolveParticipant(participantId: string, cohort: string): TargetResolver {
   return (tx) =>
     tx.impactLabParticipant.findFirst({
-      where: { id: participantId, cohort: CURRENT_COHORT },
+      where: { id: participantId, cohort },
       select: { id: true, fullName: true },
     })
 }
@@ -128,7 +123,7 @@ function resolveParticipant(participantId: string): TargetResolver {
  * they didn't opt in — they're only here because a teammate is vouching for
  * them being in the room.
  */
-function resolveOrCreateParticipant(userId: string): TargetResolver {
+function resolveOrCreateParticipant(userId: string, cohort: string): TargetResolver {
   return async (tx) => {
     const user = await tx.user.findUnique({
       where: { id: userId },
@@ -137,7 +132,7 @@ function resolveOrCreateParticipant(userId: string): TargetResolver {
     if (!user) return null
 
     const email = user.email.toLowerCase()
-    const where = { cohort_email: { cohort: CURRENT_COHORT, email } }
+    const where = { cohort_email: { cohort, email } }
 
     const existing = await tx.impactLabParticipant.findUnique({
       where,
@@ -147,7 +142,7 @@ function resolveOrCreateParticipant(userId: string): TargetResolver {
 
     return tx.impactLabParticipant.create({
       data: {
-        cohort: CURRENT_COHORT,
+        cohort,
         email,
         fullName: `${user.firstName} ${user.lastName}`.trim(),
         primaryRole: "Team member",
@@ -220,11 +215,17 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
+
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) return noTeam()
+
+  const closed = await guardClosedCohort(memberEvent.cohort)
+  if (closed) return closed
 
   const parsed = addBodySchema.safeParse(await request.json().catch(() => null))
   if (!parsed.success) {
@@ -234,14 +235,14 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const me = await resolveCaller(check.email)
+  const me = await resolveCaller(memberEvent)
   if (!me) return noTeam()
 
   const myTeamId = me.teams[me.myTeamIndex].id
   const resolveTarget =
     "participantId" in parsed.data
-      ? resolveParticipant(parsed.data.participantId)
-      : resolveOrCreateParticipant(parsed.data.userId)
+      ? resolveParticipant(parsed.data.participantId, memberEvent.cohort)
+      : resolveOrCreateParticipant(parsed.data.userId, memberEvent.cohort)
 
   const outcome = await addToTeam(me.runId, myTeamId, resolveTarget)
 
@@ -273,11 +274,17 @@ export async function DELETE(request: NextRequest) {
     )
   }
 
-  const closed = await guardClosedCohort(CURRENT_COHORT)
-  if (closed) return closed
-
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
+
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) return noTeam()
+
+  const closed = await guardClosedCohort(memberEvent.cohort)
+  if (closed) return closed
 
   const parsed = bodySchema.safeParse(await request.json().catch(() => null))
   if (!parsed.success) {
@@ -287,7 +294,7 @@ export async function DELETE(request: NextRequest) {
     )
   }
 
-  const me = await resolveCaller(check.email)
+  const me = await resolveCaller(memberEvent)
   if (!me) return noTeam()
 
   // Removing yourself would drop you out of the only team you can still edit,

--- a/src/app/api/impact-lab/team/roster/route.ts
+++ b/src/app/api/impact-lab/team/roster/route.ts
@@ -220,7 +220,7 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()
@@ -273,7 +273,7 @@ export async function DELETE(request: NextRequest) {
     )
   }
 
-  const closed = guardClosedCohort(CURRENT_COHORT)
+  const closed = await guardClosedCohort(CURRENT_COHORT)
   if (closed) return closed
 
   const check = await checkMemberAccess()

--- a/src/app/api/impact-lab/team/route.ts
+++ b/src/app/api/impact-lab/team/route.ts
@@ -1,6 +1,7 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import {
   checkMemberAccess,
   extractFrozenTeams,
@@ -45,39 +46,54 @@ function withoutPercentages(strengths: string[]): string[] {
 }
 
 /**
- * The caller's finalized team for the active cohort, read from the frozen run
- * JSON. Returns no team scores, and teammate emails only where that teammate's
- * LIVE row has consentToShareContact = true (latest consent wins — same rule
- * as the admin CSV export).
+ * The caller's finalized team for their event, read from the frozen run JSON.
+ * Returns no team scores, and teammate emails only where that teammate's LIVE
+ * row has consentToShareContact = true (latest consent wins — same rule as
+ * the admin CSV export).
  */
-export async function GET() {
+export async function GET(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const participant = await prisma.impactLabParticipant.findUnique({
-    where: { cohort_email: { cohort: CURRENT_COHORT, email: check.email } },
-    select: { id: true },
-  })
-  if (!participant) {
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(new URL(request.url).searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
     return NextResponse.json({ success: true, status: "not_registered" })
   }
 
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: CURRENT_COHORT, isFinal: true },
+    where: { cohort: memberEvent.cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
   })
   if (!run) {
-    return NextResponse.json({ success: true, status: "pending" })
+    return NextResponse.json({
+      success: true,
+      status: "pending",
+      eventName: memberEvent.name,
+      eventCohort: memberEvent.cohort,
+    })
   }
 
   // Frozen JSON, not schema-enforced — a malformed run degrades to pending.
   const teams = extractFrozenTeams(run.result)
   if (!teams) {
-    return NextResponse.json({ success: true, status: "pending" })
+    return NextResponse.json({
+      success: true,
+      status: "pending",
+      eventName: memberEvent.name,
+      eventCohort: memberEvent.cohort,
+    })
   }
-  const team = teams.find((t) => t.memberIds.includes(participant.id))
+  const team = teams.find((t) => t.memberIds.includes(memberEvent.participantId))
   if (!team) {
-    return NextResponse.json({ success: true, status: "unassigned" })
+    return NextResponse.json({
+      success: true,
+      status: "unassigned",
+      eventName: memberEvent.name,
+      eventCohort: memberEvent.cohort,
+    })
   }
 
   // The snapshot holds every cohort email plus blockedTeammates — never return
@@ -99,14 +115,14 @@ export async function GET() {
     storedExplanationFor(run.explanations, team.id) ?? explainTeam(team, members)
 
   const live = await prisma.impactLabParticipant.findMany({
-    where: { cohort: CURRENT_COHORT, id: { in: team.memberIds } },
+    where: { cohort: memberEvent.cohort, id: { in: team.memberIds } },
   })
   const liveById = new Map(live.map((p) => [p.id, p]))
 
   const memberViews: TeamMemberView[] = team.memberIds.map((id) => {
     const liveP = liveById.get(id)
     const snap = snapshotById.get(id)
-    const isSelf = id === participant.id
+    const isSelf = id === memberEvent.participantId
     const shareEmail = isSelf || Boolean(liveP?.consentToShareContact)
     return {
       id,
@@ -130,5 +146,11 @@ export async function GET() {
     projectDirection: explanation.suggestedProjectDirection ?? null,
   }
 
-  return NextResponse.json({ success: true, status: "revealed", team: teamView })
+  return NextResponse.json({
+    success: true,
+    status: "revealed",
+    team: teamView,
+    eventName: memberEvent.name,
+    eventCohort: memberEvent.cohort,
+  })
 }

--- a/src/app/api/impact-lab/team/search/route.ts
+++ b/src/app/api/impact-lab/team/search/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server"
 import { prisma } from "@/lib/prisma"
 import { rateLimit, RateLimits } from "@/lib/rate-limit"
-import { CURRENT_COHORT } from "@/lib/impact-lab/constants"
+import { validCohort } from "@/lib/impact-lab/event-lifecycle"
+import { resolveMemberEvent } from "@/lib/impact-lab/event-store"
 import { checkMemberAccess, extractFrozenTeams } from "@/lib/impact-lab/member"
 
 // One letter would return most of the cohort and turn a teammate lookup into
@@ -12,13 +13,13 @@ const ACCOUNT_MIN_QUERY_LENGTH = 3
 const RESULT_CAP = 10
 
 /**
- * Search the cohort so a team can find the person sitting with them.
+ * Search the caller's event so a team can find the person sitting with them.
  *
  * Registration only captured team leaders, so members who since signed up
  * on the site have no `ImpactLabParticipant` row yet and would otherwise be
  * invisible to their leader. Alongside the existing cohort search, this also
- * matches site accounts (`User`) with no participant row for the current
- * cohort — those come back as `kind: "account"` so the UI can label them as
+ * matches site accounts (`User`) with no participant row for the caller's
+ * event — those come back as `kind: "account"` so the UI can label them as
  * "not on the roster yet" before a leader adds them.
  *
  * Returns names only, never emails or phone numbers — this is a lookup for
@@ -38,20 +39,33 @@ export async function GET(request: NextRequest) {
   const check = await checkMemberAccess()
   if (!check.authorized) return check.response
 
-  const q = (request.nextUrl.searchParams.get("q") ?? "").trim()
-  if (q.length < PARTICIPANT_MIN_QUERY_LENGTH) {
+  const memberEvent = await resolveMemberEvent(
+    check.email,
+    validCohort(request.nextUrl.searchParams.get("cohort"))
+  )
+  if (!memberEvent) {
     return NextResponse.json({ success: true, results: [] })
   }
 
+  const q = (request.nextUrl.searchParams.get("q") ?? "").trim()
+  if (q.length < PARTICIPANT_MIN_QUERY_LENGTH) {
+    return NextResponse.json({
+      success: true,
+      results: [],
+      eventName: memberEvent.name,
+      eventCohort: memberEvent.cohort,
+    })
+  }
+
   const people = await prisma.impactLabParticipant.findMany({
-    where: { cohort: CURRENT_COHORT, fullName: { contains: q, mode: "insensitive" } },
+    where: { cohort: memberEvent.cohort, fullName: { contains: q, mode: "insensitive" } },
     select: { id: true, fullName: true },
     orderBy: { fullName: "asc" },
     take: RESULT_CAP,
   })
 
   const run = await prisma.impactLabMatchRun.findFirst({
-    where: { cohort: CURRENT_COHORT, isFinal: true },
+    where: { cohort: memberEvent.cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { result: true },
   })
@@ -70,23 +84,25 @@ export async function GET(request: NextRequest) {
 
   const accountResults =
     q.length >= ACCOUNT_MIN_QUERY_LENGTH
-      ? await searchAccounts(q, participantResults.length)
+      ? await searchAccounts(q, participantResults.length, memberEvent.cohort)
       : []
 
   return NextResponse.json({
     success: true,
     results: [...participantResults, ...accountResults].slice(0, RESULT_CAP),
+    eventName: memberEvent.name,
+    eventCohort: memberEvent.cohort,
   })
 }
 
 /**
  * Site accounts matching `q` by name that have no participant row for the
- * current cohort yet. Matched against `firstName`/`lastName` separately
+ * caller's event yet. Matched against `firstName`/`lastName` separately
  * (there is no stored full-name column), then de-duplicated against existing
  * participants by email so someone who is both never appears twice — the
  * cohort search above already returns them as `"participant"`.
  */
-async function searchAccounts(q: string, alreadyFilled: number) {
+async function searchAccounts(q: string, alreadyFilled: number, cohort: string) {
   const budget = RESULT_CAP - alreadyFilled
   if (budget <= 0) return []
 
@@ -107,7 +123,7 @@ async function searchAccounts(q: string, alreadyFilled: number) {
 
   const existing = await prisma.impactLabParticipant.findMany({
     where: {
-      cohort: CURRENT_COHORT,
+      cohort,
       email: { in: candidates.map((u) => u.email.toLowerCase()) },
     },
     select: { email: true },

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -52,6 +53,11 @@ type Phase =
   | "revealed"
   | "results";
 
+interface InviteEvent {
+  cohort: string;
+  name: string;
+}
+
 /**
  * Client state machine for /dashboard/impact-lab. The server page has already
  * enforced session + verified email; this component derives one of the four
@@ -63,6 +69,7 @@ export function ImpactLabClient({
   cohortActive,
   cohortLabel,
   cohort,
+  inviteEvent,
 }: {
   sessionEmail: string;
   cohortActive: boolean;
@@ -73,14 +80,30 @@ export function ImpactLabClient({
    * Undefined when the caller has no resolvable event (nothing to scope to).
    */
   cohort?: string;
+  /**
+   * A different event, currently open for registration, that the caller is
+   * not yet a member of — set only when the caller already has an event of
+   * their own (`cohort` above may be an old, closed one). Additive: renders
+   * as a banner above whatever `cohort`'s own state is showing, never in
+   * place of it. Null when there's nothing more to invite the caller into.
+   */
+  inviteEvent?: InviteEvent | null;
 }) {
+  const router = useRouter();
   const cohortQuery = cohort ? `?cohort=${encodeURIComponent(cohort)}` : "";
   const [phase, setPhase] = useState<Phase>("loading");
   const [profile, setProfile] = useState<MemberProfile | null>(null);
   const [team, setTeam] = useState<TeamRevealView | null>(null);
   const [results, setResults] = useState<ResultsViewProps | null>(null);
   const [editing, setEditing] = useState(false);
-  const [registering, setRegistering] = useState(false);
+  // An object payload distinguishes registering into `inviteEvent` (from the
+  // additive banner, which can appear over any phase) from `true` — the
+  // not-registered card's own flow, registering into `cohort` itself. Holding
+  // the target cohort in state (captured at click time) rather than a literal
+  // tag keeps the two paths mutually exclusive by construction in `onSaved`
+  // below — there's no way to reach the invite's navigation branch without an
+  // actual cohort to navigate to.
+  const [registering, setRegistering] = useState<boolean | { cohort: string }>(false);
   const [reloadKey, setReloadKey] = useState(0);
 
   useEffect(() => {
@@ -181,346 +204,393 @@ export function ImpactLabClient({
     );
   }
 
-  if (phase === "results" && results) {
-    return <ResultsView results={results.results} yourTeam={results.yourTeam} />;
-  }
-
-  if (phase === "revealed" && team) {
-    return <TeamReveal team={team} cohortActive={cohortActive} cohort={cohort} />;
-  }
-
-  // ─── Closed cohort ───────────────────────────────────────────────────────
-  // Past this point every branch invites an action — complete your profile,
-  // wait for teams, contact an organiser before the event. None of that is
-  // true once the cohort closes, so a participant without a team sees the
-  // record and everyone else is told plainly that nothing is running.
-  if (!cohortActive) {
+  // Registering takes over the screen regardless of what else is showing —
+  // triggered either by the not-registered card's own button (`true`,
+  // registering into `cohort`) or by the invite banner below (`{ cohort }`,
+  // registering into `inviteEvent`). Self-registration always targets
+  // whichever event is open server-side, so the form itself doesn't need to
+  // know which one; only what happens after saving differs.
+  if (registering) {
     return (
-      <section
-        className="rounded-lg border border-border-default bg-bg-secondary p-6"
-        aria-label="Impact Lab archive"
-      >
-        <div className="flex flex-wrap items-start gap-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-border-default bg-bg-card">
-            <Clock className="h-5 w-5 text-text-dim" />
-          </div>
-          <div className="min-w-0 flex-1">
-            <h2 className="font-mono text-base font-bold text-text-primary">
-              Impact Lab has wrapped
-            </h2>
-            <p className="mt-2 text-sm leading-relaxed text-text-secondary">
-              {profile
-                ? "Thanks for taking part. Your matching profile is kept as part of the event record and is no longer editable."
-                : "There's no Impact Lab running right now. When the next one opens, this is where your matching profile and team will appear."}
-            </p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <a
-                href={SOCIAL_LINKS.whatsapp}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 font-mono text-xs font-semibold text-green-primary transition-colors hover:bg-green-primary/20"
-              >
-                Hear about the next one
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
+      <MatchProfileForm
+        isNew
+        cohort={cohort}
+        profile={{
+          fullName: "",
+          email: sessionEmail,
+          phone: null,
+          institution: null,
+          experienceLevel: "BEGINNER",
+          primaryRole: "",
+          secondaryRoles: [],
+          technicalSkills: [],
+          interests: [],
+          availability: [],
+          projectIdeas: null,
+          preferredTeammates: [],
+          blockedTeammates: [],
+          consentToMatch: false,
+          consentToShareContact: false,
+        }}
+        onSaved={() => {
+          if (typeof registering === "object") {
+            // Registered into a different event than the one this page is
+            // currently showing — navigate to it so the server re-resolves
+            // membership (now including the row just created) and the page
+            // renders that event's own state, not a stale reload of the old
+            // one. router.refresh() forces the server component to re-run
+            // rather than serve a cached RSC payload for this URL.
+            router.push(`/dashboard/impact-lab?cohort=${encodeURIComponent(registering.cohort)}`);
+            router.refresh();
+            return;
+          }
+          setRegistering(false);
+          setPhase("loading");
+          setReloadKey((k) => k + 1);
+        }}
+        onCancel={() => setRegistering(false)}
+      />
     );
   }
 
-  if (phase === "not-registered") {
-    if (registering) {
-      return (
-        <MatchProfileForm
-          isNew
-          cohort={cohort}
-          profile={{
-            fullName: "",
-            email: sessionEmail,
-            phone: null,
-            institution: null,
-            experienceLevel: "BEGINNER",
-            primaryRole: "",
-            secondaryRoles: [],
-            technicalSkills: [],
-            interests: [],
-            availability: [],
-            projectIdeas: null,
-            preferredTeammates: [],
-            blockedTeammates: [],
-            consentToMatch: false,
-            consentToShareContact: false,
-          }}
-          onSaved={() => {
-            setRegistering(false);
-            setPhase("loading");
-            setReloadKey((k) => k + 1);
-          }}
-          onCancel={() => setRegistering(false)}
-        />
-      );
+  // Everything past this point is `cohort`'s own state — the invite banner,
+  // when present, renders once above it rather than inside every branch.
+  const content = (() => {
+    if (phase === "results" && results) {
+      return <ResultsView results={results.results} yourTeam={results.yourTeam} />;
     }
 
-    return (
-      <section
-        className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
-        aria-label="Registration not found"
-      >
-        <div className="flex flex-wrap items-start gap-4">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10">
-            <SearchX className="h-5 w-5 text-amber" />
-          </div>
-          <div className="flex-1 min-w-0">
-            <h2 className="font-mono text-base font-bold text-text-primary">
-              No registration found for {cohortLabel}
-            </h2>
-            <p className="mt-2 text-sm text-text-secondary leading-relaxed">
-              We couldn&apos;t find a registration under{" "}
-              <span className="font-mono text-text-primary">{sessionEmail}</span>{" "}
-              for <span className="text-text-primary">{cohortLabel}</span>. If
-              you are attending that event, register here using the same email
-              you gave the organisers — that address is what links this account
-              to your team. Your team leader then adds you to the team.
-            </p>
-            <p className="mt-2 text-sm text-text-secondary leading-relaxed">
-              Not attending? Nothing to do — this card only concerns the event
-              currently running.
-            </p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              <button
-                onClick={() => setRegistering(true)}
-                className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 text-xs font-mono font-semibold text-green-primary hover:bg-green-primary/20 transition-colors"
-              >
-                Register now
-              </button>
-              <a
-                href={SOCIAL_LINKS.discord}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-4 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
-              >
-                Discord
-              </a>
-              <a
-                href={SOCIAL_LINKS.whatsapp}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-4 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
-              >
-                WhatsApp
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
-    );
-  }
+    if (phase === "revealed" && team) {
+      return <TeamReveal team={team} cohortActive={cohortActive} cohort={cohort} />;
+    }
 
-  if (!profile) return null;
-
-  if (phase === "unassigned") {
-    return (
-      <div className="space-y-6">
+    // ─── Closed cohort ─────────────────────────────────────────────────────
+    // Past this point every branch invites an action — complete your profile,
+    // wait for teams, contact an organiser before the event. None of that is
+    // true once the cohort closes, so a participant without a team sees the
+    // record and everyone else is told plainly that nothing is running.
+    if (!cohortActive) {
+      return (
         <section
-          className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
-          aria-label="Team status"
+          className="rounded-lg border border-border-default bg-bg-secondary p-6"
+          aria-label="Impact Lab archive"
         >
           <div className="flex flex-wrap items-start gap-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10">
-              <Users className="h-5 w-5 text-amber" />
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-border-default bg-bg-card">
+              <Clock className="h-5 w-5 text-text-dim" />
             </div>
-            <div className="flex-1 min-w-0">
+            <div className="min-w-0 flex-1">
               <h2 className="font-mono text-base font-bold text-text-primary">
-                Teams are finalized
+                Impact Lab has wrapped
               </h2>
-              <p className="mt-2 text-sm text-text-secondary leading-relaxed">
-                {profile.consentToMatch
-                  ? "You weren't placed on a team this round. That's on us, not you — find an organizer at the venue, or reach out on "
-                  : "Your matching profile wasn't completed before the deadline, so the matcher couldn't include you this round. Find an organizer at the venue, or reach out on "}
-                <a
-                  href={SOCIAL_LINKS.discord}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-green-primary hover:underline"
-                >
-                  Discord
-                </a>{" "}
-                or{" "}
+              <p className="mt-2 text-sm leading-relaxed text-text-secondary">
+                {profile
+                  ? "Thanks for taking part. Your matching profile is kept as part of the event record and is no longer editable."
+                  : "There's no Impact Lab running right now. When the next one opens, this is where your matching profile and team will appear."}
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
                 <a
                   href={SOCIAL_LINKS.whatsapp}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-green-primary hover:underline"
+                  className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 font-mono text-xs font-semibold text-green-primary transition-colors hover:bg-green-primary/20"
                 >
-                  WhatsApp
-                </a>{" "}
-                and we&apos;ll find you a spot on a team.
-              </p>
+                  Hear about the next one
+                </a>
+              </div>
             </div>
           </div>
         </section>
+      );
+    }
 
+    if (phase === "not-registered") {
+      return (
         <section
-          className="rounded-lg border border-border-default bg-bg-secondary p-5"
-          aria-label="Your matching profile"
-        >
-          <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
-            {"// ./matching-profile"}
-          </p>
-          <p className="font-mono text-sm text-text-primary">
-            {profile.fullName}
-          </p>
-          <p className="mt-1 font-mono text-xs text-text-dim">
-            {profile.primaryRole} &middot;{" "}
-            {profile.experienceLevel.toLowerCase()}
-          </p>
-          {profile.technicalSkills.length > 0 && (
-            <p className="mt-1 font-mono text-xs text-text-dim">
-              {profile.technicalSkills.join(", ")}
-            </p>
-          )}
-        </section>
-      </div>
-    );
-  }
-
-  // phase === "profile": teams not final yet. A profile counts as complete
-  // once the member has opted in to matching (imported rows start at false).
-  const profileComplete = profile.consentToMatch;
-
-  if (profileComplete && !editing) {
-    return (
-      <div className="space-y-6">
-        <section
-          className="rounded-lg border border-green-primary/20 bg-bg-secondary p-6"
-          aria-label="Profile status"
+          className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
+          aria-label="Registration not found"
         >
           <div className="flex flex-wrap items-start gap-4">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-green-primary/30 bg-green-primary/10">
-              <Clock className="h-5 w-5 text-green-primary" />
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10">
+              <SearchX className="h-5 w-5 text-amber" />
             </div>
             <div className="flex-1 min-w-0">
               <h2 className="font-mono text-base font-bold text-text-primary">
-                Profile saved — you&apos;re in the matching pool
+                No registration found for {cohortLabel}
               </h2>
-              <p className="mt-1 text-sm text-text-secondary">
-                Teams drop Saturday morning, during the event. This page
-                updates itself the moment your team is ready — no need to
-                refresh on the hour.
+              <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+                We couldn&apos;t find a registration under{" "}
+                <span className="font-mono text-text-primary">{sessionEmail}</span>{" "}
+                for <span className="text-text-primary">{cohortLabel}</span>. If
+                you are attending that event, register here using the same email
+                you gave the organisers — that address is what links this account
+                to your team. Your team leader then adds you to the team.
               </p>
+              <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+                Not attending? Nothing to do — this card only concerns the event
+                currently running.
+              </p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <button
+                  onClick={() => setRegistering(true)}
+                  className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-4 py-1.5 text-xs font-mono font-semibold text-green-primary hover:bg-green-primary/20 transition-colors"
+                >
+                  Register now
+                </button>
+                <a
+                  href={SOCIAL_LINKS.discord}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-4 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
+                >
+                  Discord
+                </a>
+                <a
+                  href={SOCIAL_LINKS.whatsapp}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-4 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
+                >
+                  WhatsApp
+                </a>
+              </div>
             </div>
           </div>
         </section>
+      );
+    }
 
-        <section
-          aria-label="What happens next"
-          className="rounded-lg border border-border-default bg-bg-secondary p-5"
-        >
-          <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
-            <Sparkles className="h-3.5 w-3.5 text-amber" />
-            {"// ./whats-next"}
-          </h3>
-          <ol className="space-y-2.5 text-sm text-text-secondary">
-            <li className="flex items-start gap-2.5">
-              <span className="mt-0.5 font-mono text-xs text-green-primary">1.</span>
-              <span>
-                Organizers run the matcher against everyone&apos;s profile —
-                roles, skills, and interests get grouped into balanced teams.
-              </span>
-            </li>
-            <li className="flex items-start gap-2.5">
-              <span className="mt-0.5 font-mono text-xs text-green-primary">2.</span>
-              <span>
-                Teams are finalized and revealed here on 25–26 July, during
-                AI Mashinani itself — not before.
-              </span>
-            </li>
-            <li className="flex items-start gap-2.5">
-              <span className="mt-0.5 font-mono text-xs text-green-primary">3.</span>
-              <span>
-                This page flips straight to your team, teammates, and
-                suggested project direction. No separate announcement to
-                chase.
-              </span>
-            </li>
-          </ol>
-        </section>
+    if (!profile) return null;
 
-        <section
-          aria-label="What to bring"
-          className="rounded-lg border border-border-default bg-bg-secondary p-5"
-        >
-          <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
-            <Laptop className="h-3.5 w-3.5 text-cyan" />
-            {"// ./bring-checklist"}
-          </h3>
-          <ul className="grid gap-2 sm:grid-cols-2">
-            {[
-              "Laptop + charger",
-              "The AI tools you plan to use, signed in and ready",
-              "Whatever you need to demo — repo, data, hardware, deck",
-              "A decision on who presents",
-            ].map((item) => (
-              <li
-                key={item}
-                className="flex items-start gap-2 text-sm text-text-secondary"
-              >
-                <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-green-primary" />
-                {item}
-              </li>
-            ))}
-          </ul>
-        </section>
-
-        <section
-          className="rounded-lg border border-border-default bg-bg-secondary p-5"
-          aria-label="Your matching profile"
-        >
-          <div className="flex flex-wrap items-start gap-4">
-            <div className="flex-1 min-w-0">
-              <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
-                {"// ./matching-profile"}
-              </p>
-              <p className="font-mono text-sm text-text-primary">
-                {profile.fullName}
-              </p>
-              <p className="mt-1 font-mono text-xs text-text-dim">
-                {profile.primaryRole} &middot;{" "}
-                {profile.experienceLevel.toLowerCase()}
-              </p>
-              {profile.technicalSkills.length > 0 && (
-                <p className="mt-1 font-mono text-xs text-text-dim">
-                  {profile.technicalSkills.join(", ")}
+    if (phase === "unassigned") {
+      return (
+        <div className="space-y-6">
+          <section
+            className="rounded-lg border border-amber/30 bg-bg-secondary p-6"
+            aria-label="Team status"
+          >
+            <div className="flex flex-wrap items-start gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-amber/30 bg-amber/10">
+                <Users className="h-5 w-5 text-amber" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <h2 className="font-mono text-base font-bold text-text-primary">
+                  Teams are finalized
+                </h2>
+                <p className="mt-2 text-sm text-text-secondary leading-relaxed">
+                  {profile.consentToMatch
+                    ? "You weren't placed on a team this round. That's on us, not you — find an organizer at the venue, or reach out on "
+                    : "Your matching profile wasn't completed before the deadline, so the matcher couldn't include you this round. Find an organizer at the venue, or reach out on "}
+                  <a
+                    href={SOCIAL_LINKS.discord}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-green-primary hover:underline"
+                  >
+                    Discord
+                  </a>{" "}
+                  or{" "}
+                  <a
+                    href={SOCIAL_LINKS.whatsapp}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-green-primary hover:underline"
+                  >
+                    WhatsApp
+                  </a>{" "}
+                  and we&apos;ll find you a spot on a team.
                 </p>
-              )}
+              </div>
             </div>
-            <button
-              onClick={() => setEditing(true)}
-              className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-3 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
-            >
-              <Pencil className="h-3 w-3" />
-              Edit profile
-            </button>
-          </div>
-          <p className="mt-3 text-[11px] font-mono text-text-dim">
-            Changed your mind about a skill or track? You can edit up until
-            teams are matched.
-          </p>
-        </section>
-      </div>
+          </section>
+
+          <section
+            className="rounded-lg border border-border-default bg-bg-secondary p-5"
+            aria-label="Your matching profile"
+          >
+            <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
+              {"// ./matching-profile"}
+            </p>
+            <p className="font-mono text-sm text-text-primary">
+              {profile.fullName}
+            </p>
+            <p className="mt-1 font-mono text-xs text-text-dim">
+              {profile.primaryRole} &middot;{" "}
+              {profile.experienceLevel.toLowerCase()}
+            </p>
+            {profile.technicalSkills.length > 0 && (
+              <p className="mt-1 font-mono text-xs text-text-dim">
+                {profile.technicalSkills.join(", ")}
+              </p>
+            )}
+          </section>
+        </div>
+      );
+    }
+
+    // phase === "profile": teams not final yet. A profile counts as complete
+    // once the member has opted in to matching (imported rows start at false).
+    const profileComplete = profile.consentToMatch;
+
+    if (profileComplete && !editing) {
+      return (
+        <div className="space-y-6">
+          <section
+            className="rounded-lg border border-green-primary/20 bg-bg-secondary p-6"
+            aria-label="Profile status"
+          >
+            <div className="flex flex-wrap items-start gap-4">
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded border border-green-primary/30 bg-green-primary/10">
+                <Clock className="h-5 w-5 text-green-primary" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <h2 className="font-mono text-base font-bold text-text-primary">
+                  Profile saved — you&apos;re in the matching pool
+                </h2>
+                <p className="mt-1 text-sm text-text-secondary">
+                  Teams drop Saturday morning, during the event. This page
+                  updates itself the moment your team is ready — no need to
+                  refresh on the hour.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section
+            aria-label="What happens next"
+            className="rounded-lg border border-border-default bg-bg-secondary p-5"
+          >
+            <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
+              <Sparkles className="h-3.5 w-3.5 text-amber" />
+              {"// ./whats-next"}
+            </h3>
+            <ol className="space-y-2.5 text-sm text-text-secondary">
+              <li className="flex items-start gap-2.5">
+                <span className="mt-0.5 font-mono text-xs text-green-primary">1.</span>
+                <span>
+                  Organizers run the matcher against everyone&apos;s profile —
+                  roles, skills, and interests get grouped into balanced teams.
+                </span>
+              </li>
+              <li className="flex items-start gap-2.5">
+                <span className="mt-0.5 font-mono text-xs text-green-primary">2.</span>
+                <span>
+                  Teams are finalized and revealed here on 25–26 July, during
+                  AI Mashinani itself — not before.
+                </span>
+              </li>
+              <li className="flex items-start gap-2.5">
+                <span className="mt-0.5 font-mono text-xs text-green-primary">3.</span>
+                <span>
+                  This page flips straight to your team, teammates, and
+                  suggested project direction. No separate announcement to
+                  chase.
+                </span>
+              </li>
+            </ol>
+          </section>
+
+          <section
+            aria-label="What to bring"
+            className="rounded-lg border border-border-default bg-bg-secondary p-5"
+          >
+            <h3 className="mb-3 flex items-center gap-2 font-mono text-xs uppercase tracking-wider text-text-dim">
+              <Laptop className="h-3.5 w-3.5 text-cyan" />
+              {"// ./bring-checklist"}
+            </h3>
+            <ul className="grid gap-2 sm:grid-cols-2">
+              {[
+                "Laptop + charger",
+                "The AI tools you plan to use, signed in and ready",
+                "Whatever you need to demo — repo, data, hardware, deck",
+                "A decision on who presents",
+              ].map((item) => (
+                <li
+                  key={item}
+                  className="flex items-start gap-2 text-sm text-text-secondary"
+                >
+                  <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0 text-green-primary" />
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section
+            className="rounded-lg border border-border-default bg-bg-secondary p-5"
+            aria-label="Your matching profile"
+          >
+            <div className="flex flex-wrap items-start gap-4">
+              <div className="flex-1 min-w-0">
+                <p className="font-mono text-[11px] uppercase tracking-wider text-text-dim mb-2">
+                  {"// ./matching-profile"}
+                </p>
+                <p className="font-mono text-sm text-text-primary">
+                  {profile.fullName}
+                </p>
+                <p className="mt-1 font-mono text-xs text-text-dim">
+                  {profile.primaryRole} &middot;{" "}
+                  {profile.experienceLevel.toLowerCase()}
+                </p>
+                {profile.technicalSkills.length > 0 && (
+                  <p className="mt-1 font-mono text-xs text-text-dim">
+                    {profile.technicalSkills.join(", ")}
+                  </p>
+                )}
+              </div>
+              <button
+                onClick={() => setEditing(true)}
+                className="inline-flex items-center gap-1.5 rounded border border-border-default bg-bg-card px-3 py-1.5 text-xs font-mono text-text-secondary hover:border-green-primary/40 hover:text-green-primary transition-colors"
+              >
+                <Pencil className="h-3 w-3" />
+                Edit profile
+              </button>
+            </div>
+            <p className="mt-3 text-[11px] font-mono text-text-dim">
+              Changed your mind about a skill or track? You can edit up until
+              teams are matched.
+            </p>
+          </section>
+        </div>
+      );
+    }
+
+    return (
+      <MatchProfileForm
+        profile={profile}
+        cohort={cohort}
+        onSaved={(saved) => {
+          setProfile(saved);
+          setEditing(false);
+        }}
+        onCancel={profileComplete ? () => setEditing(false) : undefined}
+      />
     );
-  }
+  })();
 
   return (
-    <MatchProfileForm
-      profile={profile}
-      cohort={cohort}
-      onSaved={(saved) => {
-        setProfile(saved);
-        setEditing(false);
-      }}
-      onCancel={profileComplete ? () => setEditing(false) : undefined}
-    />
+    <>
+      {inviteEvent && (
+        <section
+          className="mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-green-primary/30 bg-green-primary/5 p-4"
+          aria-label="New event open for registration"
+        >
+          <p className="text-sm text-text-secondary">
+            <span className="font-mono font-semibold text-text-primary">
+              {inviteEvent.name}
+            </span>{" "}
+            is open for registration.
+          </p>
+          <button
+            type="button"
+            onClick={() => setRegistering({ cohort: inviteEvent.cohort })}
+            className="inline-flex items-center gap-1.5 rounded border border-green-primary/40 bg-green-primary/10 px-3 py-1.5 text-xs font-mono font-semibold text-green-primary transition-colors hover:bg-green-primary/20"
+          >
+            Register now
+          </button>
+        </section>
+      )}
+      {content}
+    </>
   );
 }

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -62,12 +62,19 @@ export function ImpactLabClient({
   sessionEmail,
   cohortActive,
   cohortLabel,
+  cohort,
 }: {
   sessionEmail: string;
   cohortActive: boolean;
   /** Name of the event now running, so registration copy can say which one. */
   cohortLabel: string;
+  /**
+   * The event these API calls read — appended as `?cohort=` on every fetch.
+   * Undefined when the caller has no resolvable event (nothing to scope to).
+   */
+  cohort?: string;
 }) {
+  const cohortQuery = cohort ? `?cohort=${encodeURIComponent(cohort)}` : "";
   const [phase, setPhase] = useState<Phase>("loading");
   const [profile, setProfile] = useState<MemberProfile | null>(null);
   const [team, setTeam] = useState<TeamRevealView | null>(null);
@@ -79,14 +86,14 @@ export function ImpactLabClient({
   useEffect(() => {
     let active = true;
     Promise.all([
-      fetch("/api/impact-lab/profile"),
-      fetch("/api/impact-lab/team"),
+      fetch(`/api/impact-lab/profile${cohortQuery}`),
+      fetch(`/api/impact-lab/team${cohortQuery}`),
       // Caught here, not left to reject Promise.all: the results endpoint is
       // rate-limited per client IP (100/60s), and hackathon venues put dozens
       // of participants behind one NAT address. A burst right after the
       // results email goes out can 429 this single fetch — that must not
       // black out profile/team, which have nothing to do with results.
-      fetch("/api/impact-lab/results").catch(() => null),
+      fetch(`/api/impact-lab/results${cohortQuery}`).catch(() => null),
     ])
       .then(async ([profileRes, teamRes, resultsRes]) => {
         const profileJson: ProfileResponse = await profileRes.json();
@@ -140,7 +147,7 @@ export function ImpactLabClient({
     return () => {
       active = false;
     };
-  }, [reloadKey]);
+  }, [reloadKey, cohortQuery]);
 
   if (phase === "loading") {
     return (
@@ -179,7 +186,7 @@ export function ImpactLabClient({
   }
 
   if (phase === "revealed" && team) {
-    return <TeamReveal team={team} cohortActive={cohortActive} />;
+    return <TeamReveal team={team} cohortActive={cohortActive} cohort={cohort} />;
   }
 
   // ─── Closed cohort ───────────────────────────────────────────────────────
@@ -227,6 +234,7 @@ export function ImpactLabClient({
       return (
         <MatchProfileForm
           isNew
+          cohort={cohort}
           profile={{
             fullName: "",
             email: sessionEmail,
@@ -507,6 +515,7 @@ export function ImpactLabClient({
   return (
     <MatchProfileForm
       profile={profile}
+      cohort={cohort}
       onSaved={(saved) => {
         setProfile(saved);
         setEditing(false);

--- a/src/app/dashboard/impact-lab/MatchProfileForm.tsx
+++ b/src/app/dashboard/impact-lab/MatchProfileForm.tsx
@@ -18,6 +18,12 @@ interface MatchProfileFormProps {
    * blank one (see ImpactLabClient) so the form has somewhere to write.
    */
   isNew?: boolean;
+  /**
+   * The event to edit into, appended as `?cohort=` on the PUT. Self-
+   * registration (POST) ignores this — it always targets whichever event is
+   * currently open for registration, resolved server-side.
+   */
+  cohort?: string;
 }
 
 /** Same multi-value convention as the admin participants form: split on ; or , */
@@ -28,7 +34,7 @@ const inputClass =
   "w-full bg-bg-card border border-border-default rounded px-3 py-2.5 text-sm font-mono text-text-primary focus:outline-none focus:border-green-primary/50";
 const labelClass = "block text-[11px] font-mono text-text-dim mb-1.5";
 
-export function MatchProfileForm({ profile, onSaved, onCancel, isNew }: MatchProfileFormProps) {
+export function MatchProfileForm({ profile, onSaved, onCancel, isNew, cohort }: MatchProfileFormProps) {
   const [csrfToken, setCsrfToken] = useState("");
   const [fullName, setFullName] = useState(profile.fullName);
   const [experienceLevel, setExperienceLevel] = useState(profile.experienceLevel);
@@ -78,7 +84,13 @@ export function MatchProfileForm({ profile, onSaved, onCancel, isNew }: MatchPro
 
     startTransition(async () => {
       try {
-        const res = await fetch("/api/impact-lab/profile", {
+        // Self-registration (POST) always targets the event currently open
+        // for registration, resolved server-side — no cohort to pass.
+        const url =
+          isNew || !cohort
+            ? "/api/impact-lab/profile"
+            : `/api/impact-lab/profile?cohort=${encodeURIComponent(cohort)}`;
+        const res = await fetch(url, {
           method: isNew ? "POST" : "PUT",
           headers: { "Content-Type": "application/json", "x-csrf-token": csrfToken },
           body: JSON.stringify(body),

--- a/src/app/dashboard/impact-lab/SubmitProject.tsx
+++ b/src/app/dashboard/impact-lab/SubmitProject.tsx
@@ -85,7 +85,8 @@ const inputClass =
   "w-full bg-bg-card border border-border-default rounded px-3 py-2.5 text-sm font-mono text-text-primary focus:outline-none focus:border-green-primary/50";
 const labelClass = "block text-[11px] font-mono text-text-dim mb-1.5";
 
-export function SubmitProject() {
+export function SubmitProject({ cohort }: { cohort?: string }) {
+  const cohortQuery = cohort ? `?cohort=${encodeURIComponent(cohort)}` : "";
   const [status, setStatus] = useState<Status | null>(null);
   const [closeAt, setCloseAt] = useState<string | null>(null);
   const [form, setForm] = useState<FormState>(EMPTY);
@@ -103,7 +104,7 @@ export function SubmitProject() {
   const load = useCallback(async () => {
     setLoadError(null);
     try {
-      const res = await fetch("/api/impact-lab/submission");
+      const res = await fetch(`/api/impact-lab/submission${cohortQuery}`);
       const json: GetResponse = await res.json();
       if (!res.ok || !json.success) {
         setLoadError(json.error ?? "Could not load your submission.");
@@ -118,7 +119,7 @@ export function SubmitProject() {
     } catch {
       setLoadError("Could not load your submission.");
     }
-  }, []);
+  }, [cohortQuery]);
 
   useEffect(() => {
     void load();
@@ -130,7 +131,7 @@ export function SubmitProject() {
     setError(null);
     setSaved(false);
     try {
-      const res = await fetch("/api/impact-lab/submission", {
+      const res = await fetch(`/api/impact-lab/submission${cohortQuery}`, {
         method: "PUT",
         headers: await csrfHeaders(),
         body: JSON.stringify(form),

--- a/src/app/dashboard/impact-lab/TeamReveal.tsx
+++ b/src/app/dashboard/impact-lab/TeamReveal.tsx
@@ -25,12 +25,16 @@ const TEAMMATE_POLL_INTERVAL_MS = 30_000;
 export function TeamReveal({
   team,
   cohortActive = true,
+  cohort,
 }: {
   team: TeamRevealView;
   cohortActive?: boolean;
+  /** The event this team belongs to — appended as `?cohort=` on every fetch. */
+  cohort?: string;
 }) {
   const prefersReducedMotion = useReducedMotion();
   const router = useRouter();
+  const cohortQuery = cohort ? `?cohort=${encodeURIComponent(cohort)}` : "";
 
   // Seeded from the team payload (the caller is always one of the members),
   // then flipped locally the moment the check-in call succeeds — no reload
@@ -60,7 +64,7 @@ export function TeamReveal({
     // value that can no longer change.
     if (!cohortActive) return;
     const interval = setInterval(() => {
-      fetch("/api/impact-lab/team")
+      fetch(`/api/impact-lab/team${cohortQuery}`)
         .then((res) => (res.ok ? (res.json() as Promise<TeamResponse>) : null))
         .then((json) => {
           if (!json?.success || !json.team) return; // keep showing current data, retry next tick
@@ -78,13 +82,13 @@ export function TeamReveal({
         .catch(() => {});
     }, TEAMMATE_POLL_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [cohortActive]);
+  }, [cohortActive, cohortQuery]);
 
   async function handleCheckIn() {
     setCheckingIn(true);
     setCheckInError(null);
     try {
-      const res = await fetch("/api/impact-lab/check-in", {
+      const res = await fetch(`/api/impact-lab/check-in${cohortQuery}`, {
         method: "POST",
         headers: await csrfHeaders(),
       });
@@ -328,6 +332,7 @@ export function TeamReveal({
         <>
           <TeamRoster
             members={team.members}
+            cohort={cohort}
             onChanged={() => {
               // The roster lives in the server-rendered payload, so a change is
               // only visible after a refetch — reload rather than patch local
@@ -336,7 +341,7 @@ export function TeamReveal({
             }}
           />
 
-          <SubmitProject />
+          <SubmitProject cohort={cohort} />
         </>
       )}
     </motion.div>

--- a/src/app/dashboard/impact-lab/TeamRoster.tsx
+++ b/src/app/dashboard/impact-lab/TeamRoster.tsx
@@ -21,11 +21,16 @@ type SearchHit =
 export function TeamRoster({
   members,
   onChanged,
+  cohort,
 }: {
   members: TeamMemberView[];
   onChanged: () => void;
+  /** The team's event — appended as `?cohort=` on every fetch. */
+  cohort?: string;
 }) {
   const reduceMotion = useReducedMotion();
+  const cohortQuery = cohort ? `?cohort=${encodeURIComponent(cohort)}` : "";
+  const cohortSearchParam = cohort ? `&cohort=${encodeURIComponent(cohort)}` : "";
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [hits, setHits] = useState<SearchHit[]>([]);
@@ -44,7 +49,7 @@ export function TeamRoster({
     setSearching(true);
     try {
       const res = await fetch(
-        `/api/impact-lab/team/search?q=${encodeURIComponent(value.trim())}`
+        `/api/impact-lab/team/search?q=${encodeURIComponent(value.trim())}${cohortSearchParam}`
       );
       const json = await res.json();
       if (!res.ok || !json.success) {
@@ -70,7 +75,7 @@ export function TeamRoster({
     setError(null);
     setNotice(null);
     try {
-      const res = await fetch("/api/impact-lab/team/roster", {
+      const res = await fetch(`/api/impact-lab/team/roster${cohortQuery}`, {
         method,
         headers: await csrfHeaders(),
         body: JSON.stringify(body),
@@ -104,7 +109,7 @@ export function TeamRoster({
     setError(null);
     setNotice(null);
     try {
-      const res = await fetch("/api/impact-lab/team/leader", {
+      const res = await fetch(`/api/impact-lab/team/leader${cohortQuery}`, {
         method: "POST",
         headers: await csrfHeaders(),
       });

--- a/src/app/dashboard/impact-lab/page.tsx
+++ b/src/app/dashboard/impact-lab/page.tsx
@@ -5,11 +5,8 @@ import { ArrowLeft } from "lucide-react";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification";
-import {
-  CURRENT_COHORT,
-  CURRENT_COHORT_LABEL,
-  isCohortActive,
-} from "@/lib/impact-lab/constants";
+import { validCohort, pickMemberEvent } from "@/lib/impact-lab/event-lifecycle";
+import { openRegistrationEvent, resolveMemberEvents } from "@/lib/impact-lab/event-store";
 import { VerifyEmailBanner } from "../VerifyEmailBanner";
 import { ImpactLabClient } from "./ImpactLabClient";
 
@@ -19,7 +16,11 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default async function ImpactLabPage() {
+export default async function ImpactLabPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ cohort?: string }>;
+}) {
   const session = await auth();
   if (!session?.user?.email) {
     redirect("/login?callbackUrl=/dashboard/impact-lab");
@@ -31,7 +32,16 @@ export default async function ImpactLabPage() {
   });
   if (!user) redirect("/login");
 
-  const cohortActive = isCohortActive(CURRENT_COHORT);
+  const email = session.user.email.toLowerCase();
+  const { cohort: requestedCohort } = await searchParams;
+  const memberEvents = await resolveMemberEvents(email);
+  const picked = pickMemberEvent(memberEvents, validCohort(requestedCohort));
+  // No event of the member's own: fall back to whatever is currently open
+  // for self-registration, so the page still names something and the
+  // registration invitation can appear — same fallback the dashboard card
+  // and the profile route use.
+  const activeEvent = picked ?? (await openRegistrationEvent());
+  const cohortActive = activeEvent?.status === "LIVE";
 
   return (
     <main className="min-h-screen bg-bg-primary pt-24 pb-24">
@@ -57,6 +67,28 @@ export default async function ImpactLabPage() {
           </p>
         </header>
 
+        {/* A member of more than one event (past + current, or two
+            concurrent ones) picks which to view here — plain links, not
+            client state, so the choice survives a reload and is shareable.
+            Fewer than two memberships: nothing to switch between. */}
+        {memberEvents.length > 1 && (
+          <nav aria-label="Choose event" className="mb-6 flex flex-wrap gap-2">
+            {memberEvents.map((e) => (
+              <Link
+                key={e.cohort}
+                href={`/dashboard/impact-lab?cohort=${encodeURIComponent(e.cohort)}`}
+                className={
+                  picked?.cohort === e.cohort
+                    ? "rounded border border-green-primary/40 bg-green-primary/10 px-3 py-1.5 font-mono text-xs text-green-primary"
+                    : "rounded border border-border-default px-3 py-1.5 font-mono text-xs text-text-secondary transition-colors hover:border-green-primary/40 hover:text-green-primary"
+                }
+              >
+                {e.name}
+              </Link>
+            ))}
+          </nav>
+        )}
+
         {/* Gate on the same flag the API uses. When verification is off we send
             no verification mail, so blocking here on emailVerified alone locks
             out every account created before the flag flipped, with no way to
@@ -76,9 +108,15 @@ export default async function ImpactLabPage() {
           </>
         ) : (
           <ImpactLabClient
+            // Forces a clean remount when the switcher picks a different
+            // event — otherwise the previous event's team/results state
+            // would flash under the newly-highlighted chip until the
+            // refetch lands.
+            key={activeEvent?.cohort}
             sessionEmail={session.user.email}
-            cohortActive={cohortActive}
-            cohortLabel={CURRENT_COHORT_LABEL}
+            cohortActive={Boolean(cohortActive)}
+            cohortLabel={activeEvent?.name ?? "Impact Lab"}
+            cohort={activeEvent?.cohort}
           />
         )}
       </div>

--- a/src/app/dashboard/impact-lab/page.tsx
+++ b/src/app/dashboard/impact-lab/page.tsx
@@ -36,12 +36,23 @@ export default async function ImpactLabPage({
   const { cohort: requestedCohort } = await searchParams;
   const memberEvents = await resolveMemberEvents(email);
   const picked = pickMemberEvent(memberEvents, validCohort(requestedCohort));
+  const openEvent = await openRegistrationEvent();
   // No event of the member's own: fall back to whatever is currently open
   // for self-registration, so the page still names something and the
   // registration invitation can appear — same fallback the dashboard card
   // and the profile route use.
-  const activeEvent = picked ?? (await openRegistrationEvent());
+  const activeEvent = picked ?? openEvent;
   const cohortActive = activeEvent?.status === "LIVE";
+  // A returning participant — someone with a membership of their own
+  // (`picked`, however old or closed) who is not yet a member of the event
+  // now open — still deserves the invitation to join it. Additive to
+  // `activeEvent`, not a replacement: their own event keeps driving the
+  // page's main content below; this only decides whether the invite banner
+  // also shows. A member with no event of their own already sees the full
+  // invite as their main view (`activeEvent = openEvent` above), so there is
+  // nothing more to add there.
+  const inviteEvent =
+    picked && openEvent && openEvent.cohort !== picked.cohort ? openEvent : null;
 
   return (
     <main className="min-h-screen bg-bg-primary pt-24 pb-24">
@@ -117,6 +128,9 @@ export default async function ImpactLabPage({
             cohortActive={Boolean(cohortActive)}
             cohortLabel={activeEvent?.name ?? "Impact Lab"}
             cohort={activeEvent?.cohort}
+            inviteEvent={
+              inviteEvent ? { cohort: inviteEvent.cohort, name: inviteEvent.name } : null
+            }
           />
         )}
       </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { prisma } from "@/lib/prisma";
 import { REQUIRE_EMAIL_VERIFICATION } from "@/lib/email-verification";
 import { getUpcomingEvents } from "@/lib/data";
 import { getSocialLinks } from "@/lib/social-links";
-import { CURRENT_COHORT, isCohortActive } from "@/lib/impact-lab/constants";
+import { openRegistrationEvent, resolveMemberEvent } from "@/lib/impact-lab/event-store";
 import { extractFrozenTeams } from "@/lib/impact-lab/member";
 import { Calendar, MessageSquare, BookOpen, Sparkles, Code2, FlaskConical } from "lucide-react";
 import { SignOutButton } from "./SignOutButton";
@@ -85,54 +85,54 @@ export default async function DashboardPage() {
   const nextEvent = upcomingEvents[0];
 
   // Impact Lab hackathon status — mirrors the states on /dashboard/impact-lab.
-  // null hides the card entirely: with the cohort closed, someone who never
-  // took part has no reason to see a hackathon card at all, and every live
-  // status ("complete your profile", "teams drop Saturday") would be a lie.
-  const cohortActive = isCohortActive(CURRENT_COHORT);
-  let impactLabStatus: ImpactLabStatus | null = cohortActive ? "verify" : null;
-  // Same flag the API and the Impact Lab page use: with verification off we
-  // send no verification mail, so gating on emailVerified alone would strand
-  // every pre-flag account on the "verify" card permanently.
-  if (!cohortActive) {
-    // Closed cohort: the card is a link to the record, and only for people who
-    // actually have one.
-    const participant = await prisma.impactLabParticipant.findUnique({
-      where: {
-        cohort_email: { cohort: CURRENT_COHORT, email: user.email.toLowerCase() },
-      },
-      select: { id: true },
-    });
-    impactLabStatus = participant ? "archived" : null;
-  } else if (!REQUIRE_EMAIL_VERIFICATION || user.emailVerified) {
-    // No .catch(() => null) here: swallowing a DB error would show a
-    // registered participant the affirmative "Registration not found" copy.
-    // A down DB surfaces via the page error boundary, same as the user query.
-    const participant = await prisma.impactLabParticipant.findUnique({
-      where: {
-        cohort_email: {
-          cohort: CURRENT_COHORT,
-          email: user.email.toLowerCase(),
-        },
-      },
-      select: { id: true, consentToMatch: true },
-    });
-    if (!participant) {
-      impactLabStatus = "not-registered";
-    } else {
+  // null hides the card entirely: someone with no event of their own and
+  // nothing open to register for has no reason to see a hackathon card at
+  // all, and every live status ("complete your profile", "teams drop
+  // Saturday") would be a lie.
+  //
+  // Membership decides which event this card is about: a member's own event
+  // (LIVE preferred, else their most recent) if they have one, else whatever
+  // event is currently open for self-registration, else nothing.
+  const memberEvent = await resolveMemberEvent(user.email.toLowerCase());
+  let impactLabStatus: ImpactLabStatus | null = null;
+  if (memberEvent) {
+    if (memberEvent.status !== "LIVE") {
+      // Closed event: the card is a link to the record.
+      impactLabStatus = "archived";
+    } else if (!REQUIRE_EMAIL_VERIFICATION || user.emailVerified) {
+      // No .catch(() => null) here: swallowing a DB error would show a
+      // registered participant the affirmative "Registration not found"
+      // copy. A down DB surfaces via the page error boundary, same as the
+      // user query.
+      const participant = await prisma.impactLabParticipant.findUnique({
+        where: { id: memberEvent.participantId },
+        select: { consentToMatch: true },
+      });
       const finalRun = await prisma.impactLabMatchRun.findFirst({
-        where: { cohort: CURRENT_COHORT, isFinal: true },
+        where: { cohort: memberEvent.cohort, isFinal: true },
         orderBy: { createdAt: "desc" },
         select: { result: true },
       });
       // Frozen JSON, not schema-enforced — a malformed run degrades to waiting.
       const teams = finalRun ? extractFrozenTeams(finalRun.result) : null;
       if (!teams) {
-        impactLabStatus = participant.consentToMatch ? "waiting" : "profile";
+        impactLabStatus = participant?.consentToMatch ? "waiting" : "profile";
       } else {
-        impactLabStatus = teams.some((t) => t.memberIds.includes(participant.id))
+        impactLabStatus = teams.some((t) => t.memberIds.includes(memberEvent.participantId))
           ? "revealed"
           : "unassigned";
       }
+    } else {
+      impactLabStatus = "verify";
+    }
+  } else {
+    // Same flag the API and the Impact Lab page use: with verification off
+    // we send no verification mail, so gating on emailVerified alone would
+    // strand every pre-flag account on the "verify" card permanently.
+    const openEvent = await openRegistrationEvent();
+    if (openEvent) {
+      impactLabStatus =
+        !REQUIRE_EMAIL_VERIFICATION || user.emailVerified ? "not-registered" : "verify";
     }
   }
 

--- a/src/components/admin/impact-lab/EventsTab.tsx
+++ b/src/components/admin/impact-lab/EventsTab.tsx
@@ -1,0 +1,454 @@
+"use client"
+
+import { Fragment, useCallback, useEffect, useState } from "react"
+import { AlertTriangle, Loader2, Plus } from "lucide-react"
+import { apiGet, apiSend } from "./api"
+
+/**
+ * Admin surface for the tenancy platform's events: every event across every
+ * organisation, its lifecycle status, and the controls to create one and
+ * move it through DRAFT → LIVE → CLOSED → ARCHIVED.
+ *
+ * The transition buttons shown per row are a client-side convenience only —
+ * a mirror of `canTransition` in event-lifecycle.ts for which buttons make
+ * sense to offer. The server re-checks every request (LIVE→DRAFT rejects
+ * once people have registered, for instance), so a shown button can still
+ * fail; its refusal reason renders next to the row instead of being hidden
+ * or translated into something friendlier.
+ */
+
+type EventStatus = "DRAFT" | "LIVE" | "CLOSED" | "ARCHIVED"
+
+interface EventRow {
+  id: string
+  organisationId: string
+  organisationName: string
+  cohort: string
+  name: string
+  status: EventStatus
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+  groundRules: string | null
+  createdAt: string
+}
+
+interface OrganisationOption {
+  id: string
+  slug: string
+  name: string
+}
+
+interface EventsData {
+  events: EventRow[]
+  organisations: OrganisationOption[]
+}
+
+const STATUS_COLOR: Record<EventStatus, string> = {
+  LIVE: "#00ff41",
+  DRAFT: "#666666",
+  CLOSED: "#ffb000",
+  ARCHIVED: "#ff3333",
+}
+
+const TRANSITIONS: Record<EventStatus, { to: EventStatus; label: string }[]> = {
+  DRAFT: [{ to: "LIVE", label: "Launch" }],
+  LIVE: [
+    { to: "CLOSED", label: "Close" },
+    { to: "DRAFT", label: "Back to draft" },
+  ],
+  CLOSED: [
+    { to: "LIVE", label: "Reopen" },
+    { to: "ARCHIVED", label: "Archive" },
+  ],
+  ARCHIVED: [{ to: "CLOSED", label: "Unarchive" }],
+}
+
+const FIELD =
+  "w-full rounded border border-[#1e1e1e] bg-[#111] px-2 py-1.5 text-[11px] font-mono text-[#e0e0e0] placeholder:text-[#444] focus:border-[#00ff41] focus:outline-none disabled:cursor-not-allowed disabled:text-[#666]"
+const LEGEND = "text-[10px] font-mono uppercase tracking-wider text-[#555]"
+
+const EMPTY_FORM = {
+  organisationId: "",
+  cohort: "",
+  name: "",
+  titleLead: "",
+  titleAccent: "",
+  dates: "",
+  location: "",
+  formatNote: "",
+  groundRules: "",
+}
+
+export function EventsTab() {
+  const [data, setData] = useState<EventsData | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [transitioning, setTransitioning] = useState<string | null>(null)
+  const [rowErrors, setRowErrors] = useState<Record<string, string>>({})
+
+  const [showForm, setShowForm] = useState(false)
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [creating, setCreating] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    try {
+      setData(await apiGet<EventsData>("/api/admin/impact-lab/events"))
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load events")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  const transition = async (cohort: string, to: EventStatus) => {
+    setTransitioning(cohort)
+    setRowErrors((prev) => {
+      if (!(cohort in prev)) return prev
+      const next = { ...prev }
+      delete next[cohort]
+      return next
+    })
+    try {
+      await apiSend("/api/admin/impact-lab/events", "PATCH", { cohort, status: to })
+      await load()
+    } catch (e) {
+      setRowErrors((prev) => ({
+        ...prev,
+        [cohort]: e instanceof Error ? e.message : "Could not change status",
+      }))
+    } finally {
+      setTransitioning(null)
+    }
+  }
+
+  const createEvent = async () => {
+    setCreating(true)
+    setFormError(null)
+    try {
+      await apiSend("/api/admin/impact-lab/events", "POST", {
+        organisationId: form.organisationId,
+        cohort: form.cohort,
+        name: form.name,
+        titleLead: form.titleLead,
+        titleAccent: form.titleAccent,
+        dates: form.dates,
+        location: form.location,
+        formatNote: form.formatNote,
+        ...(form.groundRules.trim() ? { groundRules: form.groundRules } : {}),
+      })
+      setForm(EMPTY_FORM)
+      setShowForm(false)
+      await load()
+    } catch (e) {
+      setFormError(e instanceof Error ? e.message : "Failed to create event")
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const formValid =
+    form.organisationId.trim() !== "" &&
+    form.cohort.trim() !== "" &&
+    form.name.trim() !== "" &&
+    form.titleLead.trim() !== "" &&
+    form.titleAccent.trim() !== "" &&
+    form.dates.trim() !== "" &&
+    form.location.trim() !== "" &&
+    form.formatNote.trim() !== ""
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center">
+        <Loader2 className="mx-auto h-5 w-5 animate-spin text-[#333]" />
+      </div>
+    )
+  }
+
+  if (!data) {
+    return (
+      <div
+        role="alert"
+        className="space-y-2 rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-3 text-[11px] font-mono text-[#ff3333]"
+      >
+        <p>{error ?? "No data"}</p>
+        <button
+          onClick={() => void load()}
+          className="rounded border border-[#ff3333]/40 px-3 py-1.5 text-[#ff3333] hover:bg-[#ff3333]/10"
+        >
+          Try again
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="text-xs font-mono text-[#555]">
+          {data.events.length} event{data.events.length === 1 ? "" : "s"}
+        </p>
+        <button
+          onClick={() => setShowForm((s) => !s)}
+          className="flex items-center gap-1.5 rounded border border-[#00ff41]/30 bg-[#00ff41]/10 px-3 py-1.5 text-[11px] font-mono text-[#00ff41] hover:bg-[#00ff41]/20"
+        >
+          <Plus className="h-3 w-3" /> New event
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]"
+        >
+          {error}
+        </div>
+      )}
+
+      {showForm && (
+        <div className="space-y-3 rounded-lg border border-[#1e1e1e] bg-[#0d0d0d] p-4">
+          <p className={LEGEND}>New event</p>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div className="space-y-1">
+              <label className={LEGEND} htmlFor="event-org">
+                Organisation
+              </label>
+              <select
+                id="event-org"
+                value={form.organisationId}
+                onChange={(e) => setForm({ ...form, organisationId: e.target.value })}
+                className={FIELD}
+              >
+                <option value="">Select an organisation…</option>
+                {data.organisations.map((org) => (
+                  <option key={org.id} value={org.id}>
+                    {org.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1">
+              <label className={LEGEND} htmlFor="event-cohort">
+                Cohort slug
+              </label>
+              <input
+                id="event-cohort"
+                value={form.cohort}
+                onChange={(e) => setForm({ ...form, cohort: e.target.value })}
+                placeholder="afretec-makerthon-2026-08"
+                className={FIELD}
+              />
+              <p className="text-[10px] font-mono text-[#444]">
+                Lowercase letters, digits and hyphens only.
+              </p>
+            </div>
+            <div className="space-y-1">
+              <label className={LEGEND} htmlFor="event-name">
+                Name
+              </label>
+              <input
+                id="event-name"
+                value={form.name}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className={FIELD}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className={LEGEND} htmlFor="event-dates">
+                Dates
+              </label>
+              <input
+                id="event-dates"
+                value={form.dates}
+                onChange={(e) => setForm({ ...form, dates: e.target.value })}
+                placeholder="8–9 Aug 2026"
+                className={FIELD}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className={LEGEND} htmlFor="event-title-lead">
+                Title lead
+              </label>
+              <input
+                id="event-title-lead"
+                value={form.titleLead}
+                onChange={(e) => setForm({ ...form, titleLead: e.target.value })}
+                className={FIELD}
+              />
+            </div>
+            <div className="space-y-1">
+              <label className={LEGEND} htmlFor="event-title-accent">
+                Title accent
+              </label>
+              <input
+                id="event-title-accent"
+                value={form.titleAccent}
+                onChange={(e) => setForm({ ...form, titleAccent: e.target.value })}
+                className={FIELD}
+              />
+            </div>
+            <div className="space-y-1 sm:col-span-2">
+              <label className={LEGEND} htmlFor="event-location">
+                Location
+              </label>
+              <input
+                id="event-location"
+                value={form.location}
+                onChange={(e) => setForm({ ...form, location: e.target.value })}
+                className={FIELD}
+              />
+            </div>
+            <div className="space-y-1 sm:col-span-2">
+              <label className={LEGEND} htmlFor="event-format-note">
+                Format note
+              </label>
+              <textarea
+                id="event-format-note"
+                rows={2}
+                value={form.formatNote}
+                onChange={(e) => setForm({ ...form, formatNote: e.target.value })}
+                className={`${FIELD} resize-y`}
+              />
+            </div>
+            <div className="space-y-1 sm:col-span-2">
+              <label className={LEGEND} htmlFor="event-ground-rules">
+                Ground rules (optional)
+              </label>
+              <textarea
+                id="event-ground-rules"
+                rows={2}
+                value={form.groundRules}
+                onChange={(e) => setForm({ ...form, groundRules: e.target.value })}
+                className={`${FIELD} resize-y`}
+              />
+            </div>
+          </div>
+
+          {formError && (
+            <div
+              role="alert"
+              className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]"
+            >
+              {formError}
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={createEvent}
+              disabled={creating || !formValid}
+              className="flex items-center gap-1.5 rounded border border-[#00ff41]/40 bg-[#00ff41]/10 px-4 py-2 text-[11px] font-mono text-[#00ff41] hover:bg-[#00ff41]/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {creating ? <Loader2 className="h-3 w-3 animate-spin" /> : <Plus className="h-3 w-3" />}
+              Create draft
+            </button>
+            <button
+              onClick={() => {
+                setShowForm(false)
+                setForm(EMPTY_FORM)
+                setFormError(null)
+              }}
+              disabled={creating}
+              className="rounded border border-[#1e1e1e] px-3 py-2 text-[11px] font-mono text-[#666] hover:text-[#e0e0e0] disabled:opacity-40"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-lg border border-[#1e1e1e] bg-[#0d0d0d]">
+        {data.events.length === 0 ? (
+          <div className="p-8 text-center text-sm font-mono text-[#555]">
+            No events yet — create one above.
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#1e1e1e]">
+                  {["Name", "Organisation", "Cohort", "Status", "Created", ""].map((h) => (
+                    <th
+                      key={h}
+                      className="px-4 py-3 text-left text-[10px] font-mono font-semibold uppercase tracking-wider text-[#555]"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-[#141414]">
+                {data.events.map((event) => (
+                  <Fragment key={event.id}>
+                    <tr className="hover:bg-[#111]">
+                      <td className="px-4 py-3 text-sm font-mono text-[#e0e0e0]">{event.name}</td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#888]">
+                        {event.organisationName}
+                      </td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#666]">{event.cohort}</td>
+                      <td className="px-4 py-3">
+                        <span
+                          className="rounded border px-2 py-0.5 text-[10px] font-mono"
+                          style={{
+                            color: STATUS_COLOR[event.status],
+                            borderColor: `${STATUS_COLOR[event.status]}40`,
+                          }}
+                        >
+                          {event.status}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-[11px] font-mono text-[#666]">
+                        {new Date(event.createdAt).toLocaleDateString("en-KE", { dateStyle: "medium" })}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <div className="flex items-center justify-end gap-2">
+                          {TRANSITIONS[event.status].map(({ to, label }) => (
+                            <button
+                              key={to}
+                              onClick={() => void transition(event.cohort, to)}
+                              disabled={transitioning === event.cohort}
+                              className="rounded border border-[#1e1e1e] px-2.5 py-1 text-[10px] font-mono text-[#888] hover:border-[#00ff41]/40 hover:text-[#00ff41] disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                              {transitioning === event.cohort ? (
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                              ) : (
+                                label
+                              )}
+                            </button>
+                          ))}
+                        </div>
+                      </td>
+                    </tr>
+                    {rowErrors[event.cohort] && (
+                      <tr className="bg-[#0a0a0a]">
+                        <td colSpan={6} className="px-4 py-2">
+                          <p
+                            role="alert"
+                            className="flex items-start gap-2 text-[11px] font-mono text-[#ff3333]"
+                          >
+                            <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                            {rowErrors[event.cohort]}
+                          </p>
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -11,6 +11,7 @@ import {
   Gavel,
   ListChecks,
   SlidersHorizontal,
+  CalendarDays,
   Info,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
@@ -25,8 +26,10 @@ import { LeaderboardTab } from "./LeaderboardTab"
 import { JudgesTab } from "./JudgesTab"
 import { ResultsTab } from "./ResultsTab"
 import { RubricTab } from "./RubricTab"
+import { EventsTab } from "./EventsTab"
 
 type Tab =
+  | "events"
   | "participants"
   | "matching"
   | "runs"
@@ -38,6 +41,9 @@ type Tab =
   | "results"
 
 const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
+  // First: events span organisations and aren't scoped to the selected
+  // cohort below, unlike every other tab here.
+  { key: "events", label: "Events", icon: CalendarDays },
   { key: "participants", label: "Participants", icon: Users },
   { key: "matching", label: "Matching", icon: Network },
   { key: "runs", label: "Runs", icon: Save },
@@ -126,6 +132,7 @@ export function ImpactLabDashboard({ cohort: initialCohort }: { cohort: string }
        * half-filled participant form) can survive onto the new one.
        */}
       <div key={cohort} className="space-y-5">
+        {tab === "events" && <EventsTab />}
         {tab === "participants" && <ParticipantsTab cohort={cohort} />}
         {tab === "matching" && (
           <MatchingTab

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -59,9 +59,9 @@ const TABS: { key: Tab; label: string; icon: typeof Users }[] = [
 ]
 
 /**
- * `initialCohort` seeds the selector — the server passes `CURRENT_COHORT` so
- * the page opens on the live event, but the organiser can switch to any
- * cohort the system knows about without a redeploy.
+ * `initialCohort` seeds the selector — the server passes the admin default
+ * cohort so the page opens on the live event, but the organiser can switch
+ * to any cohort the system knows about without a redeploy.
  */
 export function ImpactLabDashboard({ cohort: initialCohort }: { cohort: string }) {
   const [cohort, setCohort] = useState(initialCohort)
@@ -82,8 +82,8 @@ export function ImpactLabDashboard({ cohort: initialCohort }: { cohort: string }
        * Worded to cover both kinds of event this dashboard now serves: a
        * cohort that gets matched into teams here (Matching tab, Explain,
        * freeze a run) and a cohort whose teams already exist and only needs
-       * check-in, judging, and results. Naming the selected cohort — not
-       * CURRENT_COHORT — keeps this line honest after a switch.
+       * check-in, judging, and results. Naming the selected cohort — not a
+       * hardcoded default — keeps this line honest after a switch.
        */}
       <p className="text-xs font-mono text-[#555]">
         Managing <span className="text-[#00ff41]">{cohort}</span> — participants, teams, submissions,

--- a/src/lib/impact-lab/cohort-guard.ts
+++ b/src/lib/impact-lab/cohort-guard.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from "next/server"
-import { isCohortActive } from "./constants"
 import { getEventByCohort } from "./event-store"
 
 /**
@@ -11,16 +10,16 @@ import { getEventByCohort } from "./event-store"
  * rosters, check-ins and submissions are the historical record of what
  * happened, and a late write silently rewrites that record.
  *
- * Status comes from the Event row. Pre-migration (no row anywhere) the old
- * env-var behaviour still answers, so an un-migrated environment keeps
- * working exactly as before.
+ * Status comes from the Event row. Pre-migration (no row anywhere) there is
+ * no env signal left to honor, so writes stay closed until the tenancy
+ * migration has run.
  *
  * Reads are deliberately untouched: people should still be able to see their
  * team and what they built.
  */
 export async function guardClosedCohort(cohort: string): Promise<NextResponse | null> {
   const event = await getEventByCohort(cohort)
-  const open = event ? event.status === "LIVE" : isCohortActive(cohort)
+  const open = event ? event.status === "LIVE" : false
   if (open) return null
   return NextResponse.json(
     {

--- a/src/lib/impact-lab/cohort-guard.ts
+++ b/src/lib/impact-lab/cohort-guard.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server"
 import { isCohortActive } from "./constants"
+import { getEventByCohort } from "./event-store"
 
 /**
- * Refuse member-facing writes once a cohort has closed.
+ * Refuse member-facing writes unless the cohort's event is LIVE.
  *
  * The dashboard already hides these affordances, but hiding a button is a
  * presentation choice, not a guarantee — the endpoints stay reachable to
@@ -10,18 +11,22 @@ import { isCohortActive } from "./constants"
  * rosters, check-ins and submissions are the historical record of what
  * happened, and a late write silently rewrites that record.
  *
+ * Status comes from the Event row. Pre-migration (no row anywhere) the old
+ * env-var behaviour still answers, so an un-migrated environment keeps
+ * working exactly as before.
+ *
  * Reads are deliberately untouched: people should still be able to see their
  * team and what they built.
- *
- * Returns a 403 to short-circuit with, or null when the cohort is live.
  */
-export function guardClosedCohort(cohort: string): NextResponse | null {
-  if (isCohortActive(cohort)) return null
+export async function guardClosedCohort(cohort: string): Promise<NextResponse | null> {
+  const event = await getEventByCohort(cohort)
+  const open = event ? event.status === "LIVE" : isCohortActive(cohort)
+  if (open) return null
   return NextResponse.json(
     {
       success: false,
       error:
-        "This Impact Lab has closed. Your team and submission are kept as a record and can no longer be changed.",
+        "This event has closed. Your team and submission are kept as a record and can no longer be changed.",
     },
     { status: 403 },
   )

--- a/src/lib/impact-lab/constants.ts
+++ b/src/lib/impact-lab/constants.ts
@@ -1,66 +1,7 @@
-/** The default (and, for now, only) Impact Lab cohort. */
+/**
+ * The pre-tenancy fallback cohort. Every "which event?" question is now
+ * answered from the Event table (src/lib/impact-lab/event-store.ts); this
+ * slug remains only as the degrade target for an environment whose tenancy
+ * migration has not run yet.
+ */
 export const DEFAULT_COHORT = "impact-lab-2026-07"
-
-/**
- * The cohort currently running an event, or null when no Impact Lab is live.
- *
- * Env-driven rather than hardcoded so re-opening for the next hackathon is a
- * Vercel env change, not a deploy. Absent/empty means *no* cohort is active,
- * which is the correct default the moment an event ends: member-facing
- * surfaces fall back to a read-only record instead of inviting people to
- * register for something that already happened.
- *
- * Server-only — every importer of this module is a route handler or server
- * component, so there is no NEXT_PUBLIC_ inlining to worry about.
- */
-export const ACTIVE_COHORT: string | null =
-  process.env.IMPACT_LAB_ACTIVE_COHORT?.trim() || null
-
-/** True when `cohort` is the one currently running an event. */
-export function isCohortActive(cohort: string): boolean {
-  return ACTIVE_COHORT !== null && cohort === ACTIVE_COHORT
-}
-
-/**
- * The cohort every read surface serves: participant lookups, submissions,
- * results, teammate search, and the admin dashboard.
- *
- * Falls back to `DEFAULT_COHORT` (the most recent cohort) when no event is
- * live, so the site keeps showing a read-only record instead of nothing.
- * When `IMPACT_LAB_ACTIVE_COHORT` is set for a live event, that cohort takes
- * over every surface without a code change.
- */
-export const CURRENT_COHORT: string = ACTIVE_COHORT ?? DEFAULT_COHORT
-
-/**
- * Human-readable name of the current event, for copy that has to say which
- * event it means. Falls back to the slug, which is ugly but never wrong.
- *
- * This exists because the dashboard now offers self-registration to any
- * signed-in account: without naming the event, someone who joined the
- * community for unrelated reasons gets invited to register for whatever
- * hackathon happens to be live. Server-only — pass it to client components
- * as a prop.
- */
-export const CURRENT_COHORT_LABEL: string =
-  process.env.IMPACT_LAB_COHORT_LABEL?.trim() || CURRENT_COHORT
-
-const COHORT_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/i
-
-/**
- * Coerce user-supplied cohort input to a safe slug. Anything with characters
- * outside [a-z0-9-] (CR/LF, quotes, etc.) falls back — this is what keeps the
- * cohort safe to interpolate into a Content-Disposition header and into
- * queries.
- *
- * The fallback is `CURRENT_COHORT`, not `DEFAULT_COHORT`: every admin route
- * reads its cohort through here, and the judge screen calls
- * /api/admin/impact-lab/judging with no `cohort` param at all. Falling back to
- * the hardcoded default meant judges scored the previous event's teams while
- * the live leaderboard stayed empty. "The cohort you meant when you did not
- * say" is the one currently running.
- */
-export function safeCohort(input: string | null | undefined): string {
-  const value = (input ?? "").trim()
-  return COHORT_PATTERN.test(value) ? value : CURRENT_COHORT
-}

--- a/src/lib/impact-lab/event-access.ts
+++ b/src/lib/impact-lab/event-access.ts
@@ -1,0 +1,86 @@
+/**
+ * Event-scoped authorization: the two orthogonal layers from the tenancy
+ * design. The platform tier (site UserRole via rbac.ts) says what actions a
+ * staff role may take anywhere; the tenant tier (OrganisationMember) grants
+ * an organisation's people full run of their OWN events only.
+ *
+ * Impact Lab admin routes call checkEventAccess INSTEAD of a bare
+ * checkApiPermission — the platform check is embedded here.
+ */
+
+import { NextResponse } from "next/server"
+import { auth } from "@/auth"
+import { prisma } from "@/lib/prisma"
+import { hasPermission, type UserRole } from "@/lib/rbac"
+import { getEventByCohort, type EventRecord } from "./event-store"
+
+export type EventAction = "view" | "create" | "edit" | "delete" | "approve"
+
+/**
+ * The pure decision: platform role with the impact-lab permission passes;
+ * otherwise membership of the event's organisation passes every action
+ * (OWNER and ORGANISER are equally trusted on their own event — the split
+ * matters only for managing the organisation itself, which is sub-project 6).
+ * No session (`role === null`) always refuses: membership is derived FROM
+ * the session, so a null role with isOrgMember=true is a caller bug.
+ */
+export function hasEventAccess(
+  role: UserRole | null,
+  isOrgMember: boolean,
+  action: EventAction
+): boolean {
+  if (role === null) return false
+  if (hasPermission(role, "impact-lab", action)) return true
+  return isOrgMember
+}
+
+/**
+ * Authorize the caller for an event and return the event row so routes never
+ * fetch it twice. `event` is null when the cohort has no Event row (unknown
+ * slug, or pre-migration environment) — platform staff still pass in that
+ * case so existing admin behaviour survives; org members cannot, because
+ * without a row there is no organisation to be a member of.
+ */
+export async function checkEventAccess(
+  cohort: string,
+  action: EventAction
+): Promise<
+  | { authorized: true; event: EventRecord | null; user: { id: string; email: string; role: UserRole } }
+  | { authorized: false; response: NextResponse }
+> {
+  const session = await auth()
+  if (!session?.user?.email) {
+    return {
+      authorized: false,
+      response: NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 }),
+    }
+  }
+  const role = ((session.user as { role?: string }).role ?? "MEMBER") as UserRole
+  const user = { id: session.user.id ?? "", email: session.user.email, role }
+
+  const event = await getEventByCohort(cohort)
+
+  let isOrgMember = false
+  if (event && user.id) {
+    try {
+      const membership = await prisma.organisationMember.findUnique({
+        where: {
+          organisationId_userId: { organisationId: event.organisationId, userId: user.id },
+        },
+        select: { id: true },
+      })
+      isOrgMember = membership !== null
+    } catch {
+      // Missing table pre-migration — platform tier still decides.
+      isOrgMember = false
+    }
+  }
+
+  if (!hasEventAccess(role, isOrgMember, action)) {
+    return {
+      authorized: false,
+      response: NextResponse.json({ success: false, error: "Forbidden" }, { status: 403 }),
+    }
+  }
+  return { authorized: true, event, user }
+}

--- a/src/lib/impact-lab/event-branding.ts
+++ b/src/lib/impact-lab/event-branding.ts
@@ -12,6 +12,8 @@
  * override can replace the lookup table later without touching call sites.
  */
 
+import { getEventByCohort } from "./event-store"
+
 /** The facts an export prints about the event it covers. */
 export interface EventBranding {
   /** Cover title split for the two-tone treatment. */
@@ -76,22 +78,34 @@ export const AFRETEC_BRANDING: EventBranding = {
 
 // ─── Resolution ──────────────────────────────────────────────────────────────
 
-/**
- * Cohort → branding. A cohort absent from this map is branded as the Impact
- * Lab event, which is the right default: every export produced before this
- * system knew about a second event was for that one.
- */
+/** Code-constant fallbacks for the two events that predate the Event table. */
 const BRANDING_BY_COHORT: Readonly<Record<string, EventBranding>> = {
   "afretec-makerthon-2026-08": AFRETEC_BRANDING,
 }
 
 /**
- * The branding a cohort's exports print.
+ * The branding a cohort's exports print, from the Event row when one exists.
  *
  * Never throws on an unknown cohort — an organiser generating a report mid
  * event must not hit an error page because a slug was typed differently
- * somewhere. An unknown cohort gets the Impact Lab branding.
+ * somewhere. Resolution order: Event row → per-cohort code constant →
+ * Impact Lab default.
  */
-export function brandingForCohort(cohort: string): EventBranding {
+export async function brandingForCohort(cohort: string): Promise<EventBranding> {
+  const event = await getEventByCohort(cohort)
+  if (event) {
+    return {
+      titleLead: event.titleLead,
+      titleAccent: event.titleAccent,
+      title: event.name,
+      dates: event.dates,
+      host: event.organisationName,
+      location: event.location,
+      formatNote: event.formatNote,
+      ...(event.organisationName !== REPORT_PRODUCER
+        ? { platformNote: `Run on the Impact Lab platform by ${REPORT_PRODUCER}` }
+        : {}),
+    }
+  }
   return BRANDING_BY_COHORT[cohort] ?? IMPACT_LAB_BRANDING
 }

--- a/src/lib/impact-lab/event-lifecycle.ts
+++ b/src/lib/impact-lab/event-lifecycle.ts
@@ -85,11 +85,11 @@ const COHORT_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/i
 /**
  * Validate user-supplied cohort input to a safe slug, or null.
  *
- * This is the successor to constants.ts `safeCohort`, minus the fallback:
- * what "no cohort named" means now depends on who is asking (a member's own
- * events, the admin default event), so callers own the fallback and this
- * function only answers "is this string safe to put in a query and a
- * Content-Disposition header?".
+ * This is the successor to constants.ts's single-cohort input coercer, minus
+ * the fallback: what "no cohort named" means now depends on who is asking (a
+ * member's own events, the admin default event), so callers own the fallback
+ * and this function only answers "is this string safe to put in a query and
+ * a Content-Disposition header?".
  */
 export function validCohort(input: string | null | undefined): string | null {
   const value = (input ?? "").trim()

--- a/src/lib/impact-lab/event-lifecycle.ts
+++ b/src/lib/impact-lab/event-lifecycle.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure event-lifecycle logic: which status transitions are legal, which
+ * events a participant can see, and cohort slug validation.
+ *
+ * No database access — everything here is assertable by scripts/verify-events.ts
+ * without infrastructure, the same split judging.ts has from its routes.
+ */
+
+export const EVENT_STATUSES = ["DRAFT", "LIVE", "CLOSED", "ARCHIVED"] as const
+export type EventStatusValue = (typeof EVENT_STATUSES)[number]
+
+/**
+ * Whether an admin may move an event between two statuses.
+ *
+ * The graph is deliberately narrow: DRAFT⇄LIVE (back only while nobody has
+ * registered — un-launching an event people joined would hide their data),
+ * LIVE⇄CLOSED (reopening a closed event is a legitimate organiser action),
+ * CLOSED⇄ARCHIVED. Archiving from anywhere else must pass through CLOSED so
+ * that "archived" always means "was properly closed first".
+ */
+export function canTransition(
+  from: EventStatusValue,
+  to: EventStatusValue,
+  hasParticipants: boolean
+): { ok: true } | { ok: false; reason: string } {
+  if (from === to) return { ok: false, reason: "The event is already in that state." }
+  if (from === "DRAFT" && to === "LIVE") return { ok: true }
+  if (from === "LIVE" && to === "DRAFT") {
+    return hasParticipants
+      ? { ok: false, reason: "People have already registered — close the event instead of un-launching it." }
+      : { ok: true }
+  }
+  if (from === "LIVE" && to === "CLOSED") return { ok: true }
+  if (from === "CLOSED" && to === "LIVE") return { ok: true }
+  if (from === "CLOSED" && to === "ARCHIVED") return { ok: true }
+  if (from === "ARCHIVED" && to === "CLOSED") return { ok: true }
+  return { ok: false, reason: `An event cannot go from ${from} to ${to}.` }
+}
+
+/** The minimum shape resolution needs; event-store rows satisfy it. */
+export interface MemberEventRef {
+  cohort: string
+  status: EventStatusValue
+  createdAt: Date
+}
+
+/**
+ * The events a participant may see, in display order: LIVE before CLOSED,
+ * newest first within each. DRAFT (not launched) and ARCHIVED (deliberately
+ * hidden) are excluded — a participant's view of an archived event is a
+ * platform-admin conversation, not a dashboard surface.
+ */
+export function orderMemberEvents<T extends MemberEventRef>(events: T[]): T[] {
+  const rank: Record<EventStatusValue, number> = { LIVE: 0, CLOSED: 1, DRAFT: 9, ARCHIVED: 9 }
+  return events
+    .filter((e) => e.status === "LIVE" || e.status === "CLOSED")
+    .sort((a, b) =>
+      rank[a.status] !== rank[b.status]
+        ? rank[a.status] - rank[b.status]
+        : b.createdAt.getTime() - a.createdAt.getTime()
+    )
+}
+
+/**
+ * The single event a member request operates on. An explicitly requested
+ * cohort wins only if the caller is actually a visible member of it —
+ * otherwise the newest visible event (LIVE first). Null when the caller
+ * belongs to no visible event, which routes surface as their existing
+ * "no team" experience.
+ */
+export function pickMemberEvent<T extends MemberEventRef>(
+  events: T[],
+  requested?: string | null
+): T | null {
+  const visible = orderMemberEvents(events)
+  if (requested) {
+    const match = visible.find((e) => e.cohort === requested)
+    if (match) return match
+  }
+  return visible[0] ?? null
+}
+
+const COHORT_PATTERN = /^[a-z0-9][a-z0-9-]{0,59}$/i
+
+/**
+ * Validate user-supplied cohort input to a safe slug, or null.
+ *
+ * This is the successor to constants.ts `safeCohort`, minus the fallback:
+ * what "no cohort named" means now depends on who is asking (a member's own
+ * events, the admin default event), so callers own the fallback and this
+ * function only answers "is this string safe to put in a query and a
+ * Content-Disposition header?".
+ */
+export function validCohort(input: string | null | undefined): string | null {
+  const value = (input ?? "").trim()
+  return COHORT_PATTERN.test(value) ? value : null
+}

--- a/src/lib/impact-lab/event-store.ts
+++ b/src/lib/impact-lab/event-store.ts
@@ -123,8 +123,9 @@ export async function defaultAdminCohort(): Promise<string> {
 
 /**
  * The cohort an admin request operates on: the validated `?cohort=` input,
- * or the admin default. This is the successor to `safeCohort` — same
- * injection-safety contract, database-backed fallback.
+ * or the admin default. This is the successor to constants.ts's old
+ * single-cohort resolver — same injection-safety contract, database-backed
+ * fallback.
  */
 export async function resolveAdminCohort(
   input: string | null | undefined
@@ -147,10 +148,11 @@ export async function resolveMemberEvents(email: string): Promise<MemberEvent[]>
 
   const events = await listEvents()
   if (events.length === 0) {
-    // Pre-migration degrade: behave like the old CURRENT_COHORT world —
-    // including whether it's LIVE. isCohortActive reads IMPACT_LAB_ACTIVE_COHORT,
-    // the same env var guardClosedCohort still honors pre-migration; hardcoding
-    // CLOSED here would tell a member their live event had wrapped.
+    // Pre-migration degrade: behave like the old single-cohort, env-driven
+    // world — including whether it's LIVE. isCohortActive reads
+    // IMPACT_LAB_ACTIVE_COHORT, the same env var guardClosedCohort still
+    // honors pre-migration; hardcoding CLOSED here would tell a member their
+    // live event had wrapped.
     const fallback = participants.find((p) => p.cohort === DEFAULT_COHORT)
     return fallback
       ? [

--- a/src/lib/impact-lab/event-store.ts
+++ b/src/lib/impact-lab/event-store.ts
@@ -9,7 +9,7 @@
  */
 
 import { prisma } from "@/lib/prisma"
-import { DEFAULT_COHORT } from "./constants"
+import { DEFAULT_COHORT, isCohortActive } from "./constants"
 import {
   orderMemberEvents,
   pickMemberEvent,
@@ -147,7 +147,10 @@ export async function resolveMemberEvents(email: string): Promise<MemberEvent[]>
 
   const events = await listEvents()
   if (events.length === 0) {
-    // Pre-migration degrade: behave like the old CURRENT_COHORT world.
+    // Pre-migration degrade: behave like the old CURRENT_COHORT world —
+    // including whether it's LIVE. isCohortActive reads IMPACT_LAB_ACTIVE_COHORT,
+    // the same env var guardClosedCohort still honors pre-migration; hardcoding
+    // CLOSED here would tell a member their live event had wrapped.
     const fallback = participants.find((p) => p.cohort === DEFAULT_COHORT)
     return fallback
       ? [
@@ -157,7 +160,7 @@ export async function resolveMemberEvents(email: string): Promise<MemberEvent[]>
             organisationName: "Claude Community Kenya",
             cohort: DEFAULT_COHORT,
             name: DEFAULT_COHORT,
-            status: "CLOSED",
+            status: isCohortActive(DEFAULT_COHORT) ? "LIVE" : "CLOSED",
             titleLead: "",
             titleAccent: "",
             dates: "",

--- a/src/lib/impact-lab/event-store.ts
+++ b/src/lib/impact-lab/event-store.ts
@@ -1,0 +1,195 @@
+/**
+ * Database access for the tenancy tables, with the same degrade posture as
+ * rubric-store.ts: an environment whose migration has not run yet (P2021,
+ * missing table) behaves like the pre-tenancy system instead of erroring.
+ *
+ * Every function here is a thin query; the decisions (ordering, picking,
+ * transition legality) live in event-lifecycle.ts where they are pure and
+ * verified without a database.
+ */
+
+import { prisma } from "@/lib/prisma"
+import { DEFAULT_COHORT } from "./constants"
+import {
+  orderMemberEvents,
+  pickMemberEvent,
+  validCohort,
+  type EventStatusValue,
+} from "./event-lifecycle"
+
+export interface EventRecord {
+  id: string
+  organisationId: string
+  organisationName: string
+  cohort: string
+  name: string
+  status: EventStatusValue
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+  groundRules: string | null
+  createdAt: Date
+}
+
+export interface MemberEvent extends EventRecord {
+  participantId: string
+}
+
+/** True for Prisma's "table does not exist" — the migration hasn't run here. */
+function isMissingTable(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { code?: string }).code === "P2021"
+  )
+}
+
+const EVENT_SELECT = {
+  id: true,
+  organisationId: true,
+  cohort: true,
+  name: true,
+  status: true,
+  titleLead: true,
+  titleAccent: true,
+  dates: true,
+  location: true,
+  formatNote: true,
+  groundRules: true,
+  createdAt: true,
+  organisation: { select: { name: true } },
+} as const
+
+type EventRow = {
+  id: string
+  organisationId: string
+  cohort: string
+  name: string
+  status: EventStatusValue
+  titleLead: string
+  titleAccent: string
+  dates: string
+  location: string
+  formatNote: string
+  groundRules: string | null
+  createdAt: Date
+  organisation: { name: string }
+}
+
+function toRecord(row: EventRow): EventRecord {
+  const { organisation, ...rest } = row
+  return { ...rest, organisationName: organisation.name }
+}
+
+/** The event owning a cohort slug, or null (unknown cohort OR pre-migration). */
+export async function getEventByCohort(cohort: string): Promise<EventRecord | null> {
+  try {
+    const row = await prisma.impactLabEvent.findUnique({ where: { cohort }, select: EVENT_SELECT })
+    return row ? toRecord(row as EventRow) : null
+  } catch (error) {
+    if (isMissingTable(error)) return null
+    throw error
+  }
+}
+
+/** Every event, newest first; [] pre-migration. */
+export async function listEvents(): Promise<EventRecord[]> {
+  try {
+    const rows = await prisma.impactLabEvent.findMany({
+      select: EVENT_SELECT,
+      orderBy: { createdAt: "desc" },
+    })
+    return (rows as EventRow[]).map(toRecord)
+  } catch (error) {
+    if (isMissingTable(error)) return []
+    throw error
+  }
+}
+
+/**
+ * The cohort admin surfaces default to when none is named: the newest
+ * non-archived event, preferring LIVE — so during an event every admin
+ * screen opens on the running event, and afterwards on the latest record.
+ * Falls back to DEFAULT_COHORT pre-migration or on an empty table.
+ */
+export async function defaultAdminCohort(): Promise<string> {
+  const events = await listEvents()
+  const candidates = events.filter((e) => e.status !== "ARCHIVED")
+  const live = candidates.find((e) => e.status === "LIVE")
+  return live?.cohort ?? candidates[0]?.cohort ?? DEFAULT_COHORT
+}
+
+/**
+ * The cohort an admin request operates on: the validated `?cohort=` input,
+ * or the admin default. This is the successor to `safeCohort` — same
+ * injection-safety contract, database-backed fallback.
+ */
+export async function resolveAdminCohort(
+  input: string | null | undefined
+): Promise<string> {
+  return validCohort(input) ?? defaultAdminCohort()
+}
+
+/**
+ * Every visible event this email holds a participant row in, LIVE first
+ * then newest. Pre-migration, degrades to "member of DEFAULT_COHORT if a
+ * participant row exists there" so existing behaviour survives an
+ * un-migrated environment.
+ */
+export async function resolveMemberEvents(email: string): Promise<MemberEvent[]> {
+  const participants = await prisma.impactLabParticipant.findMany({
+    where: { email },
+    select: { id: true, cohort: true },
+  })
+  if (participants.length === 0) return []
+
+  const events = await listEvents()
+  if (events.length === 0) {
+    // Pre-migration degrade: behave like the old CURRENT_COHORT world.
+    const fallback = participants.find((p) => p.cohort === DEFAULT_COHORT)
+    return fallback
+      ? [
+          {
+            id: "",
+            organisationId: "",
+            organisationName: "Claude Community Kenya",
+            cohort: DEFAULT_COHORT,
+            name: DEFAULT_COHORT,
+            status: "CLOSED",
+            titleLead: "",
+            titleAccent: "",
+            dates: "",
+            location: "",
+            formatNote: "",
+            groundRules: null,
+            createdAt: new Date(0),
+            participantId: fallback.id,
+          },
+        ]
+      : []
+  }
+
+  const byCohort = new Map(events.map((e) => [e.cohort, e]))
+  const memberEvents: MemberEvent[] = []
+  for (const participant of participants) {
+    const event = byCohort.get(participant.cohort)
+    if (event) memberEvents.push({ ...event, participantId: participant.id })
+  }
+  return orderMemberEvents(memberEvents)
+}
+
+/** The single event a member request operates on — see pickMemberEvent. */
+export async function resolveMemberEvent(
+  email: string,
+  requested?: string | null
+): Promise<MemberEvent | null> {
+  return pickMemberEvent(await resolveMemberEvents(email), requested)
+}
+
+/** Whether anyone has ever been registered into this cohort. */
+export async function eventHasParticipants(cohort: string): Promise<boolean> {
+  const count = await prisma.impactLabParticipant.count({ where: { cohort } })
+  return count > 0
+}

--- a/src/lib/impact-lab/event-store.ts
+++ b/src/lib/impact-lab/event-store.ts
@@ -9,7 +9,7 @@
  */
 
 import { prisma } from "@/lib/prisma"
-import { DEFAULT_COHORT, isCohortActive } from "./constants"
+import { DEFAULT_COHORT } from "./constants"
 import {
   orderMemberEvents,
   pickMemberEvent,
@@ -148,11 +148,10 @@ export async function resolveMemberEvents(email: string): Promise<MemberEvent[]>
 
   const events = await listEvents()
   if (events.length === 0) {
-    // Pre-migration degrade: behave like the old single-cohort, env-driven
-    // world — including whether it's LIVE. isCohortActive reads
-    // IMPACT_LAB_ACTIVE_COHORT, the same env var guardClosedCohort still
-    // honors pre-migration; hardcoding CLOSED here would tell a member their
-    // live event had wrapped.
+    // Pre-migration degrade: pre-migration environments are read-only by
+    // design once the env vars are gone — the deploy checklist applies the
+    // migration and seed before this code reaches production, and guard +
+    // UI now agree (both closed).
     const fallback = participants.find((p) => p.cohort === DEFAULT_COHORT)
     return fallback
       ? [
@@ -162,7 +161,7 @@ export async function resolveMemberEvents(email: string): Promise<MemberEvent[]>
             organisationName: "Claude Community Kenya",
             cohort: DEFAULT_COHORT,
             name: DEFAULT_COHORT,
-            status: isCohortActive(DEFAULT_COHORT) ? "LIVE" : "CLOSED",
+            status: "CLOSED",
             titleLead: "",
             titleAccent: "",
             dates: "",

--- a/src/lib/impact-lab/event-store.ts
+++ b/src/lib/impact-lab/event-store.ts
@@ -193,3 +193,18 @@ export async function eventHasParticipants(cohort: string): Promise<boolean> {
   const count = await prisma.impactLabParticipant.count({ where: { cohort } })
   return count > 0
 }
+
+/**
+ * The event a not-yet-registered visitor may self-register into: the newest
+ * LIVE event, or null when nothing is currently open. Distinct from
+ * `resolveMemberEvent`, which requires an existing participant row — this is
+ * the "is there anything to sign up for right now" check the registration
+ * invitation gates on. `listEvents` is already newest-first, so the first
+ * LIVE event found is the one wanted; [] pre-migration degrades to null, the
+ * same "no event live → read-only, no invitation" behaviour the env-var
+ * system had.
+ */
+export async function openRegistrationEvent(): Promise<EventRecord | null> {
+  const events = await listEvents()
+  return events.find((e) => e.status === "LIVE") ?? null
+}

--- a/src/lib/impact-lab/export-excel.ts
+++ b/src/lib/impact-lab/export-excel.ts
@@ -496,7 +496,7 @@ function addParticipantsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): 
   }
 }
 
-function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+async function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport): Promise<void> {
   const sheet = workbook.addWorksheet("Summary")
   sheet.columns = [
     { key: "label", width: 34, style: { alignment: { vertical: "top" } } },
@@ -526,7 +526,7 @@ function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
     sheet.addRow({})
   }
 
-  const branding = brandingForCohort(data.cohort)
+  const branding = await brandingForCohort(data.cohort)
 
   section("Event")
   fact("Event", branding.title)
@@ -645,7 +645,7 @@ export async function buildResultsWorkbook(
   analyses: ReadonlyMap<string, TeamAnalysis> = new Map()
 ): Promise<Buffer> {
   const workbook = new ExcelJS.Workbook()
-  workbook.creator = brandingForCohort(data.cohort).host
+  workbook.creator = (await brandingForCohort(data.cohort)).host
   workbook.created = data.generatedAt
 
   addResultsSheet(workbook, data)
@@ -655,7 +655,7 @@ export async function buildResultsWorkbook(
   addTracksSheet(workbook, data)
   addAnalysesSheet(workbook, data, analyses)
   addParticipantsSheet(workbook, data)
-  addSummarySheet(workbook, data)
+  await addSummarySheet(workbook, data)
 
   return Buffer.from(await workbook.xlsx.writeBuffer())
 }

--- a/src/lib/impact-lab/export-pdf.ts
+++ b/src/lib/impact-lab/export-pdf.ts
@@ -1544,11 +1544,11 @@ function renderFurniture(doc: Doc, state: RenderState, branding: EventBranding):
  * are optional by construction: a missing entry means that team's analysis
  * section is simply absent (see export-analysis's fail-soft rule).
  */
-export function buildResultsPdf(
+export async function buildResultsPdf(
   data: ResultsExport,
   analyses: ReadonlyMap<string, TeamAnalysis> = new Map()
 ): Promise<Buffer> {
-  const branding = brandingForCohort(data.cohort)
+  const branding = await brandingForCohort(data.cohort)
   return new Promise<Buffer>((resolve, reject) => {
     const doc = new PDFDocument({
       size: "A4",


### PR DESCRIPTION
## What this is

Sub-project 1 of the multi-tenant event platform (approach C, per the approved spec + plan in `docs/superpowers/`): events become database rows owned by organisations, with a dashboard-controlled lifecycle replacing the `IMPACT_LAB_ACTIVE_COHORT` env var.

- **New models**: `Organisation` (cck + c4dlab backfilled), `OrganisationMember` (OWNER/ORGANISER, orthogonal to site roles), `ImpactLabEvent` owning a unique cohort slug. Migration is **purely additive** — the nine legacy cohort-keyed tables are untouched.
- **Lifecycle**: DRAFT → LIVE → CLOSED → ARCHIVED from the new admin Events tab, no redeploys; several events can be LIVE at once.
- **Resolution**: participants resolve their event by membership (multi-event picker when needed, returning-participant invite banner); judges via the event picker; admin via the event-backed selector. `CURRENT_COHORT`/`safeCohort`/`isCohortActive` are deleted — compile-time-enforced.
- **Auth**: two-tier — platform roles pass everywhere; org members get full run of their OWN org's events only (cross-tenant probe verified 403).
- **Branding**: report/export branding resolves from the Event row (code constants as fallback).
- Pre-migration environments degrade read-only by design.

## Review record

12 tasks, each implemented by a fresh subagent and gated by an independent spec+quality review; 3 fix rounds total, all re-reviewed. Final whole-branch review (most capable model): **mergeable with conditions — zero code findings**. Gates on the final tree: `verify:events` 37/0, `verify:judging` all passed, `tsc --noEmit` clean, `next build` clean.

## ⚠️ Deploy order — read before merging

Merging auto-deploys to Vercel. **Run these BEFORE merging** (old code ignores the new tables, so pre-applying is safe and leaves zero degraded window):

1. SSH tunnel to the DB VPS (direct port 5433, never PgBouncer): `npx prisma migrate deploy` with the tunnel URL.
2. `npm run seed:events` (dry-run, inspect) then `npm run seed:events -- --apply` (idempotent; never overwrites an admin-set status).
3. Confirm both cohorts' final runs have `judgingClosedAt` set (CLOSED status does not block judge scores — the run flag does) and rotate `JUDGE_ACCESS_CODE`.
4. After merge: remove `IMPACT_LAB_ACTIVE_COHORT` + `IMPACT_LAB_COHORT_LABEL` from Vercel (dead code now); smoke-test the admin Events tab (both events listed CLOSED), the dashboards read-only views, an Afretec report export, and the two client flows flagged by review (post-registration remount, returning-participant invite banner — needs a login with a July membership plus a second LIVE event).

If merged before migrating: nothing crashes or is lost, but member writes 403, Afretec participants temporarily lose dashboard read access, and events-tab writes 503 until migration+seed run — recovery is automatic, no redeploy needed.

@Spidey-Acer

https://claude.ai/code/session_01U99bKqojTVppEAmLaN4d9E