### PR TITLE
fix(impact-lab): member and admin results surfaces use each event's own rubric

### DIFF
--- a/src/app/api/admin/impact-lab/judging/audit/route.ts
+++ b/src/app/api/admin/impact-lab/judging/audit/route.ts
@@ -51,8 +51,15 @@ export async function GET(request: NextRequest) {
   const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
   // Every total below is in this rubric's units, so the rubric travels with the
   // response — a mean of 48.3 is a different verdict out of 50 than out of 100.
+  // The criteria list travels too: the per-judge table below has one column
+  // per criterion, and Impact Lab's five are the wrong columns for a second
+  // event's rubric.
   const rubric = await resolveRubric(cohort)
-  const rubricMeta = { rubricLabel: rubric.label, totalOutOf: totalOutOf(rubric) }
+  const rubricMeta = {
+    rubricLabel: rubric.label,
+    totalOutOf: totalOutOf(rubric),
+    criteria: rubric.criteria.map((c) => ({ key: c.key, label: c.label })),
+  }
 
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },

--- a/src/app/api/admin/impact-lab/judging/writeup/route.ts
+++ b/src/app/api/admin/impact-lab/judging/writeup/route.ts
@@ -11,6 +11,7 @@ import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
   AFRETEC_RUBRIC,
   IMPACT_LAB_RUBRIC,
+  serializeRubric,
   type JudgingRubric,
   type ScoreSheet,
 } from "@/lib/impact-lab/judging"
@@ -206,13 +207,18 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
+  // The score inputs this list's UI renders (criteria, per-criterion scale)
+  // must match this cohort's own rubric — the same one `draft` and `save`
+  // below score against.
+  const rubric = serializeRubric(await resolveRubric(cohort))
+
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort, isFinal: true },
     orderBy: { createdAt: "desc" },
     select: { id: true, result: true },
   })
   if (!run) {
-    return NextResponse.json({ success: true, data: { teams: [] } })
+    return NextResponse.json({ success: true, data: { teams: [], rubric } })
   }
 
   const teams = extractFrozenTeams(run.result) ?? []
@@ -259,7 +265,7 @@ export async function GET(request: NextRequest) {
       submission: submissionAsRecord(s),
     }))
 
-  return NextResponse.json({ success: true, data: { teams: awaiting } })
+  return NextResponse.json({ success: true, data: { teams: awaiting, rubric } })
 }
 
 /**

--- a/src/app/api/admin/impact-lab/results/notify/route.ts
+++ b/src/app/api/admin/impact-lab/results/notify/route.ts
@@ -9,6 +9,8 @@ import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { isResultsSnapshot } from "@/lib/impact-lab/results"
 import { loadTeamFeedback } from "@/lib/impact-lab/results-input"
+import { totalOutOf, type JudgingRubric } from "@/lib/impact-lab/judging"
+import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 import { APP_URL, impactLabResultsEmail, sendEmailBatchTracked, type BatchEmailItem } from "@/lib/email"
 
 /**
@@ -64,13 +66,25 @@ const bodySchema = z.object({
  * name is deliberately unmissable as a placeholder so nobody mistakes this
  * for a real team's result.
  */
-const SAMPLE_CARD = {
-  projectName: "Sample Project (test preview — not a real team)",
-  rank: 4,
-  criterionAverages: { impact: 4.1, demo: 3.6, claude: 4.4, clarity: 3.9, presentation: 4.0 },
-  low: 68.5,
-  high: 84.0,
-  basis: "demo" as const,
+/**
+ * Built from the cohort's own rubric rather than a fixed Impact Lab shape —
+ * a fixed `{ impact, demo, claude, clarity, presentation }` object would
+ * render as a wall of dashes under Afretec's criteria, whose keys are
+ * entirely different. Each criterion is set to roughly 80% of its own range,
+ * so the sample plausibly looks like a strong, not perfect, scorecard under
+ * any rubric.
+ */
+function sampleCard(rubric: JudgingRubric) {
+  return {
+    projectName: "Sample Project (test preview — not a real team)",
+    rank: 4,
+    criterionAverages: Object.fromEntries(
+      rubric.criteria.map((c) => [c.key, Math.round((c.min + (c.max - c.min) * 0.8) * 10) / 10])
+    ),
+    low: Math.round(totalOutOf(rubric) * 0.685 * 10) / 10,
+    high: Math.round(totalOutOf(rubric) * 0.84 * 10) / 10,
+    basis: "demo" as const,
+  }
 }
 
 async function loadPublishedRun(cohort: string) {
@@ -166,16 +180,22 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: false, error: run.error }, { status: run.status })
   }
 
