### PR TITLE
fix(ui): swap footer emoji icons for lucide-react

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -103,11 +103,11 @@ export function Footer() {
               ? "mt-4 space-y-1 text-[12px] text-[#7a7870]"
               : "mt-4 font-mono text-xs text-text-dim"}>
               <p className="flex items-center gap-1.5">
-                {!isPro && <MapPin className="h-3 w-3 shrink-0" aria-hidden="true" />}
+                <MapPin className="h-3 w-3 shrink-0" aria-hidden="true" />
                 {CONTACT.city}
               </p>
               <p className="flex items-center gap-1.5">
-                {!isPro && <Mail className="h-3 w-3 shrink-0" aria-hidden="true" />}
+                <Mail className="h-3 w-3 shrink-0" aria-hidden="true" />
                 {CONTACT.email}
               </p>
             </div>

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useTransition } from "react";
 import Link from "next/link";
+import { MapPin, Mail } from "lucide-react";
 import { FOOTER_SECTIONS, SITE_CONFIG, CONTACT } from "@/lib/constants";
 import { useSkin } from "@/contexts/SkinContext";
 import { useSocialLinks } from "@/contexts/SocialLinksContext";
@@ -101,8 +102,14 @@ export function Footer() {
             <div className={isPro
               ? "mt-4 space-y-1 text-[12px] text-[#7a7870]"
               : "mt-4 font-mono text-xs text-text-dim"}>
-              <p>{isPro ? "" : "📍 "}{CONTACT.city}</p>
-              <p>{isPro ? "" : "✉ "}{CONTACT.email}</p>
+              <p className="flex items-center gap-1.5">
+                {!isPro && <MapPin className="h-3 w-3 shrink-0" aria-hidden="true" />}
+                {CONTACT.city}
+              </p>
+              <p className="flex items-center gap-1.5">
+                {!isPro && <Mail className="h-3 w-3 shrink-0" aria-hidden="true" />}
+                {CONTACT.email}
+              </p>
             </div>
 
             {/* Newsletter */}


### PR DESCRIPTION
The footer's location/email lines used raw emoji (📍/✉) instead of the Lucide icon set the rest of the site is built on — flagged in `UI_ISSUES.md`.

Swapped both for `MapPin`/`Mail` from `lucide-react` (already a dependency, used elsewhere e.g. in the project cards). The original only showed an icon in the dev/terminal skin at all — the pro skin had no marker, just plain text — so this now shows the same icons in both skins, matching color via `currentColor`.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` on the changed file — clean
- `npm run build` — succeeds

@Spidey-Acer
