### PR TITLE
fix(impact-lab): export renders each event's own rubric, not July's

### DIFF
--- a/src/app/api/admin/impact-lab/results/export/route.ts
+++ b/src/app/api/admin/impact-lab/results/export/route.ts
@@ -4,6 +4,7 @@ import { prisma } from "@/lib/prisma"
 import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import type { ScoreSheet } from "@/lib/impact-lab/judging"
+import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 import {
   buildResultsExport,
   parseResultsSnapshot,
@@ -141,7 +142,10 @@ export async function GET(request: NextRequest) {
     }),
   }
 
-  const data = buildResultsExport(source)
+  // `resolveRubric`, not the code constant: an organiser-authored rubric for
+  // this cohort must win, exactly as it does for the judging routes.
+  const rubric = await resolveRubric(cohort)
+  const data = buildResultsExport(source, rubric)
   const stamp = data.generatedAt.toISOString().slice(0, 10)
 
   // One generation pass per export run — both builders read the same map.

--- a/src/lib/impact-lab/export-data.ts
+++ b/src/lib/impact-lab/export-data.ts
@@ -19,11 +19,11 @@
  */
 
 import {
-  JUDGING_CRITERIA,
+  scoreTotal,
   standings,
   trackOf,
   trackWinners,
-  weightedTotal,
+  type JudgingRubric,
   type ScoreSheet,
 } from "./judging"
 import type { RankedTeam, ResultsSnapshot, ResultsTrackWinner } from "./results"
@@ -229,6 +229,13 @@ export interface ExportSummary {
 export interface ResultsExport {
   cohort: string
   generatedAt: Date
+  /**
+   * The rubric this cohort was judged on. Carried on the export itself so the
+   * Excel and PDF renderers never fall back to a hardcoded default — every
+   * criteria loop, column count, and denominator in this document is driven
+   * by this rubric, not by the Impact Lab constant.
+   */
+  rubric: JudgingRubric
   /** Whether the announced result has been published (snapshot present). */
   published: boolean
   publishedAt: string | null
@@ -290,9 +297,9 @@ function toMember(p: SourceParticipant, leaderId: string | null | undefined): Ex
   }
 }
 