+  // `resolveRubric`, not the code constant: the results already published for
+  // this cohort were scored against its own rubric, and every email below
+  // must quote them in the same units.
+  const rubric = await resolveRubric(cohort)
+
   const dashboardUrl = `${APP_URL}/dashboard/impact-lab`
 
   // ── Test send: real winners, fabricated "your team" card, no DB rows touched
   if (parsed.data.testEmail) {
     const built = impactLabResultsEmail({
       fullName: "there",
-      ...SAMPLE_CARD,
+      ...sampleCard(rubric),
       overall: run.snapshot.overall,
       trackWinners: run.snapshot.trackWinners,
       dashboardUrl,
+      rubric,
     })
 
     const [result] = await sendEmailBatchTracked([
@@ -278,6 +298,7 @@ export async function POST(request: NextRequest) {
       dashboardUrl,
       judgeNotes: feedbackByTeam.get(team.id)?.judgeNotes ?? [],
       communityReview: feedbackByTeam.get(team.id)?.review ?? null,
+      rubric,
     })
     sendable.push({ row, item: { to: row.email, subject: built.subject, html: built.html } })
   }

--- a/src/app/api/admin/impact-lab/results/preview-email/route.ts
+++ b/src/app/api/admin/impact-lab/results/preview-email/route.ts
@@ -5,6 +5,7 @@ import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import { buildResultsInputFromRun, loadTeamFeedback } from "@/lib/impact-lab/results-input"
 import { buildSnapshot, isResultsSnapshot, type ResultsInput, type ResultsSnapshot } from "@/lib/impact-lab/results"
+import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 import { APP_URL, impactLabResultsEmail } from "@/lib/email"
 
 /**
@@ -53,6 +54,10 @@ export async function GET(request: NextRequest) {
   if (!check.authorized) return check.response
 
   const cohort = await resolveAdminCohort(request.nextUrl.searchParams.get("cohort"))
+  // `resolveRubric`, not the code constant: an organiser-authored rubric for
+  // this cohort must score this preview the same way it scores the live
+  // judging screen and the eventual publish.
+  const rubric = await resolveRubric(cohort)
   const teamId = (request.nextUrl.searchParams.get("teamId") ?? "").trim()
   if (teamId === "" || teamId.length > 64) {
     return NextResponse.json(
@@ -112,7 +117,7 @@ export async function GET(request: NextRequest) {
     recipientCount = team.memberIds.length
   } else {
     const { input: inputBase, teams, submittedTeamIds, scoredTeamIds } =
-      await buildResultsInputFromRun(prisma, run.id, run.result)
+      await buildResultsInputFromRun(prisma, run.id, run.result, rubric)
 
     const team = teams.find((t) => t.id === teamId)
     if (!team) {
@@ -184,6 +189,7 @@ export async function GET(request: NextRequest) {
     dashboardUrl,
     judgeNotes: feedback?.judgeNotes ?? [],
     communityReview: feedback?.review ?? null,
+    rubric,
   })
 
   return NextResponse.json({

--- a/src/app/api/admin/impact-lab/results/publish/route.ts
+++ b/src/app/api/admin/impact-lab/results/publish/route.ts
@@ -8,6 +8,7 @@ import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { buildResultsInputFromRun } from "@/lib/impact-lab/results-input"
 import { buildSnapshot, type ResultsInput } from "@/lib/impact-lab/results"
+import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 
 /**
  * Mark final. A one-way door.
@@ -150,12 +151,18 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // The rubric this run's totals are scored against — an organiser-authored
+    // one for this cohort if there is one, else the code constant. Every
+    // total and standing buildResultsInputFromRun computes below is in these
+    // units.
+    const rubric = await resolveRubric(cohort)
+
     // What an organiser actually recognises a team by — the run-JSON team
     // name is an internal id like "Table 12 — Kilimo (Agriculture)" — and
     // everything else needed to build a ResultsInput. Shared with the
     // preview-email route so the two never read the run differently.
     const { input: inputBase, teams, teamIds, submittedTeamIds, scoredTeamIds, displayName } =
-      await buildResultsInputFromRun(tx, runId, run.result)
+      await buildResultsInputFromRun(tx, runId, run.result, rubric)
 
     // 3. Every submitted team must have at least one score — this is what stops
     // the four unscored teams being published as blanks.

--- a/src/app/api/admin/impact-lab/reviews/route.ts
+++ b/src/app/api/admin/impact-lab/reviews/route.ts
@@ -10,11 +10,12 @@ import { logAudit, getRequestMetadata } from "@/lib/audit-log"
 import { resolveAdminCohort } from "@/lib/impact-lab/event-store"
 import { extractFrozenTeams } from "@/lib/impact-lab/member"
 import {
-  JUDGING_CRITERIA,
   standings,
   trackOf,
+  type JudgingRubric,
   type ScoreSheet,
 } from "@/lib/impact-lab/judging"
+import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 import { presentableJudgeNote, type TeamJudgeNote } from "@/lib/impact-lab/reviews"
 
 /**
@@ -112,13 +113,13 @@ interface TeamContext {
   judgeNote: string | null
 }
 
-function buildPrompt(ctx: TeamContext): string {
+function buildPrompt(ctx: TeamContext, rubric: JudgingRubric): string {
   const s = ctx.submission
 
   const scoreLines = ctx.criterionAverages
-    ? JUDGING_CRITERIA.map((c) => {
+    ? rubric.criteria.map((c) => {
         const value = ctx.criterionAverages?.[c.key]
-        return `- ${c.label}: ${typeof value === "number" ? value.toFixed(1) : "—"} / 5`
+        return `- ${c.label}: ${typeof value === "number" ? value.toFixed(1) : "—"} / ${c.max}`
       }).join("\n")
     : "This team was never scored."
 
@@ -153,14 +154,14 @@ ${noteBlock}`
  * writeup-draft route. Returns the review text (paragraphs joined by blank
  * lines) or null when both attempts failed.
  */
-async function generateReview(ctx: TeamContext): Promise<string | null> {
+async function generateReview(ctx: TeamContext, rubric: JudgingRubric): Promise<string | null> {
   for (let attempt = 0; attempt < 2; attempt += 1) {
     try {
       const { object } = await generateObject({
         model: anthropic(MODEL),
         schema: reviewSchema,
         system: SYSTEM,
-        prompt: buildPrompt(ctx),
+        prompt: buildPrompt(ctx, rubric),
         maxOutputTokens: 1_500,
       })
       return object.paragraphs.map((p) => p.trim()).join("\n\n")
@@ -186,8 +187,12 @@ async function loadFinalRun(cohort: string) {
  * Everything generation and the GET listing need about a run's teams:
  * submissions in full, per-team criterion averages, scoring basis, and the
  * (corrected) judge notes.
+ *
+ * `rubric` must be the cohort's own — every criterion average below is
+ * computed against it, and a cohort that is not Impact Lab does not share
+ * Impact Lab's criteria.
  */
-async function loadTeamContexts(runId: string, runResult: unknown) {
+async function loadTeamContexts(runId: string, runResult: unknown, rubric: JudgingRubric) {
   const teams = extractFrozenTeams(runResult) ?? []
   const nameById = new Map(teams.map((t) => [t.id, t.name]))
 
@@ -224,7 +229,8 @@ async function loadTeamContexts(runId: string, runResult: unknown) {
       judgeEmail: String(i),
       teamId: s.teamId,
       sheet: (s.scores ?? {}) as ScoreSheet,
-    }))
+    })),
+    rubric
   )
   const standingByTeam = new Map(table.map((t) => [t.teamId, t]))
 
@@ -275,9 +281,11 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: true, data: { teams: [] } })
   }
 
