### PR TITLE
fix(prod): sharp binaries on Vercel + draft blog posts leaking publicly

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,15 @@ const nextConfig: NextConfig = {
   // metrics from node_modules at runtime and exceljs is a large CJS tree —
   // both must stay external to the bundle too.
   serverExternalPackages: ["bcryptjs", "sharp", "archiver", "pdfkit", "exceljs"],
+  // Vercel's output file tracing misses sharp's platform packages (@img/*),
+  // so the linux libvips .so never reaches /var/task and every sharp route
+  // dies with ERR_DLOPEN_FAILED in production. Force-include them on the
+  // routes that import sharp (directly or via gallery derivatives).
+  outputFileTracingIncludes: {
+    "/api/showcase/media/finalize": ["./node_modules/@img/**"],
+    "/api/admin/photos/finalize": ["./node_modules/@img/**"],
+    "/api/admin/photos/presign": ["./node_modules/@img/**"],
+  },
   experimental: {
     optimizePackageImports: ["framer-motion", "lucide-react"],
   },

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -261,7 +261,9 @@ export async function getBlogPosts(): Promise<BlogPostView[]> {
 }
 
 export async function getBlogPostBySlug(slug: string): Promise<BlogPostView | null> {
-  const row = await prisma.blogPost.findUnique({ where: { slug } })
+  // Public surface: drafts and archived posts must 404, not render half-empty.
+  // Admin reads go through the admin API routes, never this helper.
+  const row = await prisma.blogPost.findFirst({ where: { slug, status: "PUBLISHED" } })
   if (!row) return null
   // Increment view count (non-blocking)
   prisma.blogPost.update({ where: { slug }, data: { views: { increment: 1 } } }).catch(() => {})


### PR DESCRIPTION
## Two production bugs

1. **Showcase media upload finalize 500s** — Vercel's output file tracing drops sharp's platform packages (`@img/*`), so `libvips-cpp.so` never reaches the lambda and every sharp route dies with `ERR_DLOPEN_FAILED` (verified in runtime logs). Fixed with `outputFileTracingIncludes` on the three routes that import sharp.

2. **Draft blog posts render publicly** — `getBlogPostBySlug` had no status filter, so drafts (including MCP-created posts, which are draft-only) rendered as broken half-empty pages on their public URL. Now `PUBLISHED` only; drafts 404.

Build + tsc clean.

@Spidey-Acer

https://claude.ai/code/session_01BQ8rdeMj8UvBxQKvBAN5B9