### PR TITLE
fix(lib): remove duplicate getFeaturedProjects query

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { KaribuHome } from "@/components/karibu/KaribuHome";
-import { getUpcomingEvents, getBlogPosts, getFeaturedProjects, getProjectOfTheWeek } from "@/lib/data";
+import { getUpcomingEvents, getBlogPosts, getProjects, getProjectOfTheWeek } from "@/lib/data";
 import { prisma } from "@/lib/prisma";
 import { ensureVisitorId, getAudienceCookie } from "@/lib/karibu/cookies";
 import type { AudienceState } from "@/contexts/AudienceContext";
@@ -35,7 +35,7 @@ export default async function Home() {
     getUpcomingEvents().catch(() => []),
     prisma.siteSettings.findUnique({ where: { id: "default" } }).catch(() => null),
     getBlogPosts().catch(() => []),
-    getFeaturedProjects().catch(() => []),
+    getProjects().catch(() => []),
     getProjectOfTheWeek().catch(() => null),
   ]);
 

--- a/src/components/karibu/KaribuProjects.tsx
+++ b/src/components/karibu/KaribuProjects.tsx
@@ -5,7 +5,7 @@
  *
  * Redesigns two sections the original home had (Project of the Week + the
  * featured-projects showcase) into one coherent block, wired to the same DB
- * data (getProjectOfTheWeek + getFeaturedProjects). Renders nothing when there
+ * data (getProjectOfTheWeek + getProjects). Renders nothing when there
  * is no project data.
  */
 

--- a/src/lib/chat/community-context.ts
+++ b/src/lib/chat/community-context.ts
@@ -4,7 +4,7 @@ import {
   getEvents,
   getUpcomingEvents,
   getBlogPosts,
-  getFeaturedProjects,
+  getProjects,
   getTeamMembers,
 } from "@/lib/data";
 import { getSocialLinks } from "@/lib/social-links";
@@ -31,7 +31,7 @@ export async function buildCommunityContext(): Promise<string> {
     getEvents().catch(() => []),
     getUpcomingEvents().catch(() => []),
     getBlogPosts().catch(() => []),
-    getFeaturedProjects().catch(() => []),
+    getProjects().catch(() => []),
     getTeamMembers().catch(() => []),
     getSocialLinks(),
   ]);

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -295,14 +295,6 @@ export async function getProjects(): Promise<ProjectView[]> {
   return rows.map(mapPrismaProject)
 }
 
-export async function getFeaturedProjects(): Promise<ProjectView[]> {
-  const rows = await prisma.project.findMany({
-    where: { featured: true },
-    orderBy: { createdAt: "desc" },
-  })
-  return rows.map(mapPrismaProject)
-}
-
 /**
  * Returns the most recent Project of the Week, or null if none has been set.
  * The current POTW is whichever project has the latest non-null `potwAt` date.


### PR DESCRIPTION
`getFeaturedProjects` and `getProjects` in `src/lib/data.ts` ran the exact same query (`prisma.project.findMany({ where: { featured: true }, orderBy: { createdAt: "desc" } })`). Two names for one function, which only invites drift the next time either one gets touched.

Dropped `getFeaturedProjects` and pointed its two callers — the home page and the chat community-context builder — at `getProjects`. No behavior change.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — no new warnings/errors (repo already has some pre-existing ones on `main`, unrelated to this change)
- `npm run build` — succeeds

Note: I opened these against `main`, not `development` . Since  `development` is 325 commits behind and recent merged PRs (#106, #108, #113, etc.) all target `main`, so I followed the actual practice over the CONTRIBUTING.md doc. Let me know f you need otherwise.

@Spidey-Acer
