### PR TITLE
fix(api): allowlist the admin upload folder param

### DIFF
--- a/src/app/api/admin/upload/route.ts
+++ b/src/app/api/admin/upload/route.ts
@@ -5,6 +5,7 @@ import { withCsrfProtection } from "@/lib/csrf"
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"]
+const ALLOWED_FOLDERS = new Set(["events", "blog", "team", "community"])
 
 export async function POST(request: NextRequest) {
   const csrfError = withCsrfProtection(request)
@@ -15,7 +16,8 @@ export async function POST(request: NextRequest) {
 
   const formData = await request.formData()
   const file = formData.get("file") as File | null
-  const folder = (formData.get("folder") as string) || "events"
+  const rawFolder = formData.get("folder") as string | null
+  const folder = rawFolder && ALLOWED_FOLDERS.has(rawFolder) ? rawFolder : "events"
 
   if (!file) {
     return NextResponse.json(


### PR DESCRIPTION
`POST /api/admin/upload` took the `folder` field straight from the request and used it unsanitized as the storage path prefix (`${folder}/${Date.now()}-${fileName}`). Anyone with access to the admin create-event action (the only permission this route checks) could set `folder` to anything and write into arbitrary paths in the bucket.

Added an allowlist (`events`, `blog`, `team`, `community` , the four content types the app stores images for) and fall back to `events` for anything not on it. The two existing callers (event create/edit) already send `"events"`, so this is a no-op for current behavior.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` on the changed file — clean
- `npm run build` — succeeds

@Spidey-Acer
