### PR TITLE
feat(events): per-event covers for poster-less events, 3:2 frames, paged past grid

### DIFF
--- a/src/components/karibu/EventCoverPlaceholder.tsx
+++ b/src/components/karibu/EventCoverPlaceholder.tsx
@@ -6,32 +6,169 @@
  * function for why there is no pooled-photo fallback — this placeholder is
  * the other half of that decision: it must look intentional, not like a
  * broken image, since it appears on most event cards.
+ *
+ * It used to be one sand gradient with the CCK logo centred in it, identical
+ * for every event. On a grid of ten poster-less events that reads as the same
+ * brand asset stamped ten times, not as ten events. So the placeholder now
+ * composes a printed bill out of the only thing we can state truthfully about
+ * an event without a photo: its own words. City and month set as an eyebrow,
+ * the title set large, a motif keyed to the event *type*, and a paper tone
+ * keyed to a hash of the slug so no two neighbouring cards land on the same
+ * one. Nothing here claims to depict anybody.
  */
 
 import Image from "next/image";
+import type { Event } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
-export function EventCoverPlaceholder({ className }: { className?: string }) {
+/**
+ * Background motif per event type — the texture says something true about
+ * what the event *is*, rather than decorating the card at random.
+ * Concentric rings for a gathering, a bench grid for a workshop, stacked
+ * rules for a talk, dense hatch for a hackathon.
+ */
+const TYPE_MOTIF: Record<Event["type"], string> = {
+  meetup:
+    "bg-[repeating-radial-gradient(circle_at_88%_120%,var(--clay)_0_1px,transparent_1px_20px)]",
+  workshop:
+    "bg-[repeating-linear-gradient(0deg,var(--clay)_0_1px,transparent_1px_16px),repeating-linear-gradient(90deg,var(--clay)_0_1px,transparent_1px_16px)]",
+  "career-talk":
+    "bg-[repeating-linear-gradient(0deg,var(--clay)_0_1.5px,transparent_1.5px_13px)]",
+  hackathon:
+    "bg-[repeating-linear-gradient(135deg,var(--clay)_0_2px,transparent_2px_11px)]",
+};
+
+/**
+ * Paper tones, mixed off the Karibu tokens so they follow dark mode instead
+ * of freezing a light-theme hex into the card.
+ */
+const TONES = [
+  "bg-[linear-gradient(135deg,color-mix(in_oklab,var(--clay)_7%,var(--paper-card)),var(--paper-alt))]",
+  "bg-[linear-gradient(135deg,var(--sand),color-mix(in_oklab,var(--sand-2)_70%,var(--paper-card)))]",
+  "bg-[linear-gradient(135deg,color-mix(in_oklab,var(--clay)_14%,var(--paper-alt)),var(--paper-card))]",
+  "bg-[linear-gradient(135deg,var(--paper-alt),color-mix(in_oklab,var(--sand)_75%,var(--paper-card)))]",
+] as const;
+
+/** Stable 32-bit hash — same slug always picks the same tone. */
+function hash(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+/**
+ * Their titles routinely lead with the city ("Nairobi | Claude in
+ * Production Workshop") and the eyebrow already carries the city, so drop
+ * the prefix rather than saying Nairobi twice on one card.
+ */
+function coverTitle(title: string, city?: string | null): string {
+  const bar = title.indexOf("|");
+  if (bar > 0) {
+    const head = title.slice(0, bar).trim();
+    if (!city || head.toLowerCase() === city.toLowerCase()) return title.slice(bar + 1).trim();
+  }
+  return title;
+}
+
+/**
+ * The eyebrow carries the event *type* and nothing else. City and month are
+ * already printed under every card that uses this placeholder; repeating
+ * them here made the cover read as a duplicate of its own caption rather
+ * than as artwork. Type is the one fact the card doesn't otherwise state.
+ */
+const TYPE_EYEBROW: Record<Event["type"], string> = {
+  meetup: "Meetup",
+  workshop: "Workshop",
+  "career-talk": "Career talk",
+  hackathon: "Hackathon",
+};
+
+/** Day numeral + month, for the large variant. */
+function splitDate(date: string): { day: string; month: string } | null {
+  const dt = new Date(`${date}T00:00:00`);
+  if (Number.isNaN(dt.getTime())) return null;
+  return {
+    day: dt.toLocaleString("en-US", { day: "numeric" }),
+    month: dt.toLocaleString("en-US", { month: "long", year: "numeric" }),
+  };
+}
+
+/**
+ * `sm` leads with the title, `lg` leads with the date — and that split is
+ * about what sits next to the cover, not about how much room there is.
+ *
+ * On a grid card the caption underneath is 18px, so a 26px title inside the
+ * frame reads as the printed bill above its own caption. But every place the
+ * large variant appears, the surrounding layout already sets the title big:
+ * 32px beside the featured card, a 52px `<h1>` directly above the detail
+ * hero. Repeating it there is the same word twice at almost the same size.
+ * So the large variant prints the date instead — real information the card
+ * doesn't otherwise state at that scale, and it echoes the day-numeral block
+ * already used by the upcoming-events list on the same page.
+ */
+export function EventCoverPlaceholder({
+  event,
+  size = "sm",
+  className,
+}: {
+  event: Pick<Event, "slug" | "title" | "type" | "city" | "date">;
+  size?: "sm" | "lg";
+  className?: string;
+}) {
+  const tone = TONES[hash(event.slug) % TONES.length];
+  const dateParts = splitDate(event.date);
+
   return (
     <div
       aria-hidden="true"
-      className={cn(
-        "absolute inset-0 flex items-center justify-center overflow-hidden",
-        "bg-gradient-to-br from-sand via-paper-alt to-sand-2",
-        className,
-      )}
+      className={cn("absolute inset-0 flex flex-col justify-center overflow-hidden", tone, className)}
     >
-      {/* Faint diagonal texture, echoes the drift pattern used elsewhere in Karibu */}
+      {/* Motif sits under the type, faint enough that the words stay the subject. */}
       <div
-        className="pointer-events-none absolute inset-0 opacity-[0.07] bg-[repeating-linear-gradient(135deg,var(--clay)_0px,var(--clay)_2px,transparent_2px,transparent_18px)]"
+        className={cn(
+          "pointer-events-none absolute inset-0 opacity-[0.09]",
+          TYPE_MOTIF[event.type],
+        )}
       />
+
+      {/* Stamp, bottom-right — a mark on the bill, not the bill itself. */}
       <Image
         src="/images/cck-logo.webp"
         alt=""
-        width={80}
-        height={80}
-        className="relative h-12 w-12 opacity-60 sm:h-16 sm:w-16 md:h-20 md:w-20"
+        width={64}
+        height={64}
+        className={cn(
+          "pointer-events-none absolute opacity-40",
+          size === "lg" ? "bottom-6 right-6 h-11 w-11" : "bottom-3.5 right-3.5 h-7 w-7",
+        )}
       />
+
+      <div className={cn("relative", size === "lg" ? "p-7 pr-20 md:p-10 md:pr-28" : "p-5 pr-12")}>
+        <div
+          className={cn(
+            "mb-2 font-inter font-semibold uppercase tracking-[0.18em] text-clay",
+            size === "lg" ? "text-[11.5px]" : "text-[10px]",
+          )}
+        >
+          {[TYPE_EYEBROW[event.type], size === "lg" ? event.city : null]
+            .filter(Boolean)
+            .join(" · ")}
+        </div>
+        {size === "lg" && dateParts ? (
+          <>
+            <div className="font-newsreader leading-[0.9] tracking-[-0.02em] text-ink text-[56px] md:text-[76px]">
+              {dateParts.day}
+            </div>
+            <div className="mt-1.5 font-inter text-[15px] font-medium text-ink-soft md:text-[17px]">
+              {dateParts.month}
+            </div>
+          </>
+        ) : (
+          <div className="line-clamp-3 font-newsreader text-[26px] leading-[1.06] tracking-[-0.01em] text-ink">
+            {coverTitle(event.title, event.city)}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/components/karibu/KaribuEventDetail.tsx
+++ b/src/components/karibu/KaribuEventDetail.tsx
@@ -107,7 +107,7 @@ export function KaribuEventDetail({
                 className="object-cover"
               />
             ) : (
-              <EventCoverPlaceholder />
+              <EventCoverPlaceholder event={event} size="lg" />
             )}
           </div>
         </Reveal>

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -47,8 +47,12 @@ const fmt = (dt: Date, opts: Intl.DateTimeFormatOptions) =>
 
 type Filter = { key: string; label: string };
 
+/** Past events revealed per "Show more" press. */
+const PAST_PAGE_SIZE = 9;
+
 export function KaribuEvents({ events }: { events: Event[] }) {
   const [active, setActive] = useState("all");
+  const [pastPages, setPastPages] = useState(1);
   const reduce = useReducedMotion();
   const { whatsapp } = useSocialLinks();
 
@@ -102,6 +106,9 @@ export function KaribuEvents({ events }: { events: Event[] }) {
     [filtered],
   );
 
+  const shownPast = past.slice(0, pastPages * PAST_PAGE_SIZE);
+  const hiddenPast = past.length - shownPast.length;
+
   const featured = upcoming[0];
   const rest = upcoming.slice(1);
   const bandLabel = monthRange(rest.length ? rest : upcoming);
@@ -128,7 +135,10 @@ export function KaribuEvents({ events }: { events: Event[] }) {
                 <button
                   key={f.key}
                   type="button"
-                  onClick={() => setActive(f.key)}
+                  onClick={() => {
+                    setActive(f.key);
+                    setPastPages(1);
+                  }}
                   aria-pressed={on}
                   className={`rounded-full px-4 py-2 font-inter text-[13.5px] font-semibold transition-colors ${
                     on
@@ -196,18 +206,34 @@ export function KaribuEvents({ events }: { events: Event[] }) {
       {past.length > 0 && (
         <section className={`${WRAP} pb-16 pt-2`} aria-label="Past events">
           <Reveal>
-            <div className="mb-4 border-b border-sand pb-3 font-inter text-xs font-bold uppercase tracking-[0.14em] text-ink-faint">
-              Past · picha
+            <div className="mb-4 flex items-baseline justify-between gap-4 border-b border-sand pb-3">
+              <div className="font-inter text-xs font-bold uppercase tracking-[0.14em] text-ink-faint">
+                Past · picha
+              </div>
+              <div className="font-inter text-xs text-ink-faint">
+                {past.length} {past.length === 1 ? "event" : "events"}
+              </div>
             </div>
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               <AnimatePresence mode="popLayout" initial={false}>
-                {past.map((ev) => (
+                {shownPast.map((ev) => (
                   <motion.div key={ev.slug} {...flip}>
                     <PastCard event={ev} />
                   </motion.div>
                 ))}
               </AnimatePresence>
             </div>
+            {hiddenPast > 0 && (
+              <div className="mt-8 flex justify-center">
+                <button
+                  type="button"
+                  onClick={() => setPastPages((n) => n + 1)}
+                  className="rounded-full border border-sand-2 bg-paper-card px-7 py-3 font-inter text-[13.5px] font-semibold text-ink transition-colors hover:border-ink"
+                >
+                  Show {Math.min(hiddenPast, PAST_PAGE_SIZE)} more
+                </button>
+              </div>
+            )}
           </Reveal>
         </section>
       )}
@@ -241,7 +267,7 @@ function FeaturedCard({ event }: { event: Event }) {
             className="object-cover transition-transform duration-500 group-hover:scale-[1.03]"
           />
         ) : (
-          <EventCoverPlaceholder />
+          <EventCoverPlaceholder event={event} size="lg" />
         )}
         <span className="absolute left-4 top-4 rounded-full bg-clay px-3 py-1.5 font-inter text-xs font-semibold uppercase tracking-[0.08em] text-paper-card">
           Next up
@@ -323,7 +349,7 @@ function PastCard({ event }: { event: Event }) {
   const cover = eventCover(event.posterUrl);
   return (
     <Link href={`/events/${event.slug}`} className="group block">
-      <div className="relative mb-2.5 h-[150px] overflow-hidden rounded-xl border border-sand">
+      <div className="relative mb-2.5 aspect-[3/2] overflow-hidden rounded-xl border border-sand transition-colors group-hover:border-clay">
         {cover ? (
           <Image
             src={cover}
@@ -333,7 +359,7 @@ function PastCard({ event }: { event: Event }) {
             className="object-cover transition-transform duration-500 group-hover:scale-105"
           />
         ) : (
-          <EventCoverPlaceholder />
+          <EventCoverPlaceholder event={event} />
         )}
       </div>
       <div className="font-inter text-xs text-ink-muted">

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -568,7 +568,7 @@ function EventsSection({ events }: { events: Event[] }) {
                 className={`relative overflow-hidden border-sand ${
                   single
                     ? "h-[220px] border-b md:h-full md:min-h-[280px] md:border-b-0 md:border-r"
-                    : "h-[150px] border-b"
+                    : "aspect-[3/2] border-b"
                 }`}
               >
                 {cover ? (
@@ -580,7 +580,7 @@ function EventsSection({ events }: { events: Event[] }) {
                     className="object-cover transition-transform duration-500 group-hover:scale-105"
                   />
                 ) : (
-                  <EventCoverPlaceholder />
+                  <EventCoverPlaceholder event={ev} size={single ? "lg" : "sm"} />
                 )}
               </div>
               <div className="p-[22px]">


### PR DESCRIPTION
## The problem

The past-events grid rendered as twelve near-identical brown tiles.

It isn't a CSS problem. **Ten of twelve events have `posterUrl: null`**, so they all fall through to `EventCoverPlaceholder` — one sand gradient with the CCK logo centred in it. The grid was showing the same brand asset ten times, not ten events. The two that looked different (Impact Lab, Nairobi Recap) are the only two with a real uploaded poster.

Second issue: the past grid used a fixed `h-[150px]` letterbox, which crushed photos and type alike.

## The change

### `EventCoverPlaceholder`
Composes a printed bill out of the only thing we can state truthfully about an event with no photo — its own words.

- **Motif keyed to event type** — concentric rings (meetup), bench grid (workshop), stacked rules (career talk), dense hatch (hackathon). The texture encodes what the event is rather than decorating at random.
- **Paper tone keyed to a hash of the slug**, mixed off the Karibu tokens with `color-mix` so it follows dark mode instead of freezing a light-theme hex into the card.
- **Two variants, split by what sits next to the cover — not by size.** `sm` leads with the title (the caption underneath is 18px, so a 26px title reads as the bill above its own caption). `lg` leads with the date, because everywhere the large variant appears the surrounding layout already sets the title large — 32px beside the featured card, a 52px `<h1>` directly above the detail hero — and repeating it there was the same words twice at nearly the same size.

Nothing here claims to depict anybody, so the pooled-photo misattribution that `photos.ts` warns about stays fixed.

### Frames
`h-[150px]` → `aspect-[3/2]` on both the events past grid and the home event grid, so covers scale with the column.

### Paging
Past grid reveals 9 at a time behind a **"Show N more"** button, with an event count in the section rule. Client-side, inside the existing `AnimatePresence`, no new routes. Changing a filter chip resets to page 1.

## Verification

No local `.env`, so the 12 real events were pulled from the live RSC payload and rendered through the actual components in a throwaway route (deleted before commit).

- Covers render distinct in **both light and dark** themes.
- Paging: 10 past events → 9 shown → "Show 1 more" → 10 shown, button clears. Mombasa filter → "1 event", no button.
- **28 placeholder instances measured for overflow across all four call sites: zero clipping.** Also bounded by construction (`line-clamp-3` + `aspect-[3/2]`).
- `npx tsc --noEmit` clean.
- `npm run build` compiles and type-checks clean, then fails at page-data collection on `/api/admin/photos/[id]` with `Error: supabaseUrl is required`. Confirmed environmental (no local `.env`) by reproducing the identical failure on stashed, unmodified code.

## Notes for review

1. **These covers are a stopgap, not the finish line.** Ten events still have no real poster. The admin event editor already supports uploading one — every poster added replaces a typographic cover with a real photo.
2. **Pre-existing, not addressed here:** `KaribuEvents` mounts twice — two `[aria-label="Events header"]` / `[aria-label="Past events"]` nodes, the second `0×0`. Filter chips therefore render twice and clicking one doesn't reliably drive the visible grid. Reproduces on production and on stashed code, so it predates this branch. Worth a separate issue.