-function toJudgeScore(score: SourceScore): ExportJudgeScore {
+function toJudgeScore(score: SourceScore, rubric: JudgingRubric): ExportJudgeScore {
   const criteria: Record<string, number | null> = {}
-  for (const criterion of JUDGING_CRITERIA) {
+  for (const criterion of rubric.criteria) {
     const raw = score.sheet[criterion.key]
     criteria[criterion.key] =
       typeof raw === "number" && !Number.isNaN(raw) ? raw : null
@@ -301,7 +308,7 @@ function toJudgeScore(score: SourceScore): ExportJudgeScore {
     judgeName: score.judgeName,
     judgeEmail: score.judgeEmail,
     criteria,
-    weightedTotal: weightedTotal(score.sheet),
+    weightedTotal: scoreTotal(score.sheet, rubric),
     writeupOnly: score.writeupOnly,
     feedback: score.feedback?.trim() ? score.feedback.trim() : null,
   }
@@ -310,11 +317,19 @@ function toJudgeScore(score: SourceScore): ExportJudgeScore {
 /**
  * Assemble everything the Excel and PDF builders render.
  *
- * All ranking arithmetic is `standings`/`weightedTotal`/`trackWinners` from
+ * All ranking arithmetic is `standings`/`scoreTotal`/`trackWinners` from
  * `./judging` — this module joins and labels, it never re-derives a number
- * that decides who won.
+ * that decides who won. `rubric` must be the one this cohort was actually
+ * judged on (resolve it with `resolveRubric` before calling this — it stays
+ * pure and dependency-free, like `./judging`, so the caller owns the DB
+ * lookup) or every criterion, total, and ranking below is scored against the
+ * wrong event.
  */
-export function buildResultsExport(source: ExportSource, now: Date = new Date()): ResultsExport {
+export function buildResultsExport(
+  source: ExportSource,
+  rubric: JudgingRubric,
+  now: Date = new Date()
+): ResultsExport {
   const participantById = new Map(source.participants.map((p) => [p.id, p]))
   const submissionByTeam = new Map(source.submissions.map((s) => [s.teamId, s]))
   const reviewByTeam = new Map(source.reviews.map((r) => [r.teamId, r.text]))
@@ -327,7 +342,8 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
   }
 
   const table = standings(
-    source.scores.map((s) => ({ judgeEmail: s.judgeEmail, teamId: s.teamId, sheet: s.sheet }))
+    source.scores.map((s) => ({ judgeEmail: s.judgeEmail, teamId: s.teamId, sheet: s.sheet })),
+    rubric
   )
   const standingByTeam = new Map(table.map((t) => [t.teamId, t]))
   // `standings` is already sorted by average desc, id — position is score rank.
@@ -378,7 +394,7 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
 
   const teams: ExportTeam[] = source.teams.map((team) => {
     const standing = standingByTeam.get(team.id)
-    const judgeScores = (scoresByTeam.get(team.id) ?? []).map(toJudgeScore)
+    const judgeScores = (scoresByTeam.get(team.id) ?? []).map((s) => toJudgeScore(s, rubric))
     const snapshotRow = finalRankByTeam.get(team.id)
     const submission = submissionByTeam.get(team.id)
 
@@ -455,7 +471,7 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
   }
   const judgeSummaries: ExportJudgeSummary[] = [...byJudge.values()]
     .map((sheets) => {
-      const totals = sheets.map((s) => weightedTotal(s.sheet))
+      const totals = sheets.map((s) => scoreTotal(s.sheet, rubric))
       return {
         judgeName: sheets[0].judgeName,
         judgeEmail: sheets[0].judgeEmail,
@@ -519,6 +535,7 @@ export function buildResultsExport(source: ExportSource, now: Date = new Date())
   return {
     cohort: source.cohort,
     generatedAt: now,
+    rubric,
     published: snapshot !== null,
     publishedAt: snapshot?.publishedAt ?? source.publishedAt,
     announced,

--- a/src/lib/impact-lab/export-excel.ts
+++ b/src/lib/impact-lab/export-excel.ts
@@ -13,7 +13,7 @@
  */
 
 import ExcelJS from "exceljs"
-import { JUDGING_CRITERIA, SCORE_LABELS } from "./judging"
+import { totalOutOf } from "./judging"
 import { type ExportTeam, type ResultsExport } from "./export-data"
 import { brandingForCohort } from "./event-branding"
 import { ANALYSIS_PROVENANCE, type TeamAnalysis } from "./export-analysis"
@@ -162,6 +162,8 @@ const WRITEUP_NOTE =
 // ─── Sheets ──────────────────────────────────────────────────────────────────
 
 function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+  const rubric = data.rubric
+  const denom = totalOutOf(rubric)
   const columns: ColumnSpec[] = [
     { header: "Final placing", key: "finalRank", width: 12, numFmt: "0" },
     { header: "Placing basis", key: "basis", width: 26 },
@@ -170,13 +172,13 @@ function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
     { header: "Track", key: "track", width: 22 },
     { header: "Project", key: "project", width: 26 },
     { header: "Score rank", key: "scoreRank", width: 11, numFmt: "0" },
-    { header: "Weighted average (/100)", key: "average", width: 16, numFmt: SCORE_FMT },
-    { header: "Judge low (/100)", key: "scoreLow", width: 11, numFmt: SCORE_FMT },
-    { header: "Judge high (/100)", key: "scoreHigh", width: 11, numFmt: SCORE_FMT },
+    { header: `Weighted average (/${denom})`, key: "average", width: 16, numFmt: SCORE_FMT },
+    { header: `Judge low (/${denom})`, key: "scoreLow", width: 11, numFmt: SCORE_FMT },
+    { header: `Judge high (/${denom})`, key: "scoreHigh", width: 11, numFmt: SCORE_FMT },
     { header: "Judge spread", key: "spread", width: 11, numFmt: SCORE_FMT },
     { header: "Judges", key: "judges", width: 8, numFmt: "0" },
-    ...JUDGING_CRITERIA.map((c) => ({
-      header: `${c.label} (avg /5)`,
+    ...rubric.criteria.map((c) => ({
+      header: `${c.label} (avg /${c.max})`,
       key: `avg_${c.key}`,
       width: 13,
       numFmt: SCORE_FMT,
@@ -213,7 +215,7 @@ function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
           : "—",
       judges: team.judgeCount,
       ...Object.fromEntries(
-        JUDGING_CRITERIA.map((c) => [`avg_${c.key}`, team.criterionAverages[c.key] ?? "—"])
+        rubric.criteria.map((c) => [`avg_${c.key}`, team.criterionAverages[c.key] ?? "—"])
       ),
       trackWinner: team.isTrackWinner ? "Yes" : "",
       champion: team.isChampion ? "Yes" : "",
@@ -231,9 +233,9 @@ function addResultsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
     }
   }
 
-  // Honest in-cell bars: 0→100 anchoring, on the average column.
+  // Honest in-cell bars: 0→denom anchoring, on the average column.
   const averageColumn = columns.findIndex((c) => c.key === "average") + 1
-  addDataBars(sheet, averageColumn, data.teams.length, 100)
+  addDataBars(sheet, averageColumn, data.teams.length, denom)
 }
 
 function addSubmissionsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
@@ -294,6 +296,7 @@ function addSubmissionsSheet(workbook: ExcelJS.Workbook, data: ResultsExport): v
 }
 
 function addJudgingSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+  const rubric = data.rubric
   const columns: ColumnSpec[] = [
     { header: "Final placing", key: "finalRank", width: 12, numFmt: "0" },
     { header: "Team", key: "team", width: 26 },
@@ -302,13 +305,13 @@ function addJudgingSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
     { header: "Judge", key: "judge", width: 20 },
     { header: "Judge email", key: "judgeEmail", width: 26 },
     { header: "Scoring basis", key: "basis", width: 20 },
-    ...JUDGING_CRITERIA.map((c) => ({
-      header: `${c.label} (1–5)`,
+    ...rubric.criteria.map((c) => ({
+      header: `${c.label} (${c.min}–${c.max})`,
       key: `crit_${c.key}`,
       width: 13,
       numFmt: "0",
     })),
-    { header: "Weighted total (/100)", key: "total", width: 13, numFmt: SCORE_FMT },
+    { header: `Weighted total (/${totalOutOf(rubric)})`, key: "total", width: 13, numFmt: SCORE_FMT },
     { header: "Feedback", key: "feedback", width: 70, wrap: true },
   ]
   const sheet = addSheet(workbook, "Judging detail", columns, { autoFilter: true })
@@ -324,7 +327,7 @@ function addJudgingSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
         judgeEmail: score.judgeEmail,
         basis: score.writeupOnly ? "Written submission" : "Live demo",
         ...Object.fromEntries(
-          JUDGING_CRITERIA.map((c) => [`crit_${c.key}`, score.criteria[c.key] ?? "—"])
+          rubric.criteria.map((c) => [`crit_${c.key}`, score.criteria[c.key] ?? "—"])
         ),
         total: score.weightedTotal,
         feedback: score.feedback ?? "",
@@ -341,6 +344,7 @@ function addJudgingSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void 
 
 /** One row per judge: coverage and how they used the scale. */
 function addJudgesSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+  const denom = totalOutOf(data.rubric)
   const columns: ColumnSpec[] = [
     { header: "Judge", key: "judge", width: 22 },
     { header: "Judge email", key: "email", width: 28 },
@@ -348,7 +352,7 @@ function addJudgesSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
     { header: "Live demos", key: "live", width: 11, numFmt: "0" },
     { header: "From writeups", key: "writeup", width: 12, numFmt: "0" },
     { header: "Written notes left", key: "notes", width: 14, numFmt: "0" },
-    { header: "Mean weighted total (/100)", key: "mean", width: 16, numFmt: SCORE_FMT },
+    { header: `Mean weighted total (/${denom})`, key: "mean", width: 16, numFmt: SCORE_FMT },
   ]
   const sheet = addSheet(workbook, "Judges", columns)
   for (const judge of data.judgeSummaries) {
@@ -362,7 +366,7 @@ function addJudgesSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
       mean: judge.meanWeightedTotal,
     })
   }
-  addDataBars(sheet, columns.findIndex((c) => c.key === "mean") + 1, data.judgeSummaries.length, 100)
+  addDataBars(sheet, columns.findIndex((c) => c.key === "mean") + 1, data.judgeSummaries.length, denom)
   const note = sheet.addRow({})
   note.getCell("judge").value =
     "Judges saw different, overlapping sets of teams; mean totals show how each judge used the scale, not a ranking of judges."
@@ -371,12 +375,13 @@ function addJudgesSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
 
 /** One row per track: participation, outcome, winner with its basis. */
 function addTracksSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
+  const denom = totalOutOf(data.rubric)
   const columns: ColumnSpec[] = [
     { header: "Track", key: "track", width: 26 },
     { header: "Teams formed", key: "formed", width: 12, numFmt: "0" },
     { header: "Teams submitted", key: "submitted", width: 13, numFmt: "0" },
     { header: "Teams scored", key: "scored", width: 12, numFmt: "0" },
-    { header: "Mean average (/100)", key: "mean", width: 16, numFmt: SCORE_FMT },
+    { header: `Mean average (/${denom})`, key: "mean", width: 16, numFmt: SCORE_FMT },
     { header: "Track winner (project)", key: "winnerProject", width: 24 },
     { header: "Track winner (team)", key: "winnerTeam", width: 28 },
     { header: "Winner basis", key: "basis", width: 22 },
@@ -401,7 +406,7 @@ function addTracksSheet(workbook: ExcelJS.Workbook, data: ResultsExport): void {
               : "—",
     })
   }
-  addDataBars(sheet, columns.findIndex((c) => c.key === "mean") + 1, data.trackSummaries.length, 100)
+  addDataBars(sheet, columns.findIndex((c) => c.key === "mean") + 1, data.trackSummaries.length, denom)
 }
 
 /**
@@ -552,7 +557,7 @@ async function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport):
   fact("Teams scored from their writeup", s.teamsScoredFromWriteup)
   fact("Judges on the floor", s.judges)
   fact("Scorecards recorded", s.scorecards)
-  fact("Mean team score (/100)", s.meanTeamAverage ?? "—")
+  fact(`Mean team score (/${totalOutOf(data.rubric)})`, s.meanTeamAverage ?? "—")
   fact("Tracks", s.tracks)
   gap()
 
@@ -579,16 +584,27 @@ async function addSummarySheet(workbook: ExcelJS.Workbook, data: ResultsExport):
   gap()
 
   section("Scoring criteria and weights")
-  for (const criterion of JUDGING_CRITERIA) {
-    fact(`${criterion.label} — ${criterion.weight} pts`, criterion.guidance, true)
+  const rubric = data.rubric
+  for (const criterion of rubric.criteria) {
+    fact(
+      `${criterion.label} — ${
+        rubric.scoring === "points" ? `${criterion.min}–${criterion.max} pts` : `${criterion.weight} pts`
+      }`,
+      criterion.guidance,
+      true
+    )
   }
   fact(
     "Scale",
-    Object.entries(SCORE_LABELS)
-      .map(([n, label]) => `${n} = ${label}`)
-      .join(" · ") +
-      ". A criterion contributes (score - 1) / 4 of its weight; a team's number is the mean of " +
-      "its judges' weighted totals.",
+    rubric.scoreLabels
+      ? Object.entries(rubric.scoreLabels)
+          .map(([n, label]) => `${n} = ${label}`)
+          .join(" · ") +
+          ". A criterion contributes (score - min) / (max - min) of its weight; a team's number is " +
+          "the mean of its judges' weighted totals."
+      : "Each criterion's raw score IS its points, on the scale stated in its own guidance above " +
+          "(no shared anchor text — the panel published a points rubric, not a normalised one). A " +
+          "team's number is the mean of its judges' totals.",
     true
   )
   gap()

--- a/src/lib/impact-lab/export-pdf.ts
+++ b/src/lib/impact-lab/export-pdf.ts
@@ -22,7 +22,7 @@
  */
 
 import PDFDocument from "pdfkit"
-import { JUDGING_CRITERIA, SCORE_LABELS } from "./judging"
+import { totalOutOf } from "./judging"
 import { type ExportTeam, type ResultsExport } from "./export-data"
 import { brandingForCohort, REPORT_PRODUCER, type EventBranding } from "./event-branding"
 import { REVIEW_PROVENANCE, REVIEW_SIGNATURE } from "./reviews"
@@ -378,8 +378,12 @@ function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): v
       "which is which."
   )
   markSection(doc, state, "How this record was produced")
+  const rubric = data.rubric
+  const denom = totalOutOf(rubric)
 
-  // 1 — Scoring model.
+  // 1 — Scoring model. The two rubrics score in different kinds of
+  // arithmetic (see judging-rubrics.ts) — this paragraph must say which one
+  // actually ran, never assert the other rubric's rule as if it were general.
   kicker(doc, "The scoring model")
   doc
     .font(SANS)
@@ -388,11 +392,18 @@ function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): v
     .text(
       // Plain ASCII arithmetic: U+2212 and U+2044 fall outside pdfkit's
       // WinAnsi standard-font encoding and print as garbage.
-      "Judges scored each project on five published criteria, 1 to 5, anchored the same way for " +
-        "everyone. A score of 1 means “not shown” and earns none of that criterion's weight; the " +
-        "scale is normalised so a criterion contributes (score - 1) / 4 of its weight, out of 100. " +
-        "A team's number is the mean of its judges' weighted totals — judges are averaged, not " +
-        "summed, so a team seen by two judges is not beaten by an identical team seen by four.",
+      rubric.scoring === "normalized"
+        ? `Judges scored each project on ${rubric.criteria.length} published criteria, anchored the ` +
+            "same way for everyone. The lowest score on each criterion means “not shown” and earns " +
+            "none of that criterion's weight; the scale is normalised so a criterion contributes " +
+            `(score - min) / (max - min) of its weight, out of ${denom}. A team's number is the mean ` +
+            "of its judges' totals — judges are averaged, not summed, so a team seen by two judges " +
+            "is not beaten by an identical team seen by four."
+        : `Judges scored each project on ${rubric.criteria.length} published criteria, each with its ` +
+            "own point scale set by the panel. The raw score on each criterion IS the points it " +
+            `earns — a team's total is the sum of its criteria, out of ${denom}. A team's number is ` +
+            "the mean of its judges' totals — judges are averaged, not summed, so a team seen by " +
+            "two judges is not beaten by an identical team seen by four.",
       MARGIN,
       doc.y,
       { width: CONTENT_WIDTH, lineGap: 2.5 }
@@ -402,7 +413,7 @@ function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): v
   // Criteria table: label, weight, guidance.
   const wCrit = 150
   const wWeight = 46
-  for (const criterion of JUDGING_CRITERIA) {
+  for (const criterion of rubric.criteria) {
     const top = doc.y
     doc.font(SANS_BOLD).fontSize(8.5).fillColor(INK).text(criterion.label, MARGIN, top, {
       width: wCrit - 8,
@@ -411,7 +422,14 @@ function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): v
       .font(SANS_BOLD)
       .fontSize(8.5)
       .fillColor(CLAY_DEEP)
-      .text(`${criterion.weight} pts`, MARGIN + wCrit, top, { width: wWeight, lineBreak: false })
+      .text(
+        rubric.scoring === "points"
+          ? `${criterion.min}–${criterion.max} pts`
+          : `${criterion.weight} pts`,
+        MARGIN + wCrit,
+        top,
+        { width: wWeight, lineBreak: false }
+      )
     doc
       .font(SANS)
       .fontSize(8.5)
@@ -423,19 +441,24 @@ function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): v
     doc.x = MARGIN
     doc.moveDown(0.55)
   }
-  doc
-    .font(SANS)
-    .fontSize(7.5)
-    .fillColor(FAINT)
-    .text(
-      "Scale anchors: " +
-        Object.entries(SCORE_LABELS)
-          .map(([n, label]) => `${n} = ${label}`)
-          .join(" · "),
-      MARGIN,
-      doc.y,
-      { width: CONTENT_WIDTH, lineGap: 2 }
-    )
+  // Points rubrics anchor their scale in each criterion's own guidance text
+  // (see judging-rubrics.ts), so `scoreLabels` is null and there is nothing
+  // generic to print here.
+  if (rubric.scoreLabels) {
+    doc
+      .font(SANS)
+      .fontSize(7.5)
+      .fillColor(FAINT)
+      .text(
+        "Scale anchors: " +
+          Object.entries(rubric.scoreLabels)
+            .map(([n, label]) => `${n} = ${label}`)
+            .join(" · "),
+        MARGIN,
+        doc.y,
+        { width: CONTENT_WIDTH, lineGap: 2 }
+      )
+  }
   doc.moveDown(1.1)
 
   // 2 — Coverage and the writeup rule.
@@ -534,14 +557,16 @@ function renderMethodology(doc: Doc, data: ResultsExport, state: RenderState): v
 
 // ─── The event in numbers ────────────────────────────────────────────────────
 
-function scoreBins(teams: ExportTeam[]): HistogramBin[] {
+/** Ten bins spanning the rubric's own denominator, not a hardcoded 0–100. */
+function scoreBins(teams: ExportTeam[], denom: number): HistogramBin[] {
+  const width = denom / 10
   const bins: HistogramBin[] = Array.from({ length: 10 }, (_, i) => ({
-    label: `${i * 10}–${i * 10 + 10}`,
+    label: `${Math.round(i * width)}–${Math.round(i * width + width)}`,
     count: 0,
   }))
   for (const team of teams) {
     if (team.average === null) continue
-    const index = Math.min(9, Math.floor(team.average / 10))
+    const index = Math.min(9, Math.floor(team.average / width))
     bins[index].count += 1
   }
   return bins
@@ -553,13 +578,14 @@ function scoreBins(teams: ExportTeam[]): HistogramBin[] {
  * lines because it is one composed page of charts.
  */
 function renderEventInNumbers(doc: Doc, data: ResultsExport, state: RenderState): void {
+  const denom = totalOutOf(data.rubric)
   sectionOpener(
     doc,
     "The field",
     "The event in numbers",
     "How the scores fell across the whole field — read alongside the methodology on the " +
-      "previous page. Score charts show weighted averages out of 100; the podium was decided " +
-      "by the panel, not by these charts."
+      `previous page. Score charts show weighted averages out of ${denom}; the podium was ` +
+      "decided by the panel, not by these charts."
   )
   markSection(doc, state, "The event in numbers")
 
@@ -569,13 +595,20 @@ function renderEventInNumbers(doc: Doc, data: ResultsExport, state: RenderState)
     .font(SANS)
     .fontSize(8)
     .fillColor(FAINT)
-    .text("Teams by weighted average (/100)", MARGIN, doc.y, { width: CONTENT_WIDTH })
+    .text(`Teams by weighted average (/${denom})`, MARGIN, doc.y, { width: CONTENT_WIDTH })
   doc.moveDown(0.5)
-  doc.y += drawHistogram(doc, MARGIN + 16, doc.y, CONTENT_WIDTH - 16, 90, scoreBins(data.teams))
+  doc.y += drawHistogram(
+    doc,
+    MARGIN + 16,
+    doc.y,
+    CONTENT_WIDTH - 16,
+    90,
+    scoreBins(data.teams, denom)
+  )
   doc.moveDown(1.2)
 
   // Tracks: mean score, with participation in the sublabel.
-  kicker(doc, "The five tracks", DIM)
+  kicker(doc, "The tracks", DIM)
   const trackRows: HBarRow[] = data.trackSummaries
     .filter((t) => t.track !== "Unassigned" || t.teamsFormed > 0)
     .map((t) => ({
@@ -585,9 +618,9 @@ function renderEventInNumbers(doc: Doc, data: ResultsExport, state: RenderState)
       valueLabel: t.meanAverage !== null ? fmt1(t.meanAverage) : "—",
     }))
   doc.y += drawHBars(doc, MARGIN, doc.y, CONTENT_WIDTH, trackRows, {
-    max: 100,
+    max: denom,
     labelWidth: 168,
-    scaleNote: "Mean of scored teams' weighted averages, 0–100. Track sizes differ — see sublabels.",
+    scaleNote: `Mean of scored teams' weighted averages, 0–${denom}. Track sizes differ — see sublabels.`,
   })
   doc.moveDown(1.2)
 
@@ -618,7 +651,7 @@ function renderEventInNumbers(doc: Doc, data: ResultsExport, state: RenderState)
     .fontSize(8)
     .fillColor(FAINT)
     .text(
-      "Each judge's mean weighted total across their own scorecards (/100). Judges saw " +
+      `Each judge's mean weighted total across their own scorecards (/${denom}). Judges saw ` +
         "different, overlapping sets of teams, so these are calibration profiles — not rankings " +
         "of the judges and not comparable head-to-head.",
       MARGIN,
@@ -635,7 +668,7 @@ function renderEventInNumbers(doc: Doc, data: ResultsExport, state: RenderState)
     dots: [j.meanWeightedTotal],
   }))
   doc.y += drawDotRows(doc, MARGIN, doc.y, CONTENT_WIDTH, judgeRows, {
-    max: 100,
+    max: denom,
     labelWidth: 168,
     rowHeight: 28,
   })
@@ -680,6 +713,7 @@ function renderWinners(doc: Doc, data: ResultsExport, state: RenderState): void 
       : "Results have not been published; the leaders below are ordered by score alone."
   )
   markSection(doc, state, "The winners")
+  const denom = totalOutOf(data.rubric)
 
   const medals = ["Champion", "First runner-up", "Second runner-up"]
   const teamByName = new Map(data.teams.map((t) => [t.teamName, t]))
@@ -714,7 +748,7 @@ function renderWinners(doc: Doc, data: ResultsExport, state: RenderState): void 
       .text(
         winner.teamName +
           (team?.average !== null && team?.average !== undefined
-            ? `  ·  panel average ${fmt1(team.average)}/100`
+            ? `  ·  panel average ${fmt1(team.average)}/${denom}`
             : ""),
         MARGIN + 16,
         top + 41,
@@ -788,23 +822,25 @@ function renderWinners(doc: Doc, data: ResultsExport, state: RenderState): void 
 // The team name is "Table N — Track", so a Team column would print the table
 // and track twice; Table + Track columns carry the same facts without the
 // noise. Headers sized to stay on one line at 7pt.
-const RANK_COLS = [
-  { label: "#", width: 24 },
-  { label: "Project", width: 132 },
-  { label: "Table", width: 48 },
-  { label: "Track", width: 100 },
-  { label: "Avg /100", width: 42 },
-  { label: "Range", width: 60 },
-  { label: "Judges", width: 38 },
-  { label: "Basis", width: 39 },
-] as const
+function rankCols(denom: number) {
+  return [
+    { label: "#", width: 24 },
+    { label: "Project", width: 132 },
+    { label: "Table", width: 48 },
+    { label: "Track", width: 100 },
+    { label: `Avg /${denom}`, width: 42 },
+    { label: "Range", width: 60 },
+    { label: "Judges", width: 38 },
+    { label: "Basis", width: 39 },
+  ] as const
+}
 
-function rankingHeader(doc: Doc): void {
+function rankingHeader(doc: Doc, cols: ReturnType<typeof rankCols>): void {
   if (doc.y < MARGIN + 8) doc.y = MARGIN + 8
   let x = MARGIN
   doc.font(SANS_BOLD).fontSize(7).fillColor(DIM)
   const top = doc.y
-  for (const col of RANK_COLS) {
+  for (const col of cols) {
     doc.text(col.label.toUpperCase(), x, top, { width: col.width - 6, characterSpacing: 0.5 })
     x += col.width
   }
@@ -828,7 +864,8 @@ function renderRanking(doc: Doc, data: ResultsExport, state: RenderState): void 
       "the podium."
   )
   markSection(doc, state, "Full ranking")
-  rankingHeader(doc)
+  const cols = rankCols(totalOutOf(data.rubric))
+  rankingHeader(doc, cols)
 
   const ranked = data.teams.filter((t) => t.average !== null)
   for (const team of ranked) {
@@ -846,13 +883,12 @@ function renderRanking(doc: Doc, data: ResultsExport, state: RenderState): void 
     ]
     doc.font(SANS).fontSize(8)
     const rowHeight =
-      Math.max(
-        ...cells.map((text, i) => doc.heightOfString(text, { width: RANK_COLS[i].width - 6 }))
-      ) + 7
+      Math.max(...cells.map((text, i) => doc.heightOfString(text, { width: cols[i].width - 6 }))) +
+      7
     if (doc.y + rowHeight > CONTENT_BOTTOM) {
       doc.addPage()
       doc.y = MARGIN + 8
-      rankingHeader(doc)
+      rankingHeader(doc, cols)
     }
     const top = doc.y
     if (team.finalRankBasis === "announced") {
@@ -865,8 +901,8 @@ function renderRanking(doc: Doc, data: ResultsExport, state: RenderState): void 
         .font(i === 1 ? SANS_BOLD : SANS)
         .fontSize(8)
         .fillColor(i === 3 || i === 5 || i === 7 ? DIM : INK)
-        .text(text, x, top, { width: RANK_COLS[i].width - 6 })
-      x += RANK_COLS[i].width
+        .text(text, x, top, { width: cols[i].width - 6 })
+      x += cols[i].width
     })
     doc.x = MARGIN
     doc.y = top + rowHeight
@@ -1159,8 +1195,9 @@ function renderSubmission(doc: Doc, team: ExportTeam): void {
  * verbatim judge notes. Longer than 50 lines because the pieces share
  * geometry and pagination decisions that must be made together.
  */
-function renderJudging(doc: Doc, team: ExportTeam): void {
+function renderJudging(doc: Doc, team: ExportTeam, rubric: ResultsExport["rubric"]): void {
   if (team.judgeScores.length === 0) return
+  const denom = totalOutOf(rubric)
   ensureSpace(doc, 200)
   // No divider when the block landed at the top of a fresh page — it would
   // double the running header's rule.
@@ -1170,29 +1207,43 @@ function renderJudging(doc: Doc, team: ExportTeam): void {
   }
   kicker(doc, "Judging", DIM)
 
-  // Criterion profile: the five published criteria, averaged across judges.
+  // Criterion profile: every published criterion, averaged across judges.
+  // Criteria can carry different maxima (the Afretec rubric does), so the
+  // bars share the largest one and each row states its own out of its label
+  // — one shared `max` would draw a 4-of-4 and a 4-of-10 identically.
   if (team.average !== null) {
-    const rows: HBarRow[] = JUDGING_CRITERIA.map((criterion) => ({
-      label: criterion.label,
+    const criteriaMax = Math.max(...rubric.criteria.map((c) => c.max))
+    const rows: HBarRow[] = rubric.criteria.map((criterion) => ({
+      label:
+        rubric.scoring === "points"
+          ? `${criterion.label} (/${criterion.max})`
+          : criterion.label,
       value: team.criterionAverages[criterion.key] ?? 0,
       valueLabel: fmt1(team.criterionAverages[criterion.key] ?? 0),
     }))
     doc.y += drawHBars(doc, MARGIN, doc.y, CONTENT_WIDTH * 0.72, rows, {
-      max: 5,
+      max: criteriaMax,
       labelWidth: 150,
       rowHeight: 15,
-      scaleNote: "Mean of judges' raw 1–5 scores per criterion. 1 = not shown.",
+      scaleNote:
+        rubric.scoring === "points"
+          ? "Mean of judges' raw scores per criterion, against that criterion's own maximum."
+          : `Mean of judges' raw ${rubric.criteria[0]?.min ?? 1}–${rubric.criteria[0]?.max ?? 5} scores per criterion. Lowest = not shown.`,
     })
     doc.moveDown(0.8)
   }
 
-  // Per-judge table.
+  // Per-judge table. Column width shrinks to fit however many criteria the
+  // rubric has — 42pt fits five (July) exactly; eight (Afretec) needs
+  // narrower columns to leave room for the name, basis and total columns.
   const nameWidth = 104
   const basisWidth = 62
-  const critWidth = 42
-  const totalWidth = CONTENT_WIDTH - nameWidth - basisWidth - critWidth * JUDGING_CRITERIA.length
+  const critWidth = Math.min(
+    42,
+    (CONTENT_WIDTH - nameWidth - basisWidth - 46) / rubric.criteria.length
+  )
+  const totalWidth = CONTENT_WIDTH - nameWidth - basisWidth - critWidth * rubric.criteria.length
   ensureSpace(doc, 30 + team.judgeScores.length * 15)
-  const shortLabels = ["Impact", "Demo", "AI", "Clarity", "Present."]
   let x = MARGIN
   const headTop = doc.y
   doc.font(SANS_BOLD).fontSize(6.5).fillColor(DIM)
@@ -1200,11 +1251,15 @@ function renderJudging(doc: Doc, team: ExportTeam): void {
   x += nameWidth
   doc.text("BASIS", x, headTop, { width: basisWidth - 6 })
   x += basisWidth
-  shortLabels.forEach((label) => {
-    doc.text(label.toUpperCase(), x, headTop, { width: critWidth - 4 })
+  for (const criterion of rubric.criteria) {
+    doc.text(criterion.label.toUpperCase(), x, headTop, {
+      width: critWidth - 4,
+      lineBreak: false,
+      ellipsis: true,
+    })
     x += critWidth
-  })
-  doc.text("TOTAL /100", x, headTop, { width: totalWidth })
+  }
+  doc.text(`TOTAL /${denom}`, x, headTop, { width: totalWidth })
   doc.x = MARGIN
   doc.y = headTop + 11
   rule(doc, INK, 0.8)
@@ -1224,13 +1279,16 @@ function renderJudging(doc: Doc, team: ExportTeam): void {
       .fillColor(score.writeupOnly ? CLAY_DEEP : DIM)
       .text(score.writeupOnly ? "Writeup" : "Live demo", cx, top, { width: basisWidth - 6 })
     cx += basisWidth
-    for (const criterion of JUDGING_CRITERIA) {
+    for (const criterion of rubric.criteria) {
       const value = score.criteria[criterion.key]
       doc
         .font(SANS)
         .fontSize(8)
         .fillColor(INK)
-        .text(value === null ? "—" : String(value), cx, top, { width: critWidth - 4 })
+        .text(value === null ? "—" : String(value), cx, top, {
+          width: critWidth - 4,
+          lineBreak: false,
+        })
       cx += critWidth
     }
     doc.font(SANS_BOLD).fontSize(8).fillColor(INK).text(fmt1(score.weightedTotal), cx, top, {
@@ -1253,7 +1311,7 @@ function renderJudging(doc: Doc, team: ExportTeam): void {
       },
     ]
     doc.y += drawDotRows(doc, MARGIN, doc.y, CONTENT_WIDTH * 0.72, spreadRows, {
-      max: 100,
+      max: denom,
       labelWidth: 92,
     })
     doc.moveDown(0.4)
@@ -1329,7 +1387,8 @@ function renderTeamProfile(
   doc: Doc,
   team: ExportTeam,
   analysis: TeamAnalysis | undefined,
-  state: RenderState
+  state: RenderState,
+  rubric: ResultsExport["rubric"]
 ): void {
   doc.addPage()
   doc.y = MARGIN + 8
@@ -1377,7 +1436,7 @@ function renderTeamProfile(
       .fontSize(8.5)
       .fillColor(DIM)
       .text(
-        `Panel average ${fmt1(team.average)}/100 across ${team.judgeCount} scorecard` +
+        `Panel average ${fmt1(team.average)}/${totalOutOf(rubric)} across ${team.judgeCount} scorecard` +
           `${team.judgeCount === 1 ? "" : "s"}` +
           (team.judgeCount > 1 && team.scoreLow !== null && team.scoreHigh !== null
             ? ` (judges ranged ${fmt1(team.scoreLow)}–${fmt1(team.scoreHigh)})`
@@ -1402,7 +1461,7 @@ function renderTeamProfile(
   if (team.communityReview !== null) renderCommunityReview(doc, team)
   else if (analysis) renderAnalysis(doc, analysis)
   renderSubmission(doc, team)
-  renderJudging(doc, team)
+  renderJudging(doc, team, rubric)
 }
 
 // ─── Appendix ────────────────────────────────────────────────────────────────
@@ -1578,14 +1637,14 @@ export async function buildResultsPdf(
     if (profiled.length > 0) {
       // The profiles section mark points at the first profile page.
       const first = profiled[0]
-      renderTeamProfile(doc, first, analyses.get(first.teamId), state)
+      renderTeamProfile(doc, first, analyses.get(first.teamId), state, data.rubric)
       state.toc.splice(state.toc.length - 1, 0, {
         title: "Team profiles",
         page: state.toc[state.toc.length - 1].page,
         level: 0,
       })
       for (const team of profiled.slice(1)) {
-        renderTeamProfile(doc, team, analyses.get(team.teamId), state)
+        renderTeamProfile(doc, team, analyses.get(team.teamId), state, data.rubric)
       }
     }
     renderAppendix(doc, data, state, branding)


### PR DESCRIPTION
## The bug — and why this is urgent

The results export pipeline (PDF + Excel) was hardcoded to the July Impact Lab rubric via the legacy `JUDGING_CRITERIA`/`weightedTotal` aliases. Every export for any other event rendered **wrong criteria columns AND a wrong standings order** (July's normalized /100 arithmetic applied to Afretec's points /50 scorecards — the ranking demonstrably flips). The v1 Afretec report sent to C4DLab on 2026-08-10 is affected; **the program is Mastercard Foundation funded**, so the corrected report needs to reach the organiser with a documented correction before v1 circulates.

The live judging screens always used the correct rubric — announced winners are unaffected. Scorecard records untouched.

## The fix

`buildResultsExport(source, rubric)` now takes the event's resolved rubric (route resolves via `resolveRubric(cohort)` — DB override → code constant, same path judging uses) and carries it on `ResultsExport`; both renderers read criteria, denominators, score labels (nullable for points rubrics), bar ceilings, and column layouts from it. The old layout computed a **negative column width** at 8 criteria — that garbage rendering is what the organiser screenshotted.

## Verification (26/26 fixture assertions, no DB)

- July regression: totals identical to the decimal (100 / 66.3 fixtures), all 5 criteria + scale anchors still printed.
- Afretec: 8 criteria rendered by name, /50 everywhere, /100 nowhere; raw-sum arithmetic exact.
- Ranking-flip fixture: same sheets order A>B under July's formula, B>A under Afretec's — proving standings are rubric-driven.
- Gates: `tsc --noEmit`, `next build`, `verify:judging` all clean.

## After merge

Regenerate the Afretec report from the admin panel; the standings will be diffed against production scorecards before it is resent with a correction notice.

Known same-shape debt (NOT in this PR, follow-up coming): `ResultsView.tsx`, `email.ts`, `ResultsTab.tsx`, `JudgesTab.tsx`, `reviews/route.ts`, `results-input.ts` still import the July-bound aliases.

@Spidey-Acer

https://claude.ai/code/session_01U99bKqojTVppEAmLaN4d9E