### PR TITLE
fix(showcase): adaptive media frames + cover image fallback

### DIFF
--- a/src/components/karibu/showcase/MediaGallery.tsx
+++ b/src/components/karibu/showcase/MediaGallery.tsx
@@ -13,13 +13,20 @@ interface MediaGalleryProps {
 
 /**
  * The post's media strip: images and gifs through `next/image`, mp4 through
- * a native `<video>`. Every container is a fixed aspect ratio with
- * `overflow-hidden` so the layout never reflows as media loads in.
+ * a native `<video>`. The container never letterboxes: a single image gets a
+ * frame matching its own aspect ratio (so the upload fills it edge to edge),
+ * while multi-item posts share one fixed 16:9 frame with `object-cover` so
+ * switching items never resizes the viewer. `overflow-hidden` everywhere so
+ * the layout never reflows as media loads in.
  *
  * The mp4 autoplays only when the OS has no reduced-motion preference; it is
  * always muted, looped and inline regardless, so a reduced-motion visitor
  * still gets a poster frame with the same fixed footprint, not a gap.
  */
+
+/** Tallest frame a single upload may claim: 4:5, so a phone-portrait shot cannot swallow the page. */
+const MIN_SINGLE_RATIO = 0.8
+
 export function MediaGallery({ media }: MediaGalleryProps) {
   const prefersReducedMotion = useReducedMotion()
   const [active, setActive] = useState(0)
@@ -28,9 +35,24 @@ export function MediaGallery({ media }: MediaGalleryProps) {
 
   const current = media[active]
 
+  // A lone image adopts its own aspect ratio; anything else keeps 16:9.
+  const hasOwnRatio =
+    media.length === 1 && current.kind !== "mp4" && current.width > 0 && current.height > 0
+  const singleRatio = hasOwnRatio
+    ? Math.max(current.width / current.height, MIN_SINGLE_RATIO)
+    : undefined
+  // If the ratio had to be clamped, contain would letterbox — cover instead.
+  const ratioClamped = hasOwnRatio && current.width / current.height < MIN_SINGLE_RATIO
+
   return (
     <div className="space-y-3">
-      <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-sand bg-paper-card">
+      <div
+        className={cn(
+          "relative w-full overflow-hidden rounded-2xl border border-sand bg-paper-card",
+          !hasOwnRatio && "aspect-video",
+        )}
+        style={singleRatio ? { aspectRatio: `${singleRatio}` } : undefined}
+      >
         {current.kind === "mp4" ? (
           <video
             key={current.url}
@@ -53,7 +75,7 @@ export function MediaGallery({ media }: MediaGalleryProps) {
             fill
             sizes="(max-width: 768px) 100vw, 768px"
             unoptimized={current.kind === "gif"}
-            className="object-contain"
+            className={hasOwnRatio && !ratioClamped ? "object-contain" : "object-cover"}
           />
         )}
       </div>

--- a/src/components/karibu/showcase/ShowcaseComposer.tsx
+++ b/src/components/karibu/showcase/ShowcaseComposer.tsx
@@ -237,9 +237,13 @@ function ComposerForm({ events }: { events: ComposerEventOption[] }) {
   // stay selected — the server rejects a coverImageUrl that is not one of the
   // submitted media URLs. Derived rather than corrected in an effect: the
   // selection is only ever valid *relative to* the current media, so reading
-  // it that way at render leaves no window where the two disagree.
-  const effectiveCoverImageUrl =
+  // it that way at render leaves no window where the two disagree. When
+  // nothing is picked, the first image is the cover — a post with visual
+  // media must never publish without a card thumbnail.
+  const explicitCoverImageUrl =
     coverImageUrl && media.some((m) => m.url === coverImageUrl) ? coverImageUrl : undefined
+  const effectiveCoverImageUrl =
+    explicitCoverImageUrl ?? media.find((m) => m.kind !== "mp4")?.url
 
   function insertEmoji(char: string) {
     const el = descriptionRef.current

--- a/src/lib/showcase/queries.ts
+++ b/src/lib/showcase/queries.ts
@@ -52,6 +52,20 @@ type Row = Prisma.CommunitySubmissionGetPayload<{
   }
 }>
 
+/**
+ * The card thumbnail must never be empty when the post has visual media: an
+ * explicit cover pick wins, otherwise the first image/gif, otherwise a video
+ * poster. Older rows submitted before the composer defaulted the cover rely
+ * on this fallback.
+ */
+function resolveCoverImage(row: Row): string | null {
+  if (row.coverImageUrl) return row.coverImageUrl
+  const media = asArray<MediaDescriptor>(row.media)
+  const image = media.find(m => m.kind !== "mp4")
+  if (image) return image.url
+  return media.find(m => m.posterUrl)?.posterUrl ?? null
+}
+
 function mapRow(row: Row): ShowcasePostView {
   return {
     id: row.id,
@@ -63,7 +77,7 @@ function mapRow(row: Row): ShowcasePostView {
     repoUrl: row.repoUrl,
     tags: asArray<string>(row.tags),
     authorName: row.submitterName,
-    coverImageUrl: row.coverImageUrl,
+    coverImageUrl: resolveCoverImage(row),
     media: asArray<MediaDescriptor>(row.media),
     needs: asArray<NeedKey>(row.needs),
     builtWith: (row.builtWith as BuiltWith | null) ?? null,


### PR DESCRIPTION
## What

Three fixes found via the first live showcase post:

1. **Media letterboxing (the "gaps at the edges")** — `MediaGallery` rendered every upload with `object-contain` inside a fixed 16:9 frame, so any non-16:9 screenshot showed paper-colored bands. Now:
   - **Single image/GIF:** frame adopts the upload's own aspect ratio (from the sharp-measured `width`/`height` on `MediaDescriptor`), clamped at 4:5 so portrait shots can't take over the page (`object-cover` when clamped). The image fills the frame edge to edge.
   - **Multiple items:** one shared 16:9 frame with `object-cover` — uniform viewer size when switching items, no gaps.
   - **Video:** unchanged (16:9, contain).

2. **Feed card showed the Sparkles placeholder for posts that have images** — the composer only set `coverImageUrl` on an explicit thumbnail click. It now defaults to the first non-video upload, and the cover picker highlights that default.

3. **Retroactive cover fallback** — `mapRow()` derives the cover from the first image/gif (then any video poster) when `coverImageUrl` is null, so existing rows (including the live first post) get their card thumbnail back with no data migration.

## Verification

- `npx tsc --noEmit` clean
- `npm test` 44/44
- `npm run build` **not run** — blocked by the local disk-space guard (C: at 93%). Changes are UI/query-layer only and type-safe; the Vercel preview build is the backstop.

## After merge

- Check the live post card at /showcase shows the screenshot thumbnail
- Check the post page media fills its frame with no bands

@Spidey-Acer

https://claude.ai/code/session_01BQ8rdeMj8UvBxQKvBAN5B9