### PR TITLE
fix(admin): make the admin panel usable on mobile

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,7 +27,9 @@ jobs:
       - name: Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          model: claude-sonnet-4-6
+          # v1 has no `model` input (it was warned as ignored); the model is
+          # pinned via claude_args instead.
+          claude_args: "--model claude-sonnet-4-6"
           prompt: |
             Review this PR for:
             1. Bugs that pass TypeScript but break at runtime

--- a/docs/audits/2026-08-26-production-ui-audit.md
+++ b/docs/audits/2026-08-26-production-ui-audit.md
@@ -27,10 +27,11 @@ disappear.
    hard-coded text on the warm cream Karibu background (~1.1:1 — unreadable), is
    linked from nowhere, yet sits in the sitemap; `/newsletter/[slug]` is a full-black
    Noir page sandwiched inside warm Karibu chrome.
-3. **Every page title is double-suffixed.** The root layout defines
-   `title.template: "%s | Claude Community Kenya"` and nearly every page also bakes
-   the suffix into its title string → "About | Claude Community Kenya | Claude
-   Community Kenya" in tabs and search results, sitewide.
+3. **Title authoring is inverted, though not doubled.** (Corrected after
+   verification: the root template is a bare `"%s"`, so titles rendered once —
+   the double-suffix claim in the original pass was wrong.) 49 page titles baked
+   "| Claude Community Kenya" in by hand instead of letting a template append it;
+   fixed on `claude/ui-roadmap-1` (template appends, pages author bare titles).
 4. **`/resources/api-guide` teaches a fabricated model ID.** `claude-haiku-3-5` has
    never existed (that generation was `claude-3-5-haiku-*`); it appears in api-guide
    and production-guide as copy-pasteable code. The rest of the model lineup is a
@@ -91,11 +92,10 @@ files, validated with tsc/build/tests, lint surface identical to main).
 
 ## C. Sitewide metadata + content accuracy
 