+  const rubric = await resolveRubric(cohort)
   const { nameById, submissions, judgeNotesByTeam } = await loadTeamContexts(
     run.id,
-    run.result
+    run.result,
+    rubric
   )
   const reviews = await prisma.impactLabTeamReview.findMany({
     where: { runId: run.id },
@@ -458,7 +466,8 @@ async function handlePost(request: NextRequest) {
   }
 
   // ── generate ───────────────────────────────────────────────────────────────
-  const { submissions, contextFor } = await loadTeamContexts(run.id, run.result)
+  const rubric = await resolveRubric(cohort)
+  const { submissions, contextFor } = await loadTeamContexts(run.id, run.result, rubric)
   const existingReviews = await prisma.impactLabTeamReview.findMany({
     where: { runId: run.id },
     select: { teamId: true, editedAt: true, approvedAt: true },
@@ -488,7 +497,7 @@ async function handlePost(request: NextRequest) {
       )
     }
 
-    const text = await generateReview(contextFor(submission))
+    const text = await generateReview(contextFor(submission), rubric)
     if (text === null) {
       return NextResponse.json(
         {
@@ -528,7 +537,7 @@ async function handlePost(request: NextRequest) {
   let generated = 0
   const failedProjects: string[] = []
   for (const submission of batch) {
-    const text = await generateReview(contextFor(submission))
+    const text = await generateReview(contextFor(submission), rubric)
     if (text === null) {
       failedProjects.push(submission.projectName)
       continue

--- a/src/app/api/impact-lab/results/route.ts
+++ b/src/app/api/impact-lab/results/route.ts
@@ -10,6 +10,8 @@ import {
   type ResultsSnapshot,
   type TeamFeedback,
 } from "@/lib/impact-lab/results"
+import { serializeRubric } from "@/lib/impact-lab/judging"
+import { resolveRubric } from "@/lib/impact-lab/rubric-store"
 import { presentableJudgeNote, publishableReview } from "@/lib/impact-lab/reviews"
 
 /**
@@ -70,6 +72,12 @@ export async function GET(request: NextRequest) {
     displayName = display?.name
   }
 
+  // `resolveRubric`, not the code constant: the ranking's criterion averages
+  // and score range below are quoted against this cohort's own rubric, and
+  // ResultsView needs the criteria/scales/denominator to render them —
+  // Impact Lab's five 1-5 criteria are the wrong labels for a second event.
+  const rubric = serializeRubric(await resolveRubric(displayCohort))
+
   const run = await prisma.impactLabMatchRun.findFirst({
     where: { cohort: displayCohort, isFinal: true },
     orderBy: { createdAt: "desc" },
@@ -86,6 +94,7 @@ export async function GET(request: NextRequest) {
       published: false,
       eventName: displayName ?? displayCohort,
       eventCohort: displayCohort,
+      rubric,
     })
   }
 
@@ -129,5 +138,6 @@ export async function GET(request: NextRequest) {
     ...buildMemberPayload(snapshot, viewerTeamId, feedback),
     eventName: displayName ?? displayCohort,
     eventCohort: displayCohort,
+    rubric,
   })
 }

--- a/src/app/dashboard/impact-lab/ImpactLabClient.tsx
+++ b/src/app/dashboard/impact-lab/ImpactLabClient.tsx
@@ -41,6 +41,7 @@ interface ResultsResponse {
   published?: boolean;
   results?: ResultsViewProps["results"];
   yourTeam?: ResultsViewProps["yourTeam"];
+  rubric?: ResultsViewProps["rubric"];
   error?: string;
 }
 
@@ -146,8 +147,16 @@ export function ImpactLabClient({
 
         // Results published takes precedence over the team reveal — once
         // results are out, the hackathon is over and this is what matters.
-        if (resultsJson.published && resultsJson.results) {
-          setResults({ results: resultsJson.results, yourTeam: resultsJson.yourTeam });
+        // `rubric` travels on every response the route sends (see its own
+        // doc comment), so its absence here means a malformed payload —
+        // treated the same as "not published yet" rather than rendering the
+        // results view with no criteria to show.
+        if (resultsJson.published && resultsJson.results && resultsJson.rubric) {
+          setResults({
+            results: resultsJson.results,
+            yourTeam: resultsJson.yourTeam,
+            rubric: resultsJson.rubric,
+          });
           setPhase("results");
           return;
         }
@@ -257,7 +266,13 @@ export function ImpactLabClient({
   // when present, renders once above it rather than inside every branch.
   const content = (() => {
     if (phase === "results" && results) {
-      return <ResultsView results={results.results} yourTeam={results.yourTeam} />;
+      return (
+        <ResultsView
+          results={results.results}
+          yourTeam={results.yourTeam}
+          rubric={results.rubric}
+        />
+      );
     }
 
     if (phase === "revealed" && team) {

--- a/src/app/dashboard/impact-lab/ResultsView.tsx
+++ b/src/app/dashboard/impact-lab/ResultsView.tsx
@@ -2,7 +2,7 @@
 
 import { motion, useReducedMotion } from "framer-motion";
 import { Award, Medal, Trophy } from "lucide-react";
-import { JUDGING_CRITERIA, MAX_SCORE, MIN_SCORE } from "@/lib/impact-lab/judging";
+import type { SerializedRubric } from "@/lib/impact-lab/judging";
 import type {
   AnnouncedWinner,
   PublicRankedTeam,
@@ -27,6 +27,14 @@ export interface ResultsViewProps {
     judgeNotes?: TeamJudgeNote[];
     review?: TeamReviewPayload;
   };
+  /**
+   * This event's own rubric — criteria, scales, and the denominator to quote
+   * totals against. Never the Impact Lab constant: a second event does not
+   * share Impact Lab's five criteria or its 1-5 scale, and every number
+   * rendered below (the criterion bars, the "/ N" denominators, the score
+   * range) is only meaningful read against the rubric it was scored on.
+   */
+  rubric: SerializedRubric;
 }
 
 const ORDINALS: Record<number, string> = {
@@ -39,6 +47,13 @@ function ordinal(rank: number): string {
   return ORDINALS[rank] ?? `${rank}th`;
 }
 
+// Spelled out, matching the original Impact Lab copy's "same five criteria"
+// rather than switching to a numeral once a second rubric exists.
+const CRITERIA_COUNT_WORDS: Record<number, string> = {
+  1: "one", 2: "two", 3: "three", 4: "four", 5: "five",
+  6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten",
+};
+
 /**
  * Results view — the payoff page. Four sections, in a fixed order: winners
  * (announced champion + runners-up, then track winners), the caller's own
@@ -50,7 +65,7 @@ function ordinal(rank: number): string {
  * from the ranking before this component ever sees it (see the route's own
  * doc comment) — nothing here re-derives or re-fetches a score.
  */
-export function ResultsView({ results, yourTeam }: ResultsViewProps) {
+export function ResultsView({ results, yourTeam, rubric }: ResultsViewProps) {
   const prefersReducedMotion = useReducedMotion();
 
   const container = {
@@ -68,6 +83,14 @@ export function ResultsView({ results, yourTeam }: ResultsViewProps) {
   const yourTrack = yourTeam
     ? results.ranking.find((r) => r.teamId === yourTeam.teamId)?.track
     : undefined;
+
+  const criteriaPhrase = `the same ${CRITERIA_COUNT_WORDS[rubric.criteria.length] ?? rubric.criteria.length} criteria`;
+  // "the demo criterion" only when this rubric actually has one keyed
+  // "demo" (Impact Lab's does) — naming a criterion that does not exist
+  // under a different rubric would be a plain factual error.
+  const demoCriterionPhrase = rubric.criteria.some((c) => c.key === "demo")
+    ? "the demo criterion"
+    : "the relevant criteria";
 
   return (
     <motion.div className="space-y-8" variants={container} initial="hidden" animate="show">
@@ -168,32 +191,35 @@ export function ResultsView({ results, yourTeam }: ResultsViewProps) {
 
           {yourTeam.card.basis === "submission" && (
             <p className="mt-3 rounded border border-border-default bg-bg-card p-3 text-xs leading-relaxed text-text-secondary">
-              Your project was reviewed from your written submission against the
-              same five criteria. A live demo was not part of that review, which
-              is noted against the demo criterion below.
+              Your project was reviewed from your written submission against{" "}
+              {criteriaPhrase}. A live demo was not part of that review, which
+              is noted against {demoCriterionPhrase} below.
             </p>
           )}
 
           <div className="mt-5 space-y-3">
-            {JUDGING_CRITERIA.map((criterion) => {
+            {rubric.criteria.map((criterion) => {
               const value = yourTeam.card.criterionAverages[criterion.key] ?? 0;
-              const pct = Math.max(
-                0,
-                Math.min(100, ((value - MIN_SCORE) / (MAX_SCORE - MIN_SCORE)) * 100)
-              );
+              const span = criterion.max - criterion.min;
+              const pct =
+                span === 0
+                  ? 100
+                  : Math.max(0, Math.min(100, ((value - criterion.min) / span) * 100));
               return (
                 <div key={criterion.key}>
                   <div className="flex items-baseline justify-between gap-2">
                     <span className="font-mono text-xs text-text-secondary">
                       {criterion.label}
                     </span>
-                    <span className="font-mono text-xs text-text-dim">{value.toFixed(1)} / 5</span>
+                    <span className="font-mono text-xs text-text-dim">
+                      {value.toFixed(1)} / {criterion.max}
+                    </span>
                   </div>
                   <div
                     role="progressbar"
                     aria-label={criterion.label}
-                    aria-valuemin={MIN_SCORE}
-                    aria-valuemax={MAX_SCORE}
+                    aria-valuemin={criterion.min}
+                    aria-valuemax={criterion.max}
                     aria-valuenow={value}
                     className="mt-1 h-2 w-full overflow-hidden rounded-full bg-bg-card"
                   >
@@ -210,7 +236,7 @@ export function ResultsView({ results, yourTeam }: ResultsViewProps) {
           {yourTeam.card.low !== null && yourTeam.card.high !== null && (
             <p className="mt-4 font-mono text-[11px] text-text-dim">
               Score range across judges: {yourTeam.card.low.toFixed(1)}–
-              {yourTeam.card.high.toFixed(1)}
+              {yourTeam.card.high.toFixed(1)} / {rubric.totalOutOf}
             </p>
           )}
 
@@ -324,8 +350,8 @@ export function ResultsView({ results, yourTeam }: ResultsViewProps) {
             How these results were decided
           </p>
           <p>
-            Every project that was submitted has been reviewed against the same
-            five criteria and ranked. Where the panel saw a live demo, their
+            Every project that was submitted has been reviewed against{" "}
+            {criteriaPhrase} and ranked. Where the panel saw a live demo, their
             scores are the ones shown. Where a team submitted but the panel did
             not see it presented, the project was reviewed from the written
             submission instead.

--- a/src/components/admin/impact-lab/JudgesTab.tsx
+++ b/src/components/admin/impact-lab/JudgesTab.tsx
@@ -12,7 +12,11 @@ import {
   Minus,
 } from "lucide-react"
 import { apiGet, apiSend } from "./api"
-import { JUDGING_CRITERIA, type JudgingCriterion } from "@/lib/impact-lab/judging"
+
+interface AuditCriterion {
+  key: string
+  label: string
+}
 
 interface AuditSheet {
   teamId: string
@@ -36,6 +40,8 @@ interface JudgeAudit {
 
 interface AuditData {
   judges: JudgeAudit[]
+  totalOutOf: number
+  criteria: AuditCriterion[]
 }
 
 interface PreviewRow {
@@ -178,7 +184,8 @@ export function JudgesTab({ cohort }: { cohort: string }) {
               Lowest — <span className="text-[#ff3333]">{lowest.judgeName}</span> ({lowest.mean})
             </span>
             <span className="text-[#888]">
-              gap: <span className="font-semibold text-[#ffb000]">{spread}</span> points out of 100
+              gap: <span className="font-semibold text-[#ffb000]">{spread}</span> points out of{" "}
+              {data.totalOutOf}
             </span>
           </div>
         </div>
@@ -224,7 +231,7 @@ export function JudgesTab({ cohort }: { cohort: string }) {
                         {[
                           "Team",
                           "Project",
-                          ...JUDGING_CRITERIA.map((c: JudgingCriterion) => c.label),
+                          ...data.criteria.map((c) => c.label),
                           "Total",
                           "Basis",
                         ].map((h) => (
@@ -246,7 +253,7 @@ export function JudgesTab({ cohort }: { cohort: string }) {
                           <td className="whitespace-nowrap px-4 py-2 text-[11px] font-mono text-[#888]">
                             {sheet.projectName ?? "—"}
                           </td>
-                          {JUDGING_CRITERIA.map((c: JudgingCriterion) => (
+                          {data.criteria.map((c) => (
                             <td key={c.key} className="px-4 py-2 text-[11px] font-mono text-[#888]">
                               {sheet.scores[c.key] ?? "—"}
                             </td>

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -15,14 +15,7 @@ import {
   Trophy,
 } from "lucide-react"
 import { apiGet, apiSend } from "./api"
-import {
-  CRITERION_KEYS,
-  JUDGING_CRITERIA,
-  MAX_SCORE,
-  MIN_SCORE,
-  trackOf,
-  type TeamStanding,
-} from "@/lib/impact-lab/judging"
+import { trackOf, type SerializedRubric, type TeamStanding } from "@/lib/impact-lab/judging"
 import { buildRanking, buildTrackWinners, toPublicRanking, type ResultsInput } from "@/lib/impact-lab/results"
 
 interface AwaitingTeam {
@@ -66,6 +59,7 @@ function emptyState(): TeamDraftState {
  */
 function AwaitingScoreSection({ cohort }: { cohort: string }) {
   const [teams, setTeams] = useState<AwaitingTeam[] | null>(null)
+  const [rubric, setRubric] = useState<SerializedRubric | null>(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState<string | null>(null)
   const [drafts, setDrafts] = useState<Record<string, TeamDraftState>>({})
@@ -76,10 +70,11 @@ function AwaitingScoreSection({ cohort }: { cohort: string }) {
   const load = useCallback(async () => {
     setLoading(true)
     try {
-      const data = await apiGet<{ teams: AwaitingTeam[] }>(
+      const data = await apiGet<{ teams: AwaitingTeam[]; rubric: SerializedRubric }>(
         `/api/admin/impact-lab/judging/writeup?cohort=${cohort}`
       )
       setTeams(data.teams)
+      setRubric(data.rubric)
       setLoadError(null)
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : "Failed to load teams awaiting a score")
@@ -169,7 +164,7 @@ function AwaitingScoreSection({ cohort }: { cohort: string }) {
     )
   }
 
-  if (loadError || !teams) {
+  if (loadError || !teams || !rubric) {
     return (
       <div className="rounded border border-[#ff3333]/30 bg-[#ff3333]/10 p-2 text-[11px] font-mono text-[#ff3333]">
         {loadError ?? "No data"}
@@ -205,13 +200,13 @@ function AwaitingScoreSection({ cohort }: { cohort: string }) {
       ) : (
         teams.map((team) => {
           const state = stateFor(team.teamId)
-          const canSave = CRITERION_KEYS.every((key) => {
-            const value = state.scores[key]
+          const canSave = rubric.criteria.every((criterion) => {
+            const value = state.scores[criterion.key]
             return (
               typeof value === "number" &&
               Number.isInteger(value) &&
-              value >= MIN_SCORE &&
-              value <= MAX_SCORE
+              value >= criterion.min &&
+              value <= criterion.max
             )
           })
 
@@ -275,7 +270,7 @@ function AwaitingScoreSection({ cohort }: { cohort: string }) {
               </p>
 
               <div className="space-y-3">
-                {JUDGING_CRITERIA.map((criterion) => (
+                {rubric.criteria.map((criterion) => (
                   <div
                     key={criterion.key}
                     className="grid gap-2 sm:grid-cols-[180px_80px_1fr] sm:items-start"
@@ -290,8 +285,8 @@ function AwaitingScoreSection({ cohort }: { cohort: string }) {
                     <input
                       id={`${team.teamId}-${criterion.key}`}
                       type="number"
-                      min={MIN_SCORE}
-                      max={MAX_SCORE}
+                      min={criterion.min}
+                      max={criterion.max}
                       step={1}
                       value={state.scores[criterion.key] ?? ""}
                       onChange={(e) => setScore(team.teamId, criterion.key, e.target.value)}

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -5,7 +5,7 @@
 
 import { Resend } from "resend"
 import { VOLUNTEER_ROLE_LABELS as SHARED_VOLUNTEER_ROLE_LABELS } from "@/lib/volunteer-roles"
-import { JUDGING_CRITERIA } from "@/lib/impact-lab/judging"
+import type { JudgingRubric } from "@/lib/impact-lab/judging"
 import type { AnnouncedWinner, ResultsTrackWinner } from "@/lib/impact-lab/results"
 import {
   REVIEW_PROVENANCE,
@@ -578,6 +578,13 @@ export function impactLabResultsEmail(data: {
    * so generated words can never read as a judge's.
    */
   communityReview?: string | null
+  /**
+   * The rubric this team was actually scored against. Every criterion label,
+   * denominator, and the "same N criteria" language below is read off it —
+   * never off the Impact Lab constant — because a second event does not
+   * share Impact Lab's five criteria or its 1-5 scale.
+   */
+  rubric: JudgingRubric
 }): { subject: string; html: string } {
   // Publishing with zero announced winners is a legal (if unusual) state —
   // the publish panel warns rather than blocks it. Guard each block the same
@@ -618,14 +625,23 @@ export function impactLabResultsEmail(data: {
             </table>`
       : ""
 
+  // Spelled out, matching the original Impact Lab copy's "same five criteria"
+  // rather than switching to a numeral once a second rubric exists.
+  const CRITERIA_COUNT_WORDS: Record<number, string> = {
+    1: "one", 2: "two", 3: "three", 4: "four", 5: "five",
+    6: "six", 7: "seven", 8: "eight", 9: "nine", 10: "ten",
+  }
+  const criterionCount = data.rubric.criteria.length
+  const criteriaPhrase = `the same ${CRITERIA_COUNT_WORDS[criterionCount] ?? criterionCount} criteria`
+
   const note =
     data.overall.length > 0
-      ? "The top three placings were decided by the judging panel after they had seen the demos and discussed the projects together — that conversation is what those placings reflect. Everyone else is ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
-      : "Every project was ranked by score across the same five criteria your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed."
+      ? `The top three placings were decided by the judging panel after they had seen the demos and discussed the projects together — that conversation is what those placings reflect. Everyone else is ranked by score across ${criteriaPhrase} your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed.`
+      : `Every project was ranked by score across ${criteriaPhrase} your team was judged on. Scores are shown here in full because you're entitled to see how your own work was assessed.`
 
-  const criterionRows = JUDGING_CRITERIA.map((criterion) => {
+  const criterionRows = data.rubric.criteria.map((criterion) => {
     const value = data.criterionAverages[criterion.key]
-    const shown = typeof value === "number" ? `${value.toFixed(1)} / 5` : "—"
+    const shown = typeof value === "number" ? `${value.toFixed(1)} / ${criterion.max}` : "—"
     return `
         <tr>
           <td style="padding:5px 0;font-family:monospace,monospace;font-size:12px;color:#888;">${esc(criterion.label)}</td>
@@ -635,7 +651,7 @@ export function impactLabResultsEmail(data: {
 
   const rangeRow =
     data.low !== null && data.high !== null
-      ? `<p style="margin:10px 0 0;font-family:monospace,monospace;font-size:11px;color:#888;">Score range across judges: ${data.low.toFixed(1)}–${data.high.toFixed(1)}</p>`
+      ? `<p style="margin:10px 0 0;font-family:monospace,monospace;font-size:11px;color:#888;">Score range across judges: ${data.low.toFixed(1)}–${data.high.toFixed(1)} / ${data.rubric.totalOutOf}</p>`
       : ""
 
   const judgeNotesSection = (data.judgeNotes ?? [])
@@ -672,9 +688,16 @@ export function impactLabResultsEmail(data: {
             </table>`
     : ""
 
+  // "the demo criterion" only when this rubric actually has one keyed
+  // "demo" (Impact Lab's does) — naming a criterion that does not exist
+  // under a different rubric would be a plain factual error.
+  const demoCriterionPhrase = data.rubric.criteria.some((c) => c.key === "demo")
+    ? "the demo criterion"
+    : "the relevant criteria"
+
   const submissionNote =
     data.basis === "submission"
-      ? `<p style="margin:0 0 14px;font-family:monospace,monospace;font-size:12px;line-height:1.6;color:#888;border:1px solid #1e1e1e;border-radius:4px;padding:10px 12px;">Your project was reviewed from your written submission against the same five criteria. A live demo was not part of that review, which is reflected in the demo criterion below.</p>`
+      ? `<p style="margin:0 0 14px;font-family:monospace,monospace;font-size:12px;line-height:1.6;color:#888;border:1px solid #1e1e1e;border-radius:4px;padding:10px 12px;">Your project was reviewed from your written submission against ${criteriaPhrase}. A live demo was not part of that review, which is reflected in ${demoCriterionPhrase} below.</p>`
       : ""
 
   const html = `

--- a/src/lib/impact-lab/judging.ts
+++ b/src/lib/impact-lab/judging.ts
@@ -20,7 +20,7 @@ import {
   type JudgingRubric,
 } from "./judging-rubrics"
 
-export type { JudgingCriterion, JudgingRubric } from "./judging-rubrics"
+export type { JudgingCriterion, JudgingRubric, ScoringMode } from "./judging-rubrics"
 export {
   IMPACT_LAB_RUBRIC,
   AFRETEC_RUBRIC,
@@ -241,4 +241,49 @@ export function trackWinners(
 /** Highest total achievable under a rubric — the denominator to quote against. */
 export function totalOutOf(rubric: JudgingRubric = IMPACT_LAB_RUBRIC): number {
   return rubric.scoring === "points" ? maxPoints(rubric) : 100
+}
+
+/** The wire shape of a rubric — every field a client needs to render it, nothing DB-internal. */
+export interface SerializedRubric {
+  id: string
+  label: string
+  scoring: JudgingRubric["scoring"]
+  totalOutOf: number
+  scoreLabels: Readonly<Record<number, string>> | null
+  criteria: {
+    key: string
+    label: string
+    guidance: string
+    min: number
+    max: number
+    weight: number
+  }[]
+}
+
+/**
+ * A rubric projected field-by-field for the wire — the shape every
+ * cohort-aware route sends a client so it can render that cohort's own
+ * criteria, scales and denominator instead of a hardcoded rubric.
+ *
+ * Projected rather than spread, so an internal field added to `JudgingRubric`
+ * later cannot silently widen this contract. `totalOutOf` is the derived
+ * value, not the declared one, so it can never disagree with the criteria a
+ * client is actually rendering.
+ */
+export function serializeRubric(rubric: JudgingRubric): SerializedRubric {
+  return {
+    id: rubric.id,
+    label: rubric.label,
+    scoring: rubric.scoring,
+    totalOutOf: totalOutOf(rubric),
+    scoreLabels: rubric.scoreLabels,
+    criteria: rubric.criteria.map((c) => ({
+      key: c.key,
+      label: c.label,
+      guidance: c.guidance,
+      min: c.min,
+      max: c.max,
+      weight: c.weight,
+    })),
+  }
 }

--- a/src/lib/impact-lab/results-input.ts
+++ b/src/lib/impact-lab/results-input.ts
@@ -13,7 +13,7 @@
 
 import type { Prisma } from "@/generated/prisma/client"
 import { extractFrozenTeams } from "./member"
-import { standings, trackOf, weightedTotal, type JudgeScore, type ScoreSheet } from "./judging"
+import { scoreTotal, standings, trackOf, type JudgeScore, type JudgingRubric, type ScoreSheet } from "./judging"
 import type { ResultsInput, TeamFeedback } from "./results"
 import { presentableJudgeNote, publishableReview } from "./reviews"
 import type { Team } from "@/lib/matching"
@@ -40,8 +40,17 @@ export interface RunResultsData {
  * inputs `buildSnapshot` needs — minus `publishedAt` and `announcedTeamIds`,
  * which are decided by the caller (publish takes them from the request body;
  * a pre-publish preview has no announced winners yet).
+ *
+ * `rubric` must be the cohort's own — resolved via `resolveRubric(cohort)` by
+ * the caller, never defaulted here. Every total and standing below is scored
+ * against it, and this cohort's rubric may not be Impact Lab's.
  */
-export async function buildResultsInputFromRun(db: Db, runId: string, runResult: unknown): Promise<RunResultsData> {
+export async function buildResultsInputFromRun(
+  db: Db,
+  runId: string,
+  runResult: unknown,
+  rubric: JudgingRubric
+): Promise<RunResultsData> {
   const teams = extractFrozenTeams(runResult) ?? []
   const nameById = new Map(teams.map((t) => [t.id, t.name]))
   const teamIds = new Set(teams.map((t) => t.id))
@@ -67,7 +76,7 @@ export async function buildResultsInputFromRun(db: Db, runId: string, runResult:
     teamId: s.teamId,
     sheet: (s.scores ?? {}) as ScoreSheet,
   }))
-  const table = standings(judgeScores)
+  const table = standings(judgeScores, rubric)
 
   const rowsByTeam = new Map<string, typeof scoreRows>()
   for (const row of scoreRows) {
@@ -81,7 +90,7 @@ export async function buildResultsInputFromRun(db: Db, runId: string, runResult:
   for (const [teamId, rows] of rowsByTeam) {
     if (rows.every((r) => r.writeupOnly)) writeupOnly.add(teamId)
 
-    const totals = rows.map((r) => weightedTotal((r.scores ?? {}) as ScoreSheet))
+    const totals = rows.map((r) => scoreTotal((r.scores ?? {}) as ScoreSheet, rubric))
     range.set(teamId, { low: Math.min(...totals), high: Math.max(...totals) })
   }
 


### PR DESCRIPTION
## What this is

Companion to #109. That PR fixed the PDF/Excel **export**; this one fixes the same "hardcoded to July rubric" bug on every surface people actually look at:

- **Participant dashboard results** (`ResultsView` via `results-input.ts` — totals silently computed with July's normalized /100 arithmetic for every cohort)
- **Results notification email** (criteria rows, denominators, and the sample card used for test sends)
- **Admin ResultsTab / JudgesTab** (criteria and scales now come from the cohort's resolved rubric, served by the writeup/audit endpoints)

Pattern matches #109: server resolves `resolveRubric(cohort)` (DB override → code constant), totals via `scoreTotal(sheet, rubric)`, clients receive a serialized rubric instead of importing constants. New shared `serializeRubric()` helper in `judging.ts`.

July behavior is pinned: exact totals asserted unchanged, "the same five criteria" wording preserved, `verify:results` 43/43 untouched. One deliberate July-visible improvement: the score-range line now shows its denominator (it previously showed none).

## Verification

16/16 new fixture assertions (no DB): Afretec member payload totals raw-sum /50; July totals identical to before; Afretec email contains /50 and real criterion names, never /100. Gates: `tsc`, `build`, `verify:results` 43/43, `verify:judging` all green.

Files are disjoint from #109 — the two PRs merge independently in either order.

@Spidey-Acer

https://claude.ai/code/session_01U99bKqojTVppEAmLaN4d9E