### PR TITLE
fix(seo): drop orphaned React streaming containers duplicating BreadcrumbList

### DIFF
--- a/src/components/layout/ConditionalLayout.tsx
+++ b/src/components/layout/ConditionalLayout.tsx
@@ -17,6 +17,7 @@ import { SocialLinksProvider } from "@/contexts/SocialLinksContext";
 import type { SocialLinks } from "@/lib/social-links-schema";
 import { KaribuBanner } from "@/components/karibu/KaribuBanner";
 import { StickyMobileCTA } from "@/components/layout/StickyMobileCTA";
+import { StreamingCleanup } from "@/components/layout/StreamingCleanup";
 
 const KaribuModal = dynamic(
   () => import("@/components/karibu/KaribuModal").then((m) => m.KaribuModal),
@@ -60,7 +61,12 @@ export function ConditionalLayout({
   const isKaribu = !legacyPrefixes.some((p) => pathname.startsWith(p));
 
   if (isAdmin || isBareDisplay) {
-    return <>{children}</>;
+    return (
+      <>
+        <StreamingCleanup />
+        {children}
+      </>
+    );
   }
 
   return (
@@ -84,6 +90,7 @@ export function ConditionalLayout({
             <KaribuBanner />
             {!isDashboard && !isKaribu && <StickyMobileCTA />}
             {showKaribu && <KaribuModal />}
+            <StreamingCleanup />
           </SocialLinksProvider>
         </AudienceProvider>
       </SkinProvider>

--- a/src/components/layout/StreamingCleanup.tsx
+++ b/src/components/layout/StreamingCleanup.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Removes React's stranded HTML-streaming containers. See issue #125.
+ *
+ * React streams a Suspense boundary's resolved HTML into a `<div hidden
+ * id="S:n">` at the end of <body>, then calls `$RC("B:n","S:n")` from an
+ * inline script to move the content into place and delete the container. On
+ * some routes the boundary instead resolves through the React tree on the
+ * client, `$RC` never runs for it, and the container is left behind holding a
+ * complete second copy of the page. `/events` carries 22.5KB of it — 23% of
+ * <body>.
+ *
+ * That copy is `display: none`, so it is inert for users: not focusable, not
+ * in the accessibility tree. What it is not inert for is structured data. A
+ * `<script type="application/ld+json">` inside a hidden element is still
+ * extracted, and crawlers read the rendered DOM rather than the streamed
+ * HTML — so `/events` was serving two competing BreadcrumbList graphs where
+ * the HTML has one. That, not the DOM weight, is why this is worth code.
+ *
+ * The upstream fix would be in the framework (we are on Next 16.1.6; 16.3.3
+ * is current, and the `$~` postpone marker in the boundary comments points at
+ * the prerender-resume path). Until that is tried on its own, this prunes.
+ */
+
+/** True while any Suspense boundary is still pending (`<!--$?-->`). */
+function isStreaming(): boolean {
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_COMMENT);
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    if (n.nodeValue === "$?") return true;
+  }
+  return false;
+}
+
+function prune() {
+  // Never touch the DOM mid-stream: a pending boundary still needs its
+  // container, and `$RC` throws if we delete one out from under it.
+  if (isStreaming()) return;
+
+  for (const el of document.querySelectorAll("body > div[hidden][id^='S:']")) {
+    el.remove();
+  }
+  // The boundary templates are stranded by the same failure.
+  for (const el of document.querySelectorAll("template[id^='B:']")) {
+    el.remove();
+  }
+}
+
+export function StreamingCleanup() {
+  useEffect(() => {
+    // `load` is the signal that matters: these containers arrive with the HTML
+    // stream, so anything earlier (an effect, a rAF) runs before they exist —
+    // which is exactly how the first attempt at this silently did nothing.
+    // Client navigations never produce them, so there is nothing to re-run.
+    if (document.readyState === "complete") {
+      prune();
+      return;
+    }
+    window.addEventListener("load", prune, { once: true });
+    return () => window.removeEventListener("load", prune);
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Closes #125.

## The problem

React streams a Suspense boundary's resolved HTML into a `<div hidden id="S:n">` at the end of `<body>`, then calls `$RC("B:n","S:n")` from an inline script to move the content into place and delete the container. On some routes the boundary instead resolves **through the React tree on the client**, `$RC` never runs for it, and the container is stranded holding a complete second copy of the page.

| Route | Orphans | Duplicated bytes |
|---|---|---|
| `/events` | 2 | 22,530 (**23% of `<body>`**) |
| `/blog` | 2 | 26,336 |
| `/team` | 2 | 8,272 |
| `/projects` | 1 | 6,645 |
| `/`, `/about` | 0 | — |

## Why this needs code

The DOM weight isn't the reason. Those containers are `display: none` — of 20 links/buttons inside them, **0 are focusable**, and none reach the accessibility tree. Genuinely inert for users.

They are not inert for structured data. A `<script type="application/ld+json">` inside a hidden element is still extracted, and **crawlers read the rendered DOM, not the streamed HTML**. So `/events` was serving Google two competing BreadcrumbList graphs where the HTML has one:

```js
[...document.querySelectorAll('script[type="application/ld+json"]')].map(s => JSON.parse(s.textContent)['@type'])

// before: ["Organization", "BreadcrumbList", "BreadcrumbList"]
// after:  ["Organization", "BreadcrumbList"]
```

On a site shipping `robots.ts`, `sitemap.ts`, per-page canonicals and a dedicated `BreadcrumbSchema` component, that's worth fixing.

## The fix

One client component, mounted in both `ConditionalLayout` branches. Guarded twice:

1. **Runs on `load`.** These containers arrive with the HTML stream, so anything earlier runs before they exist. My first attempt hooked a `useEffect` plus a double `requestAnimationFrame` and silently did nothing — verified, not assumed.
2. **Bails while any boundary is still pending** (`<!--$?-->`), because `$RC` throws if its container is deleted out from under it.

Client navigations never produce these containers, so there's nothing to re-run per route.

## Verification

Reproduced and fixed locally in dev:

| | orphans | templates | JSON-LD |
|---|---|---|---|
| `/events` before | 2 | 1 | `Organization, BreadcrumbList, BreadcrumbList` |
| `/events` after | **0** | **0** | `Organization, BreadcrumbList` |
| `/projects` after | **0** | — | `Organization, BreadcrumbList` |

Client-side nav `/about` → `/events` after pruning: route renders (`h1` = "Where we meet."), 0 orphans, single BreadcrumbList, body intact. `npx tsc --noEmit` clean.

**Dev over-reports** (`/about` shows 1 orphan in dev, 0 in production), so I'll confirm the counts against this PR's Vercel preview before merge and post the numbers here.

## Caveat — this treats the symptom

The real fix is upstream. We're on **Next 16.1.6** against **16.3.3** current, and the `$~` postpone marker in the boundary comments points at the prerender-resume path. That bump has a much larger blast radius and deserves its own PR; if it clears the orphans, delete this component.

Rejected: removing the 12 `loading.tsx` skeletons. Real UX regression to solve this.