-- **Double title suffix (high, sitewide):** `layout.tsx:59-62` sets
-  `title.template: "%s | Claude Community Kenya"`; nearly every page passes a string
-  title already containing "| Claude Community Kenya". Fix once: strip the suffix from
-  every page title and let the template append it (only `/chat` does this correctly
-  today).
+- **Title authoring (corrected):** the template was a bare `"%s"`, so no doubling
+  occurred; the finding downgrades to inconsistent authoring — 49 hand-baked
+  suffixes. Fixed on `claude/ui-roadmap-1`: template appends the suffix once,
+  pages author bare titles, home uses `title.absolute`.
 - **Missing canonicals:** `/` (has OG url, no canonical), `/chat`,
   `/code-of-conduct` (known gap, still open).
 - **`claude-haiku-3-5` is fabricated** (`resources/api-guide` ~line 39,

--- a/docs/audits/2026-08-26-production-ui-audit.md
+++ b/docs/audits/2026-08-26-production-ui-audit.md
@@ -1,0 +1,220 @@
+# Production UI Audit — everything outside /community + /showcase
+
+**Date:** 2026-08-26
+**Scope:** All public content pages, forms, auth flows, resource pages, shared chrome,
+and the admin panel — everything the community UI audit
+(`2026-08-26-community-ui-audit.md`, PR #118) did not cover.
+**Method:** Three parallel review passes (public content pages; forms/auth/resources;
+admin mobile), findings verified against source.
+**Note on baselines:** the pass ran against `main`. Findings already fixed on
+`claude/community-ui-fixes` (the sitewide `bg-[#F3E3D9]`/`text-[#4A4238]`/Tailwind-red
+sweep across `src/components/karibu/`) are excluded below — merge that branch and they
+disappear.
+
+---
+
+## Executive summary
+
+1. **Admin panel was non-functional on mobile — root-caused and FIXED on
+   `claude/admin-mobile-fixes`.** A permanent 256px sidebar with zero responsive
+   breakpoints left ~119px of content at phone width, and every list page clipped its
+   table inside `overflow-hidden`; on five pages the only detail link sat in the
+   clipped last column, so an organiser could not open an application from a phone.
+   The branch ships: a hamburger-drawer shell below `md`, horizontally scrollable
+   tables everywhere, name-cell detail links, touch-visible row actions, and stacked
+   stat/form grids. Login was already fine.
+2. **Two pages are actively broken for visitors:** `/team/[slug]` renders near-white
+   hard-coded text on the warm cream Karibu background (~1.1:1 — unreadable), is
+   linked from nowhere, yet sits in the sitemap; `/newsletter/[slug]` is a full-black
+   Noir page sandwiched inside warm Karibu chrome.
+3. **Every page title is double-suffixed.** The root layout defines
+   `title.template: "%s | Claude Community Kenya"` and nearly every page also bakes
+   the suffix into its title string → "About | Claude Community Kenya | Claude
+   Community Kenya" in tabs and search results, sitewide.
+4. **`/resources/api-guide` teaches a fabricated model ID.** `claude-haiku-3-5` has
+   never existed (that generation was `claude-3-5-haiku-*`); it appears in api-guide
+   and production-guide as copy-pasteable code. The rest of the model lineup is a
+   generation stale.
+5. **The older Karibu forms miss the basics the new ones have.** KaribuSubmitIdea,
+   KaribuSubmitProject, and KaribuDemoRequestForm render labels with no `htmlFor`/`id`
+   at all; they plus KaribuSpeak have no `role="alert"` on errors and a
+   silently-failing on-mount CSRF fetch that leaves the submit button disabled forever.
+6. **The Noir remainder is now a defined set:** auth flows (5 pages, each duplicating
+   its whole markup per skin), 7 resource sub-pages + blog posts (the warm listing →
+   black detail flip), `/chat`, `/merch`, `/code-of-conduct`, plus the ChatWidget and
+   KaribuBanner overlays that render dark on warm pages.
+7. **A large dead-code inventory** from the Karibu conversion is ready to delete —
+   including CLAUDE.md's stale claim that `TerminalApplication.tsx` is 1,356 lines
+   (it's 412, already refactored, and `/join` no longer renders it at all).
+
+---
+
+## A. Admin mobile (diagnosed → fixed on `claude/admin-mobile-fixes`)
+
+Root cause chain, for the record:
+
+- `src/app/admin/layout.tsx` + `AdminSidebar.tsx`: `w-64 shrink-0 sticky` rail, no
+  responsive prefix anywhere in either file → 119px of content at 375px, and `p-6`
+  page padding left ~71px. `min-w-0` on main meant content was crushed and *clipped*,
+  not scrollable.
+- Every list page: card `overflow-hidden` directly wrapping a 5–7 column
+  `<table className="w-full">` → columns clipped with no scroll. On
+  applications/speakers/ideas/demos/volunteers the only detail link was a 16px chevron
+  in the last (first-clipped) column.
+- `AdminUserManager` row actions were `opacity-0 group-hover:opacity-100` — invisible
+  on touch. Stat rows `grid-cols-4`, contact inbox hard `w-1/2` split view, event
+  editor `grid-cols-2/3` field grids: none responsive. Impact Lab's ten-tab bar
+  clipped.
+- Genuinely fine and untouched: login, viewport meta, all `[id]` detail pages,
+  dashboard grids, six impact-lab tables that already scrolled, the Noir theme itself.
+
+All of the above is implemented on the branch (2 shell files + ~23 page/component
+files, validated with tsc/build/tests, lint surface identical to main).
+
+## B. Broken pages (high)
+
+- **`/team/[slug]`** — dark "Pro" body under Karibu chrome: `text-[#faf9f5]` h1,
+  `text-[#b0aea5]` bio etc. on `--paper` ≈ 1.1:1, unreadable in light mode
+  (`src/app/team/[slug]/page.tsx:77-185`). Also orphaned (no page links to it —
+  `KaribuTeam` cards link only to member socials) yet emitted by the sitemap.
+  **Decide:** convert to Karibu and link it from `/team`, or stop emitting it.
+- **`/newsletter/[slug]`** — `bg-bg-primary` (#0a0a0a) full-page Noir inside
+  KaribuNav/KaribuFooter, ~22 hard-coded dark hexes, plus the dark `HeroEmailCapture`;
+  the warm paper loading skeleton flashes into a black page
+  (`src/app/newsletter/[slug]/page.tsx:245,97-296`).
+- **`KaribuHome.tsx:722`** — `text-paper` inside the non-inverting `bg-panel-dark`
+  "How to join" slab: in dark mode ≈ 1.05:1 (invisible). Exactly the footer-bug class
+  the `--on-panel-dark` trio exists to prevent.
+- **`KaribuAbout.tsx:182`, `KaribuEventDetail.tsx:275`** — `bg-ink … text-paper
+  hover:bg-black` buttons: hover state in dark mode renders invisible text
+  (`bg-black` never flips while `text-paper` goes dark).
+
+## C. Sitewide metadata + content accuracy
+
+- **Double title suffix (high, sitewide):** `layout.tsx:59-62` sets
+  `title.template: "%s | Claude Community Kenya"`; nearly every page passes a string
+  title already containing "| Claude Community Kenya". Fix once: strip the suffix from
+  every page title and let the template append it (only `/chat` does this correctly
+  today).
+- **Missing canonicals:** `/` (has OG url, no canonical), `/chat`,
+  `/code-of-conduct` (known gap, still open).
+- **`claude-haiku-3-5` is fabricated** (`resources/api-guide` ~line 39,
+  `production-guide` 262/351) — never a real model ID; 404s at the API. The whole
+  lineup (opus-4-5/sonnet-4-5/haiku-3-5) is also a generation stale — refresh to the
+  current tier while in there. ~2 hours including link fixes; worth shipping
+  immediately regardless of any conversion work.
+- **Verify two social URLs** in `src/data/resources.ts:220,227`
+  (`twitter.com/ClaudeCommunityKE`, `linkedin.com/company/claude-community-kenya`) —
+  they look pattern-guessed; everything else in the file checks out. `cursor.sh`
+  now redirects to cursor.com (cosmetic).
+- `/join`'s city list includes "Kisumu — Growing" while site facts elsewhere say
+  Nairobi + Mombasa only.
+
+## D. Forms (Karibu-converted, quality varies)
+
+House standard = the fixed `/community/submit` + `KaribuVolunteer` (the model form).
+
+- **KaribuSubmitIdea, KaribuSubmitProject, KaribuDemoRequestForm (high):** their
+  shared `Field` helper renders `<label>` with **no `htmlFor`/id wiring at all** —
+  every field announces unnamed. KaribuSpeak's variant does wire ids (via
+  cloneElement) but misses the rest.
+- **All four + newsletter:** on-mount CSRF fetch with silent `catch` +
+  `disabled={!csrfToken}` → the primary CTA is bricked forever if the token fetch
+  fails, with no message. (Newsletter subscribe is the homepage conversion CTA.)
+- **No `role="alert"`** on global/field errors in Speak/SubmitIdea/SubmitProject/
+  DemoRequest; SubmitIdea's "seeking roles" chips have no `aria-pressed` and its
+  tag-remove buttons no accessible name; four radio groups use bare labels instead
+  of fieldset/legend; newsletter's error renders in `text-clay` (accent) instead of
+  `text-error`.
+- `/contact` **does not exist**: `/api/contact` and the admin inbox are live, but
+  nothing on the site can create a ContactMessage — dead capability or missing page.
+- Quick-win batch for all of the above: ~1 day, no conversions required.
+
+## E. Auth flows (Noir, user-facing)
+
+/login, /signup, /forgot-password, /reset-password, /verify-email each render **two
+complete hard-coded variants** switched on `useSkin()` — 100% markup duplication per
+page, raw hexes, no tokens. KaribuNav links straight into them, so the warm→dark flip
+is on the main nav path.
+
+- `/signup` has **no metadata layout at all** — indexed, root-fallback title, no
+  noindex (every other auth page has one).
+- The Noir variant of every page lacks `role="alert"` on errors while the pro variant
+  has it; `/verify-email`'s verifying→success transition is never announced.
+- `/forgot-password`'s two variants disagree on account enumeration ("We sent a reset
+  link" vs "If an account exists…") — the pro copy asserts a send the API refuses to
+  confirm.
+- `/login` enforces `minLength={8}` on the login password — can lock out legacy
+  short-password users from even submitting.
+- Estimate: one shared Karibu auth-card + 5 page rewrites ≈ 2–3 days (deletes the
+  dual-skin branching); the missing `role="alert"`s + signup metadata are ~1 hour
+  standalone if conversion waits.
+
+## F. Resource pages + blog detail (Noir remainder)
+
+- `/resources` and `/blog` listings are Karibu; **all 7 resource sub-pages and every
+  blog post render Noir** — each card click on the warm hub flips the site to the
+  green terminal. `/code-of-conduct` (linked from three warm forms) same.
+- `/resources/links`: still no `alternates.canonical` (the known issue); long literal
+  URLs with no `break-all`/overflow handling overflow a 360px viewport.
+- Conversion estimate: ~3–4 days (needs a Karibu article/code-block component first,
+  which also fixes the mobile overflow); content fixes ship separately (§C).
+
+## G. Chrome + polish (medium/low)
+
+- **ChatWidget + KaribuBanner** are mounted on every non-admin route but styled only
+  in Noir vocab — a dark launcher/toast floating on warm paper pages.
+- **PageTransition** wraps every page in a Framer fade with no `useReducedMotion`
+  guard (the CSS kill-switch doesn't reach Framer's inline styles), SSRs content at
+  opacity 0 for no-JS/bots, and double-animates on top of the (exemplary) Reveal
+  system on Karibu routes.
+- `KaribuHome.tsx:87` `toLocaleString()` without a locale in a client component —
+  hydration mismatch risk; pin `"en-KE"`.
+- `KaribuHome.tsx:440` `text-[#F5E4DB]` and `Marquee.tsx:25,30` hard-coded lights on
+  `bg-clay` ≈ 2.9:1 in dark mode; `KaribuVolunteer.tsx:73` `text-amber-600` CharCount.
+- KaribuNav dropdown trigger lacks `aria-haspopup`/`aria-expanded`; KaribuBanner
+  auto-dismisses with pause only on pointer hover; `chat/page.tsx` decorative flame
+  has `alt="Kenya"` instead of empty alt.
+- `blog/[slug]` and `events/[slug]` data fetches have no `.catch` (transient DB error
+  → 500 instead of degrading).
+- Latent: `ensureVisitorId()` calls `cookies().set()` from the home RSC (only legal in
+  actions/route handlers) — masked by the proxy setting the cookie first; also makes
+  `/` dynamic so its `revalidate = 3600` is inert.
+- StickyMobileCTA scrolls to `#hero-email`, which exists on none of the legacy routes
+  it renders on.
+- Verified good: MobileMenu and PhotoLightbox focus traps, FAQ accordion ARIA, skip
+  link, skeletons, all internal links resolve, all external links carry `rel`.
+
+## H. Dead code inventory (delete-ready, zero live importers verified)
+
+- Pre-Karibu page twins: `events/[slug]/EventDetailContent.tsx` + `EventPhotoStrip`,
+  `events/EventsContent.tsx`, `about/AboutClient.tsx`, `projects/ProjectsClient.tsx`,
+  `faq/FaqPageContent.tsx` + `FaqClient.tsx` + `FloatingDiscordCTA.tsx`,
+  `join/JoinSwitcher.tsx` + `ProJoinContent.tsx` + `LazyTerminalApplication` +
+  `TerminalApplication` (+ its `terminal/application/*` submodules if unshared),
+  `events/[slug]/DemoRequestForm.tsx` (Noir twin).
+- The whole `sections/HomeContent.tsx` tree: MadeForYou, PersonalizedHero, HeroPro,
+  StatsBarPro, SocialProofRail, TestimonialsCarousel, StatsBar, ProjectOfTheWeek,
+  EventCard, ProjectCard, CommunityResourceCard (HeroTerminal survives only as a type
+  source; HeroEmailCapture is live).
+- `karibu/KaribuGallery.tsx` (superseded); `ui/MediaFrame`, `ui/Timeline`,
+  `ui/Button`, `ui/Accordion` now reachable only via dead files.
+- **CLAUDE.md updates needed:** TerminalApplication is 412 lines and unmounted (not
+  1,356 / "needs refactoring"); `/ambassador` doesn't exist; 17-vs-24 Prisma model
+  count discrepancy.
+
+## Recommended roadmap
+
+1. **Merge the two open fix branches** (`claude/community-ui-fixes`,
+   `claude/admin-mobile-fixes`) — admin mobile and the community surface are done.
+2. **Ship the small high-impact batch (~1 day):** title-template de-duplication,
+   `/team/[slug]` decision, resource content fixes (`claude-haiku-3-5`, model
+   refresh, links canonical + overflow), the four dark-mode color bugs in §B,
+   forms quick-win batch (§D), signup metadata + auth `role="alert"`s.
+3. **Dead-code deletion + CLAUDE.md refresh (~0.5 day).**
+4. **Auth flows → Karibu (2–3 days).**
+5. **Resource sub-pages + blog detail + newsletter detail → Karibu (3–4 days),**
+   retiring the last legacyPrefixes and the Noir chrome for the public site.
+6. **Sitewide wart, own decision:** re-layer the `.persona-pro h1-h3` rule so
+   `font-newsreader` headings actually render Newsreader — the entire Karibu
+   identity's serif currently silently renders Fraunces.

--- a/src/app/admin/applications/page.tsx
+++ b/src/app/admin/applications/page.tsx
@@ -24,7 +24,7 @@ export default async function ApplicationsPage() {
     <div>
       <AdminHeader title="Join Applications" />
       <div className="p-6 space-y-4">
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[
             { label: "Total", value: counts.total, color: "#888" },
             { label: "Pending", value: counts.pending, color: "#ffb000" },
@@ -38,7 +38,7 @@ export default async function ApplicationsPage() {
           ))}
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {applications.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Users className="w-8 h-8 text-[#333] mb-3" />
@@ -46,7 +46,7 @@ export default async function ApplicationsPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Applications via the /join form will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Applicant</th>
@@ -62,7 +62,12 @@ export default async function ApplicationsPage() {
                   <tr key={app.id} className="hover:bg-[#111] transition-colors group">
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-2">
-                        <span className="text-sm font-mono text-[#e0e0e0]">{app.name}</span>
+                        <Link
+                          href={`/admin/applications/${app.id}`}
+                          className="text-sm font-mono text-[#e0e0e0] hover:text-[#00ff41]"
+                        >
+                          {app.name}
+                        </Link>
                         {app.karibuAudience && (
                           <span className="text-[10px] font-mono px-1.5 py-0.5 rounded border border-[#00ff41]/30 text-[#00ff41] bg-[#00ff41]/5 whitespace-nowrap">
                             From Karibu · {isAudience(app.karibuAudience) ? AUDIENCE_LABELS[app.karibuAudience] : app.karibuAudience}
@@ -84,7 +89,7 @@ export default async function ApplicationsPage() {
                       <span className="text-[11px] font-mono text-[#444]">{formatDate(app.createdAt.toISOString())}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <Link href={`/admin/applications/${app.id}`} className="text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
+                      <Link href={`/admin/applications/${app.id}`} aria-label="View details" className="inline-flex p-2 -m-2 text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
                         <ChevronRight className="w-4 h-4" />
                       </Link>
                     </td>

--- a/src/app/admin/blog/[id]/edit/page.tsx
+++ b/src/app/admin/blog/[id]/edit/page.tsx
@@ -349,7 +349,7 @@ export default function EditBlogPostPage() {
             <p className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Personalization Tags</p>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Audiences</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {AUDIENCES.map((a) => (
                   <label key={a} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input
@@ -367,7 +367,7 @@ export default function EditBlogPostPage() {
             </fieldset>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Intents</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {INTENTS.map((i) => (
                   <label key={i} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input

--- a/src/app/admin/blog/new/page.tsx
+++ b/src/app/admin/blog/new/page.tsx
@@ -297,7 +297,7 @@ export default function NewBlogPostPage() {
             <p className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Personalization Tags</p>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Audiences</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {AUDIENCES.map((a) => (
                   <label key={a} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input
@@ -315,7 +315,7 @@ export default function NewBlogPostPage() {
             </fieldset>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Intents</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {INTENTS.map((i) => (
                   <label key={i} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input

--- a/src/app/admin/blog/page.tsx
+++ b/src/app/admin/blog/page.tsx
@@ -39,7 +39,7 @@ export default async function BlogAdminPage() {
           </Link>
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {posts.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <FileText className="w-8 h-8 text-[#333] mb-3" />
@@ -47,7 +47,7 @@ export default async function BlogAdminPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Run the seed script to populate blog posts</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Title</th>

--- a/src/app/admin/community/[id]/edit/page.tsx
+++ b/src/app/admin/community/[id]/edit/page.tsx
@@ -175,7 +175,7 @@ export default function EditCommunityPage() {
           {/* Links */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Links</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="URL" type="url" value={url} onChange={setUrl} placeholder="https://..." />
               <FieldInput label="Repository URL" type="url" value={repoUrl} onChange={setRepoUrl} placeholder="https://github.com/..." />
             </div>
@@ -190,7 +190,7 @@ export default function EditCommunityPage() {
           {/* Classification */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Classification</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldSelect label="Type" value={type} onChange={setType} options={SUBMISSION_TYPES.map((t) => ({ value: t, label: TYPE_LABELS[t] }))} />
               <FieldSelect label="Status" value={status} onChange={setStatus} options={SUBMISSION_STATUSES.map((s) => ({ value: s, label: STATUS_LABELS[s] }))} />
             </div>

--- a/src/app/admin/community/page.tsx
+++ b/src/app/admin/community/page.tsx
@@ -84,7 +84,7 @@ export default async function CommunityAdminPage({
           </form>
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {submissions.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <MessageSquare className="w-8 h-8 text-[#333] mb-3" />
@@ -92,7 +92,7 @@ export default async function CommunityAdminPage({
               <p className="text-xs font-mono text-[#333] mt-1">Community submissions will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Title</th>

--- a/src/app/admin/contact/page.tsx
+++ b/src/app/admin/contact/page.tsx
@@ -166,7 +166,7 @@ export default function ContactAdminPage() {
 
       <div className="p-6 space-y-4">
         {/* Stats Cards */}
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           {[
             { label: "Total", value: counts.total, color: "#888" },
             { label: "Unread", value: counts.unread, color: "#ffb000" },
@@ -215,9 +215,9 @@ export default function ContactAdminPage() {
         )}
 
         {/* Main Content */}
-        <div className="flex gap-4">
+        <div className="flex flex-col gap-4 lg:flex-row">
           {/* Message List */}
-          <div className={`bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden ${selectedMessage ? "w-1/2" : "w-full"} transition-all`}>
+          <div className={`bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden w-full ${selectedMessage ? "lg:w-1/2" : ""} transition-all`}>
             {loading ? (
               <div className="flex flex-col items-center justify-center py-16 text-center">
                 <Loader2 className="w-6 h-6 text-[#00ff41] animate-spin mb-3" />
@@ -282,7 +282,7 @@ export default function ContactAdminPage() {
 
           {/* Detail Panel */}
           {selectedMessage && (
-            <div className="w-1/2 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden flex flex-col">
+            <div className="w-full lg:w-1/2 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden flex flex-col">
               {/* Detail Header */}
               <div className="flex items-center justify-between px-5 py-3 border-b border-[#1e1e1e]">
                 <div className="flex items-center gap-2">

--- a/src/app/admin/demos/page.tsx
+++ b/src/app/admin/demos/page.tsx
@@ -24,7 +24,7 @@ export default async function DemosPage() {
       <AdminHeader title="Demo Requests" />
       <div className="p-6 space-y-4">
         {/* Summary */}
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[
             { label: "Total", value: counts.total, color: "#888" },
             { label: "Pending", value: counts.pending, color: "#ffb000" },
@@ -39,7 +39,7 @@ export default async function DemosPage() {
         </div>
 
         {/* Table */}
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {demoRequests.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Presentation className="w-8 h-8 text-[#333] mb-3" />
@@ -47,7 +47,7 @@ export default async function DemosPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Requests submitted via event pages will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Applicant</th>
@@ -62,8 +62,10 @@ export default async function DemosPage() {
                 {demoRequests.map((demo) => (
                   <tr key={demo.id} className="hover:bg-[#111] transition-colors group">
                     <td className="px-4 py-3">
-                      <div className="text-sm font-mono text-[#e0e0e0]">{demo.name}</div>
-                      <div className="text-[11px] font-mono text-[#444]">{demo.email}</div>
+                      <Link href={`/admin/demos/${demo.id}`} className="block hover:text-[#00ff41]">
+                        <div className="text-sm font-mono text-[#e0e0e0]">{demo.name}</div>
+                        <div className="text-[11px] font-mono text-[#444]">{demo.email}</div>
+                      </Link>
                     </td>
                     <td className="px-4 py-3">
                       <div className="text-sm font-mono text-[#aaa] max-w-[220px] truncate">{demo.projectTitle}</div>
@@ -78,7 +80,7 @@ export default async function DemosPage() {
                       <span className="text-[11px] font-mono text-[#444]">{formatDate(demo.createdAt.toISOString())}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <Link href={`/admin/demos/${demo.id}`} className="text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
+                      <Link href={`/admin/demos/${demo.id}`} aria-label="View details" className="inline-flex p-2 -m-2 text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
                         <ChevronRight className="w-4 h-4" />
                       </Link>
                     </td>

--- a/src/app/admin/events/[id]/edit/page.tsx
+++ b/src/app/admin/events/[id]/edit/page.tsx
@@ -248,11 +248,11 @@ export default function EditEventPage() {
           {/* Date, Time, Venue */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Schedule & Location</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Date" type="date" value={date} onChange={setDate} required />
               <FieldInput label="Time" value={time} onChange={setTime} placeholder="e.g. 2:00 PM - 5:00 PM" required />
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Venue" value={venue} onChange={setVenue} required />
               <FieldInput label="City" value={city} onChange={setCity} required />
             </div>
@@ -261,11 +261,11 @@ export default function EditEventPage() {
           {/* Type, Status, Featured */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Classification</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldSelect label="Type" value={type} onChange={setType} options={EVENT_TYPES.map(t => ({ value: t, label: TYPE_LABELS[t] }))} />
               <FieldSelect label="Status" value={status} onChange={setStatus} options={EVENT_STATUSES.map(s => ({ value: s, label: STATUS_LABELS[s] }))} />
             </div>
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <FieldInput label="Attendee Count" type="number" value={attendeeCount} onChange={setAttendeeCount} placeholder="Signed up" />
               <FieldInput label="Capacity" type="number" value={capacity} onChange={setCapacity} placeholder="Max seats" />
               <div className="flex items-center gap-3 pt-5">
@@ -284,14 +284,14 @@ export default function EditEventPage() {
           {/* Organizer & Links */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Organizer & Links</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Host" value={host} onChange={setHost} placeholder="Optional" />
               {/* Renders publicly under "With thanks to" — per ambassador program
                   rules, never use "partner"/"co-host"/"sponsor" framing for orgs
                   that are not listed Claude customers. */}
               <FieldInput label="Venue / host orgs (thanks)" value={partnerOrg} onChange={setPartnerOrg} placeholder="Optional" />
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Registration URL" type="url" value={registrationUrl} onChange={setRegistrationUrl} placeholder="Optional" />
               <FieldInput label="Luma URL" type="url" value={lumaUrl} onChange={setLumaUrl} placeholder="Optional" />
             </div>
@@ -314,7 +314,7 @@ export default function EditEventPage() {
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Personalization Tags</h2>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Audiences</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {AUDIENCES.map((a) => (
                   <label key={a} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input
@@ -332,7 +332,7 @@ export default function EditEventPage() {
             </fieldset>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Intents</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {INTENTS.map((i) => (
                   <label key={i} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input

--- a/src/app/admin/events/new/page.tsx
+++ b/src/app/admin/events/new/page.tsx
@@ -171,11 +171,11 @@ export default function NewEventPage() {
           {/* Date, Time, Venue */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Schedule & Location</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Date" type="date" value={date} onChange={setDate} required />
               <FieldInput label="Time" value={time} onChange={setTime} placeholder="e.g. 2:00 PM - 5:00 PM" required />
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Venue" value={venue} onChange={setVenue} required />
               <FieldInput label="City" value={city} onChange={setCity} required />
             </div>
@@ -184,11 +184,11 @@ export default function NewEventPage() {
           {/* Type, Status, Featured */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Classification</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldSelect label="Type" value={type} onChange={setType} options={EVENT_TYPES.map(t => ({ value: t, label: TYPE_LABELS[t] }))} />
               <FieldSelect label="Status" value={status} onChange={setStatus} options={EVENT_STATUSES.map(s => ({ value: s, label: STATUS_LABELS[s] }))} />
             </div>
-            <div className="grid grid-cols-3 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               <FieldInput label="Attendee Count" type="number" value={attendeeCount} onChange={setAttendeeCount} placeholder="Signed up" />
               <FieldInput label="Capacity" type="number" value={capacity} onChange={setCapacity} placeholder="Max seats" />
               <div className="flex items-center gap-3 pt-5">
@@ -207,14 +207,14 @@ export default function NewEventPage() {
           {/* Organizer & Links */}
           <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg p-5 space-y-4">
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Organizer & Links</h2>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Host" value={host} onChange={setHost} placeholder="Optional" />
               {/* Renders publicly under "With thanks to" — per ambassador program
                   rules, never use "partner"/"co-host"/"sponsor" framing for orgs
                   that are not listed Claude customers. */}
               <FieldInput label="Venue / host orgs (thanks)" value={partnerOrg} onChange={setPartnerOrg} placeholder="Optional" />
             </div>
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               <FieldInput label="Registration URL" type="url" value={registrationUrl} onChange={setRegistrationUrl} placeholder="Optional" />
               <FieldInput label="Luma URL" type="url" value={lumaUrl} onChange={setLumaUrl} placeholder="Optional" />
             </div>
@@ -237,7 +237,7 @@ export default function NewEventPage() {
             <h2 className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider">Personalization Tags</h2>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Audiences</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {AUDIENCES.map((a) => (
                   <label key={a} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input
@@ -255,7 +255,7 @@ export default function NewEventPage() {
             </fieldset>
             <fieldset className="space-y-2">
               <legend className="font-mono text-xs text-[#555]">Intents</legend>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                 {INTENTS.map((i) => (
                   <label key={i} className="flex items-center gap-2 text-xs font-mono text-[#888] cursor-pointer">
                     <input

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -35,7 +35,7 @@ export default async function EventsAdminPage() {
           </Link>
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {events.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Calendar className="w-8 h-8 text-[#333] mb-3" />
@@ -43,7 +43,7 @@ export default async function EventsAdminPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Run the seed script to populate events</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Event</th>

--- a/src/app/admin/ideas/page.tsx
+++ b/src/app/admin/ideas/page.tsx
@@ -29,7 +29,7 @@ export default async function IdeasPage() {
     <div>
       <AdminHeader title="Idea Submissions" />
       <div className="p-6 space-y-4">
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[
             { label: "Total", value: counts.total, color: "#888" },
             { label: "Pending", value: counts.pending, color: "#ffb000" },
@@ -43,7 +43,7 @@ export default async function IdeasPage() {
           ))}
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {submissions.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Lightbulb className="w-8 h-8 text-[#333] mb-3" />
@@ -51,7 +51,7 @@ export default async function IdeasPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Submissions via /submit-idea will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Project</th>
@@ -66,8 +66,10 @@ export default async function IdeasPage() {
                 {submissions.map((sub) => (
                   <tr key={sub.id} className="hover:bg-[#111] transition-colors group">
                     <td className="px-4 py-3">
-                      <div className="text-sm font-mono text-[#e0e0e0]">{sub.title}</div>
-                      <div className="text-[11px] font-mono text-[#444] max-w-[220px] truncate">{sub.description}</div>
+                      <Link href={`/admin/ideas/${sub.id}`} className="block hover:text-[#00ff41]">
+                        <div className="text-sm font-mono text-[#e0e0e0]">{sub.title}</div>
+                        <div className="text-[11px] font-mono text-[#444] max-w-[220px] truncate">{sub.description}</div>
+                      </Link>
                     </td>
                     <td className="px-4 py-3">
                       <span className="text-[11px] font-mono text-[#666]">{STAGE_LABELS[sub.stage] ?? sub.stage}</span>
@@ -83,7 +85,7 @@ export default async function IdeasPage() {
                       <span className="text-[11px] font-mono text-[#444]">{formatDate(sub.createdAt.toISOString())}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <Link href={`/admin/ideas/${sub.id}`} className="text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
+                      <Link href={`/admin/ideas/${sub.id}`} aria-label="View details" className="inline-flex p-2 -m-2 text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
                         <ChevronRight className="w-4 h-4" />
                       </Link>
                     </td>

--- a/src/app/admin/karibu/page.tsx
+++ b/src/app/admin/karibu/page.tsx
@@ -264,7 +264,7 @@ export default async function KaribuAdminPage() {
         </div>
 
         {/* ── Recent completions ────────────────────────────────────────── */}
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           <div className="px-5 py-3 border-b border-[#1e1e1e]">
             <h2 className="text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">
               Recent Completions (last 10)
@@ -275,7 +275,7 @@ export default async function KaribuAdminPage() {
               <p className="text-sm font-mono text-[#444]">No completions yet</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1a1a1a]">
                   <th className="px-4 py-2 text-left text-[10px] font-mono text-[#444] uppercase tracking-wider">When</th>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -65,7 +65,9 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <AdminProviders>
-      <div className="flex min-h-screen bg-[#0a0a0a]">
+      {/* Column below md so the mobile top bar stacks above the content;
+        * row from md up where the sticky rail sits beside it. */}
+      <div className="flex min-h-screen flex-col bg-[#0a0a0a] md:flex-row">
         <AdminSidebar />
         <main className="flex-1 min-w-0">{children}</main>
       </div>

--- a/src/app/admin/photos/page.tsx
+++ b/src/app/admin/photos/page.tsx
@@ -84,7 +84,7 @@ export default async function PhotosAdminPage({
           </Link>
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {filtered.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Camera className="w-8 h-8 text-[#333] mb-3" />
@@ -92,7 +92,7 @@ export default async function PhotosAdminPage({
               <p className="text-xs font-mono text-[#333] mt-1">Upload photos from community meetups.</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Photo</th>

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -83,7 +83,7 @@ export default async function ReportsAdminPage() {
       <div className="p-6 space-y-4">
         <p className="text-xs font-mono text-[#555]">{reports.length} open report{reports.length !== 1 ? "s" : ""}</p>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {reports.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <ShieldAlert className="w-8 h-8 text-[#333] mb-3" />
@@ -91,7 +91,7 @@ export default async function ReportsAdminPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Flagged content will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Target</th>

--- a/src/app/admin/speakers/page.tsx
+++ b/src/app/admin/speakers/page.tsx
@@ -32,7 +32,7 @@ export default async function SpeakersPage() {
       <AdminHeader title="Speaker Applications" />
       <div className="p-6 space-y-4">
         {/* Summary */}
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[
             { label: "Total", value: counts.total, color: "#888" },
             { label: "Pending", value: counts.pending, color: "#ffb000" },
@@ -47,7 +47,7 @@ export default async function SpeakersPage() {
         </div>
 
         {/* Table */}
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {applications.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Mic2 className="w-8 h-8 text-[#333] mb-3" />
@@ -55,7 +55,7 @@ export default async function SpeakersPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Applications submitted via /speak will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Applicant</th>
@@ -70,8 +70,10 @@ export default async function SpeakersPage() {
                 {applications.map((app) => (
                   <tr key={app.id} className="hover:bg-[#111] transition-colors group">
                     <td className="px-4 py-3">
-                      <div className="text-sm font-mono text-[#e0e0e0]">{app.name}</div>
-                      <div className="text-[11px] font-mono text-[#444]">{app.email}</div>
+                      <Link href={`/admin/speakers/${app.id}`} className="block hover:text-[#00ff41]">
+                        <div className="text-sm font-mono text-[#e0e0e0]">{app.name}</div>
+                        <div className="text-[11px] font-mono text-[#444]">{app.email}</div>
+                      </Link>
                     </td>
                     <td className="px-4 py-3">
                       <div className="text-sm font-mono text-[#aaa] max-w-[220px] truncate">{app.topic}</div>
@@ -86,7 +88,7 @@ export default async function SpeakersPage() {
                       <span className="text-[11px] font-mono text-[#444]">{formatDate(app.createdAt.toISOString())}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <Link href={`/admin/speakers/${app.id}`} className="text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
+                      <Link href={`/admin/speakers/${app.id}`} aria-label="View details" className="inline-flex p-2 -m-2 text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
                         <ChevronRight className="w-4 h-4" />
                       </Link>
                     </td>

--- a/src/app/admin/team/page.tsx
+++ b/src/app/admin/team/page.tsx
@@ -26,7 +26,7 @@ export default async function TeamAdminPage() {
           </Link>
         </div>
 
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {members.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Users className="w-8 h-8 text-[#333] mb-3" />
@@ -34,7 +34,7 @@ export default async function TeamAdminPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Add your first team member to get started.</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Name</th>

--- a/src/app/admin/volunteers/page.tsx
+++ b/src/app/admin/volunteers/page.tsx
@@ -28,7 +28,7 @@ export default async function VolunteersPage() {
       <AdminHeader title="Volunteer Applications" />
       <div className="p-6 space-y-4">
         {/* Summary */}
-        <div className="grid grid-cols-4 gap-3">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           {[
             { label: "Total", value: counts.total, color: "#888" },
             { label: "Pending", value: counts.pending, color: "#ffb000" },
@@ -43,7 +43,7 @@ export default async function VolunteersPage() {
         </div>
 
         {/* Table */}
-        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
+        <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
           {applications.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <HandHeart className="w-8 h-8 text-[#333] mb-3" />
@@ -51,7 +51,7 @@ export default async function VolunteersPage() {
               <p className="text-xs font-mono text-[#333] mt-1">Applications submitted via /volunteer will appear here</p>
             </div>
           ) : (
-            <table className="w-full">
+            <table className="w-full min-w-[640px]">
               <thead>
                 <tr className="border-b border-[#1e1e1e]">
                   <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">Applicant</th>
@@ -66,8 +66,10 @@ export default async function VolunteersPage() {
                 {applications.map((app) => (
                   <tr key={app.id} className="hover:bg-[#111] transition-colors group">
                     <td className="px-4 py-3">
-                      <div className="text-sm font-mono text-[#e0e0e0]">{app.name}</div>
-                      <div className="text-[11px] font-mono text-[#444]">{app.email}</div>
+                      <Link href={`/admin/volunteers/${app.id}`} className="block hover:text-[#00ff41]">
+                        <div className="text-sm font-mono text-[#e0e0e0]">{app.name}</div>
+                        <div className="text-[11px] font-mono text-[#444]">{app.email}</div>
+                      </Link>
                     </td>
                     <td className="px-4 py-3">
                       <span
@@ -91,7 +93,7 @@ export default async function VolunteersPage() {
                       <span className="text-[11px] font-mono text-[#444]">{formatDate(app.createdAt.toISOString())}</span>
                     </td>
                     <td className="px-4 py-3">
-                      <Link href={`/admin/volunteers/${app.id}`} className="text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
+                      <Link href={`/admin/volunteers/${app.id}`} aria-label="View details" className="inline-flex p-2 -m-2 text-[#444] hover:text-[#00ff41] transition-colors group-hover:text-[#00ff41]">
                         <ChevronRight className="w-4 h-4" />
                       </Link>
                     </td>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -82,11 +82,6 @@ export function AdminSidebar() {
     setHydrated(true)
   }, [])
 
-  // Navigating closes the drawer; Escape closes it too.
-  useEffect(() => {
-    setDrawerOpen(false)
-  }, [pathname])
-
   useEffect(() => {
     if (!drawerOpen) return
     function onKeyDown(e: KeyboardEvent) {
@@ -113,7 +108,10 @@ export function AdminSidebar() {
     return pathname.startsWith(href)
   }
 
-  const navLinks = (
+  // Rendered twice (drawer + rail); the drawer passes onNavigate so tapping a
+  // link closes it — cheaper and lint-cleaner than watching pathname in an
+  // effect.
+  const renderNav = (onNavigate?: () => void) => (
     <nav className={cn("flex-1 overflow-y-auto p-3 space-y-0.5", collapsed && "md:p-2")}>
       {visibleNavItems.map(({ href, label, icon: Icon, exact }) => {
         const active = isActive(href, exact)
@@ -121,6 +119,7 @@ export function AdminSidebar() {
           <Link
             key={href}
             href={href}
+            onClick={onNavigate}
             title={collapsed ? label : undefined}
             className={cn(
               "flex items-center gap-3 rounded text-sm font-mono transition-all group px-3 py-2.5",
@@ -218,7 +217,7 @@ export function AdminSidebar() {
                 <X className="w-5 h-5" />
               </button>
             </div>
-            {navLinks}
+            {renderNav(() => setDrawerOpen(false))}
             {footer}
           </div>
         </div>
@@ -268,7 +267,7 @@ export function AdminSidebar() {
         )}
 
         {/* Navigation — scrolls internally, the rail itself stays pinned */}
-        {navLinks}
+        {renderNav()}
 
         {/* Sign Out */}
         {footer}

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -26,6 +26,8 @@ import {
   ShieldAlert,
   PanelLeftClose,
   PanelLeftOpen,
+  Menu,
+  X,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
 
@@ -58,10 +60,19 @@ const COLLAPSED_KEY = "cck-admin-sidebar-collapsed"
 // Keep in sync with rbac.ts's `reports` entry if that ever changes.
 const REPORTS_VISIBLE_ROLES = new Set(["SUPER_ADMIN", "ADMIN", "MODERATOR"])
 
+/**
+ * Admin navigation shell.
+ *
+ * Desktop (md+): the original sticky rail with a collapse toggle.
+ * Mobile (below md): the rail is hidden entirely — it used to occupy 256 of
+ * a phone's 375px and crush every page — replaced by a top bar with a
+ * hamburger that opens the same nav as an off-canvas drawer.
+ */
 export function AdminSidebar() {
   const pathname = usePathname()
   const { data: session } = useSession()
   const [collapsed, setCollapsed] = useState(false)
+  const [drawerOpen, setDrawerOpen] = useState(false)
   // localStorage is read after mount — reading it during render would make the
   // server and client HTML disagree and trigger a hydration error.
   const [hydrated, setHydrated] = useState(false)
@@ -70,6 +81,20 @@ export function AdminSidebar() {
     setCollapsed(localStorage.getItem(COLLAPSED_KEY) === "1")
     setHydrated(true)
   }, [])
+
+  // Navigating closes the drawer; Escape closes it too.
+  useEffect(() => {
+    setDrawerOpen(false)
+  }, [pathname])
+
+  useEffect(() => {
+    if (!drawerOpen) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setDrawerOpen(false)
+    }
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [drawerOpen])
 
   const role = (session?.user as { role?: string } | undefined)?.role
   const visibleNavItems = navItems.filter(
@@ -88,110 +113,166 @@ export function AdminSidebar() {
     return pathname.startsWith(href)
   }
 
-  return (
-    <aside
-      className={cn(
-        "sticky top-0 h-screen shrink-0 bg-bg-secondary border-r border-border-default flex flex-col",
-        hydrated && "transition-[width] duration-200 motion-reduce:transition-none",
-        collapsed ? "w-16" : "w-64"
-      )}
-    >
-      {/* Logo + collapse toggle */}
-      <div
+  const navLinks = (
+    <nav className={cn("flex-1 overflow-y-auto p-3 space-y-0.5", collapsed && "md:p-2")}>
+      {visibleNavItems.map(({ href, label, icon: Icon, exact }) => {
+        const active = isActive(href, exact)
+        return (
+          <Link
+            key={href}
+            href={href}
+            title={collapsed ? label : undefined}
+            className={cn(
+              "flex items-center gap-3 rounded text-sm font-mono transition-all group px-3 py-2.5",
+              collapsed && "md:px-0 md:justify-center",
+              active
+                ? "bg-green-primary/10 text-green-primary border border-green-primary/20"
+                : "text-text-secondary hover:text-text-primary hover:bg-bg-card border border-transparent"
+            )}
+          >
+            <Icon className={cn("w-4 h-4 flex-shrink-0", active ? "text-green-primary" : "text-current")} />
+            <span className={cn("flex-1", collapsed && "md:hidden")}>{label}</span>
+            {active && (
+              <ChevronRight className={cn("w-3 h-3 text-green-primary", collapsed && "md:hidden")} />
+            )}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+
+  const footer = (
+    <div className={cn("border-t border-border-default p-3", collapsed && "md:p-2")}>
+      <button
+        onClick={() => signOut({ callbackUrl: "/admin/login" })}
+        title={collapsed ? "Sign Out" : undefined}
         className={cn(
-          "border-b border-border-default flex items-center",
-          collapsed ? "p-3 justify-center" : "p-5 justify-between"
+          "w-full flex items-center gap-3 rounded text-sm font-mono text-text-dim hover:text-red hover:bg-red/10 border border-transparent hover:border-red/20 transition-all px-3 py-2.5",
+          collapsed && "md:px-0 md:justify-center"
         )}
       >
-        <Link
-          href="/admin"
-          className="flex items-center gap-2.5 group"
-          title={collapsed ? "CCK Admin Panel" : undefined}
-        >
-          <div className="w-8 h-8 rounded bg-green-primary/10 border border-green-primary/30 flex items-center justify-center shrink-0">
-            <Terminal className="w-4 h-4 text-green-primary" />
-          </div>
-          {!collapsed && (
-            <div>
-              <div className="text-xs font-mono font-bold text-green-primary leading-none">CCK</div>
-              <div className="text-[10px] font-mono text-text-dim leading-none mt-0.5">Admin Panel</div>
-            </div>
-          )}
-        </Link>
-        {!collapsed && (
-          <button
-            onClick={toggleCollapsed}
-            aria-label="Collapse sidebar"
-            aria-expanded="true"
-            className="p-1.5 rounded text-text-dim hover:text-text-primary hover:bg-bg-card transition-colors"
-          >
-            <PanelLeftClose className="w-4 h-4" />
-          </button>
+        <LogOut className="w-4 h-4" />
+        <span className={cn(collapsed && "md:hidden")}>Sign Out</span>
+      </button>
+      <Link
+        href="/"
+        className={cn(
+          "mt-1 w-full flex items-center gap-3 px-3 py-2 rounded text-xs font-mono text-text-dim hover:text-text-secondary transition-colors",
+          collapsed && "md:hidden"
         )}
-      </div>
+      >
+        <span>← Back to site</span>
+      </Link>
+    </div>
+  )
 
-      {/* Expand button when collapsed */}
-      {collapsed && (
-        <div className="p-3 border-b border-border-default flex justify-center">
-          <button
-            onClick={toggleCollapsed}
-            aria-label="Expand sidebar"
-            aria-expanded="false"
-            title="Expand sidebar"
-            className="p-1.5 rounded text-text-dim hover:text-text-primary hover:bg-bg-card transition-colors"
+  const logo = (
+    <Link href="/admin" className="flex items-center gap-2.5 group" title="CCK Admin Panel">
+      <div className="w-8 h-8 rounded bg-green-primary/10 border border-green-primary/30 flex items-center justify-center shrink-0">
+        <Terminal className="w-4 h-4 text-green-primary" />
+      </div>
+      <div className={cn(collapsed && "md:hidden")}>
+        <div className="text-xs font-mono font-bold text-green-primary leading-none">CCK</div>
+        <div className="text-[10px] font-mono text-text-dim leading-none mt-0.5">Admin Panel</div>
+      </div>
+    </Link>
+  )
+
+  return (
+    <>
+      {/* Mobile top bar */}
+      <header className="md:hidden sticky top-0 z-40 flex h-14 items-center justify-between border-b border-border-default bg-bg-secondary px-4">
+        {logo}
+        <button
+          type="button"
+          onClick={() => setDrawerOpen(true)}
+          aria-label="Open admin menu"
+          aria-expanded={drawerOpen}
+          className="flex h-11 w-11 items-center justify-center rounded text-text-secondary hover:bg-bg-card hover:text-text-primary transition-colors"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+      </header>
+
+      {/* Mobile drawer + backdrop */}
+      {drawerOpen && (
+        <div className="md:hidden fixed inset-0 z-50">
+          <div
+            className="absolute inset-0 bg-black/60"
+            aria-hidden="true"
+            onClick={() => setDrawerOpen(false)}
+          />
+          <div
+            role="dialog"
+            aria-label="Admin navigation"
+            className="absolute inset-y-0 left-0 flex w-72 max-w-[85vw] flex-col border-r border-border-default bg-bg-secondary"
           >
-            <PanelLeftOpen className="w-4 h-4" />
-          </button>
+            <div className="flex items-center justify-between border-b border-border-default p-4">
+              {logo}
+              <button
+                type="button"
+                onClick={() => setDrawerOpen(false)}
+                aria-label="Close admin menu"
+                className="flex h-11 w-11 items-center justify-center rounded text-text-dim hover:bg-bg-card hover:text-text-primary transition-colors"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+            {navLinks}
+            {footer}
+          </div>
         </div>
       )}
 
-      {/* Navigation — scrolls internally, the rail itself stays pinned */}
-      <nav className={cn("flex-1 overflow-y-auto p-3 space-y-0.5", collapsed && "p-2")}>
-        {visibleNavItems.map(({ href, label, icon: Icon, exact }) => {
-          const active = isActive(href, exact)
-          return (
-            <Link
-              key={href}
-              href={href}
-              title={collapsed ? label : undefined}
-              className={cn(
-                "flex items-center gap-3 rounded text-sm font-mono transition-all group",
-                collapsed ? "px-0 py-2.5 justify-center" : "px-3 py-2.5",
-                active
-                  ? "bg-green-primary/10 text-green-primary border border-green-primary/20"
-                  : "text-text-secondary hover:text-text-primary hover:bg-bg-card border border-transparent"
-              )}
-            >
-              <Icon className={cn("w-4 h-4 flex-shrink-0", active ? "text-green-primary" : "text-current")} />
-              {!collapsed && <span className="flex-1">{label}</span>}
-              {!collapsed && active && <ChevronRight className="w-3 h-3 text-green-primary" />}
-            </Link>
-          )
-        })}
-      </nav>
-
-      {/* Sign Out */}
-      <div className={cn("border-t border-border-default", collapsed ? "p-2" : "p-3")}>
-        <button
-          onClick={() => signOut({ callbackUrl: "/admin/login" })}
-          title={collapsed ? "Sign Out" : undefined}
+      {/* Desktop rail */}
+      <aside
+        className={cn(
+          "hidden md:flex sticky top-0 h-screen shrink-0 bg-bg-secondary border-r border-border-default flex-col",
+          hydrated && "transition-[width] duration-200 motion-reduce:transition-none",
+          collapsed ? "w-16" : "w-64"
+        )}
+      >
+        {/* Logo + collapse toggle */}
+        <div
           className={cn(
-            "w-full flex items-center gap-3 rounded text-sm font-mono text-text-dim hover:text-red hover:bg-red/10 border border-transparent hover:border-red/20 transition-all",
-            collapsed ? "px-0 py-2.5 justify-center" : "px-3 py-2.5"
+            "border-b border-border-default flex items-center",
+            collapsed ? "p-3 justify-center" : "p-5 justify-between"
           )}
         >
-          <LogOut className="w-4 h-4" />
-          {!collapsed && <span>Sign Out</span>}
-        </button>
-        {!collapsed && (
-          <Link
-            href="/"
-            className="mt-1 w-full flex items-center gap-3 px-3 py-2 rounded text-xs font-mono text-text-dim hover:text-text-secondary transition-colors"
-          >
-            <span>← Back to site</span>
-          </Link>
+          {logo}
+          {!collapsed && (
+            <button
+              onClick={toggleCollapsed}
+              aria-label="Collapse sidebar"
+              aria-expanded="true"
+              className="p-1.5 rounded text-text-dim hover:text-text-primary hover:bg-bg-card transition-colors"
+            >
+              <PanelLeftClose className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+
+        {/* Expand button when collapsed */}
+        {collapsed && (
+          <div className="p-3 border-b border-border-default flex justify-center">
+            <button
+              onClick={toggleCollapsed}
+              aria-label="Expand sidebar"
+              aria-expanded="false"
+              title="Expand sidebar"
+              className="p-1.5 rounded text-text-dim hover:text-text-primary hover:bg-bg-card transition-colors"
+            >
+              <PanelLeftOpen className="w-4 h-4" />
+            </button>
+          </div>
         )}
-      </div>
-    </aside>
+
+        {/* Navigation — scrolls internally, the rail itself stays pinned */}
+        {navLinks}
+
+        {/* Sign Out */}
+        {footer}
+      </aside>
+    </>
   )
 }

--- a/src/components/admin/AdminUserManager.tsx
+++ b/src/components/admin/AdminUserManager.tsx
@@ -219,7 +219,7 @@ export function AdminUserManager({
           <div className="text-[11px] font-mono font-semibold text-[#00ff41] uppercase tracking-wider">
             New Admin User
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="block text-[10px] font-mono text-[#555] mb-1">First Name</label>
               <input
@@ -248,7 +248,7 @@ export function AdminUserManager({
               className="w-full bg-[#0a0a0a] border border-[#222] rounded px-3 py-2 text-sm font-mono text-[#e0e0e0] focus:border-[#00ff41]/50 focus:outline-none transition-colors"
             />
           </div>
-          <div className="grid grid-cols-2 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
             <div>
               <label className="block text-[10px] font-mono text-[#555] mb-1">Password</label>
               <input
@@ -284,8 +284,8 @@ export function AdminUserManager({
       )}
 
       {/* Users Table */}
-      <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-hidden">
-        <table className="w-full">
+      <div className="bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg overflow-x-auto">
+        <table className="w-full min-w-[640px]">
           <thead>
             <tr className="border-b border-[#1e1e1e]">
               <th className="px-4 py-3 text-left text-[10px] font-mono font-semibold text-[#555] uppercase tracking-wider">User</th>
@@ -345,8 +345,10 @@ export function AdminUserManager({
                   </span>
                 </td>
                 <td className="px-4 py-3">
+                  {/* Hover-revealed on desktop only — touch devices have no
+                    * hover, so below md the actions stay visible. */}
                   {user.id !== currentUserId ? (
-                    <div className="flex items-center justify-end gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <div className="flex items-center justify-end gap-1 transition-opacity md:opacity-0 md:group-hover:opacity-100 md:focus-within:opacity-100">
                       <button
                         onClick={() => setEditingRole(editingRole === user.id ? null : user.id)}
                         title="Change role"

--- a/src/components/admin/SiteStatsEditor.tsx
+++ b/src/components/admin/SiteStatsEditor.tsx
@@ -68,7 +68,7 @@ export function SiteStatsEditor({ initialStats }: { initialStats: SiteStats }) {
           <div className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider mb-3">
             Platform Members
           </div>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             {[
               { key: "discordMembers" as const, label: "Discord", color: "#5865F2" },
               { key: "whatsappMembers" as const, label: "WhatsApp", color: "#25D366" },
@@ -96,7 +96,7 @@ export function SiteStatsEditor({ initialStats }: { initialStats: SiteStats }) {
           <div className="text-[11px] font-mono font-semibold text-[#555] uppercase tracking-wider mb-3">
             Activity
           </div>
-          <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div>
               <label className="text-[11px] font-mono text-[#666] mb-1 block">Events Held</label>
               <input

--- a/src/components/admin/impact-lab/ImpactLabDashboard.tsx
+++ b/src/components/admin/impact-lab/ImpactLabDashboard.tsx
@@ -108,13 +108,13 @@ export function ImpactLabDashboard({ cohort: initialCohort }: { cohort: string }
         </div>
       )}
 
-      <div className="flex items-center gap-1 border-b border-[#1e1e1e]">
+      <div className="flex items-center gap-1 border-b border-[#1e1e1e] overflow-x-auto">
         {TABS.map(({ key, label, icon: Icon }) => (
           <button
             key={key}
             onClick={() => setTab(key)}
             className={cn(
-              "flex items-center gap-2 px-4 py-2.5 text-xs font-mono transition-all border-b-2 -mb-px",
+              "flex shrink-0 items-center gap-2 whitespace-nowrap px-4 py-2.5 text-xs font-mono transition-all border-b-2 -mb-px",
               tab === key
                 ? "border-[#00ff41] text-[#00ff41]"
                 : "border-transparent text-[#666] hover:text-[#999]"

--- a/src/components/admin/impact-lab/MatchingTab.tsx
+++ b/src/components/admin/impact-lab/MatchingTab.tsx
@@ -198,7 +198,7 @@ export function MatchingTab({ cohort, onSaved }: MatchingTabProps) {
     <div className="space-y-4">
       <div className="p-4 bg-[#0d0d0d] border border-[#1e1e1e] rounded-lg space-y-3">
         <p className="text-[10px] font-mono text-[#555] uppercase tracking-wider">Settings</p>
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <Num label="Desired size" value={settings.desiredTeamSize} onChange={(v) => setSettings({ ...settings, desiredTeamSize: v })} />
           <Num label="Min size" value={settings.minTeamSize} onChange={(v) => setSettings({ ...settings, minTeamSize: v })} />
           <Num label="Max size" value={settings.maxTeamSize} onChange={(v) => setSettings({ ...settings, maxTeamSize: v })} />

--- a/src/components/admin/impact-lab/ResultsTab.tsx
+++ b/src/components/admin/impact-lab/ResultsTab.tsx
@@ -1455,7 +1455,7 @@ function NotifyPanel({ cohort }: { cohort: string }) {
       </div>
 
       {counts && (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           {[
             { label: "Queued", value: counts.queued, color: "#888" },
             { label: "Sent", value: counts.sent, color: "#00ff41" },

--- a/src/components/admin/impact-lab/RunsTab.tsx
+++ b/src/components/admin/impact-lab/RunsTab.tsx
@@ -123,7 +123,8 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
         ) : runs.length === 0 ? (
           <div className="p-8 text-center text-sm font-mono text-[#555]">No saved runs yet — generate and save from the Matching tab.</div>
         ) : (
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead>
               <tr className="border-b border-[#1e1e1e]">
                 {["Name", "Teams", "Avg", "Unassigned", "Status", ""].map((h) => (
@@ -237,6 +238,7 @@ export function RunsTab({ cohort, refreshKey }: RunsTabProps) {
               })}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </div>

--- a/src/components/admin/impact-lab/SubmissionsTab.tsx
+++ b/src/components/admin/impact-lab/SubmissionsTab.tsx
@@ -217,7 +217,8 @@ export function SubmissionsTab({ cohort }: { cohort: string }) {
             No submissions yet
           </p>
         ) : (
-          <table className="w-full">
+          <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
             <thead>
               <tr className="border-b border-[#1e1e1e]">
                 {["Team", "Project", "Track", "Links", "Status", "Updated", ""].map((h) => (
@@ -301,6 +302,7 @@ export function SubmissionsTab({ cohort }: { cohort: string }) {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Fixes the admin panel being non-functional on phones: a permanent 256px sidebar with no responsive breakpoint left ~119px of content at 375px, and every list page clipped its table inside `overflow-hidden` — on five pages the only detail link sat in the clipped last column, so an organiser could not open an application from a phone at all.
- Also adds `docs/audits/2026-08-26-production-ui-audit.md` — the phase-2 audit of everything outside `/community`/`/showcase`, whose admin-mobile findings this PR implements.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Performance improvement
- [ ] Other: ___

## Changes

### Admin shell
- `AdminSidebar`: desktop (md+) keeps the sticky rail and collapse toggle unchanged; below `md` it's replaced by a top bar with a 44px hamburger that opens the same nav as an off-canvas drawer (backdrop click, Escape, and link taps all close it).
- `admin/layout.tsx`: stacks column-wise below `md` so the top bar sits above content.

### Tables and detail access
- Every admin list table card scrolls horizontally (`overflow-hidden` → `overflow-x-auto`, `min-w-[640px]` on tables); the two impact-lab tables with no wrapper got scroll containers; the six already-scrollable ones untouched.
- applications/speakers/ideas/demos/volunteers: the record's name cell is now a link to its detail page, and the chevron link has a 32px target plus an accessible name.

### Touch and stacking
- `AdminUserManager` row actions were `opacity-0` until hover (invisible on touch) — now always visible below `md`, `focus-within` on desktop.
- Stat rows stack 2-up on phones; the contact inbox's hard `w-1/2` split view stacks below `lg`; event/community/blog editor field grids and settings/impact-lab grids stack below `sm`; the Impact Lab tab bar scrolls instead of clipping its ten tabs.
- Login was already responsive and is untouched.

## Test Plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npm run build` succeeds
- [ ] Manually tested on localhost
- [x] No hardcoded secrets or credentials
- [x] Commit messages follow conventional commits

All 44 unit tests pass; lint problem count identical to `main`.

## Screenshots (if applicable)

None — the change is layout-mechanical; the diagnosis with exact measurements is in the audit doc included in this PR.

## Related Issues

Implements section A of `docs/audits/2026-08-26-production-ui-audit.md` (included in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YXS1APjPwmvYka2PDDSYQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXS1APjPwmvYka2PDDSYQP)_