### PR TITLE
feat(showcase): migrate GIF picker from Tenor to GIPHY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,10 +43,11 @@ KARIBU_CANARY_PCT=100
 # Karibu daily cron secret — Vercel cron sends "Authorization: Bearer $CRON_SECRET"
 CRON_SECRET=
 
-# Tenor (GIF picker on the community showcase).
-# Get a key at https://developers.google.com/tenor/guides/quickstart
-# Requests are always sent with contentfilter=high.
-TENOR_API_KEY=
+# GIPHY (GIF picker on the community showcase). Server-side only — the key
+# never reaches the browser; all calls go through /api/showcase/gifs.
+# Get a key at https://developers.giphy.com/dashboard/
+# Requests are always sent with rating=g.
+GIPHY_API_KEY=
 
 # ─── Impact Lab ───────────────────────────────────────────────────────────────
 # Which cohort is running, and its lifecycle status (DRAFT/LIVE/CLOSED/

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,14 @@ const nextConfig: NextConfig = {
         hostname: "media.claudekenya.org",
         pathname: "/**",
       },
+      // GIPHY — a picked GIF can become a post's cover image, and the feed
+      // card renders covers through next/image, so the media hosts
+      // (media0–media4, i.giphy.com) must be allowed.
+      {
+        protocol: "https",
+        hostname: "*.giphy.com",
+        pathname: "/**",
+      },
     ],
     formats: ["image/avif", "image/webp"],
   },

--- a/scripts/verify-showcase.ts
+++ b/scripts/verify-showcase.ts
@@ -110,7 +110,7 @@ async function seed(): Promise<void> {
       needs: [],
       media: [
         { key: "fixture/img.png", url: "https://example.test/img.png", width: 100, height: 100, kind: "image" },
-        { key: "tenor:abc", url: "https://media.tenor.com/abc.gif", width: 200, height: 200, kind: "gif" },
+        { key: "giphy:abc", url: "https://media.giphy.com/media/abc/giphy.gif", width: 200, height: 200, kind: "gif" },
       ],
       lastActivityAt: new Date(),
     },

--- a/src/app/api/showcase/gifs/route.ts
+++ b/src/app/api/showcase/gifs/route.ts
@@ -3,25 +3,28 @@ import { rateLimit, RateLimits } from "@/lib/rate-limit"
 import { getSessionUserId } from "@/lib/auth-helpers"
 
 /**
- * GET /api/showcase/gifs — proxy Tenor search.
+ * GET /api/showcase/gifs — proxy GIPHY search and trending.
  *
- * Server-side so the API key never reaches a browser. contentfilter=high is
- * hard-coded rather than passed through: it is a safety floor for a public
- * community surface, not a caller preference.
+ * Server-side so the API key never reaches a browser. rating=g is hard-coded
+ * rather than passed through: it is a safety floor for a public community
+ * surface, not a caller preference. With no `q` the route returns trending —
+ * that is what fills the picker before the member has typed anything.
  */
 
-const TENOR_ENDPOINT = "https://tenor.googleapis.com/v2/search"
+const GIPHY_SEARCH_ENDPOINT = "https://api.giphy.com/v1/gifs/search"
+const GIPHY_TRENDING_ENDPOINT = "https://api.giphy.com/v1/gifs/trending"
 const RESULT_LIMIT = 24
 
-interface TenorMediaFormat {
+interface GiphyImageRendition {
   url: string
-  dims: [number, number]
+  width: string
+  height: string
 }
 
-interface TenorResult {
+interface GiphyResult {
   id: string
-  content_description: string
-  media_formats: Record<string, TenorMediaFormat | undefined>
+  title: string
+  images: Partial<Record<"fixed_height" | "preview_gif" | "fixed_height_small", GiphyImageRendition>>
 }
 
 export async function GET(request: NextRequest) {
@@ -39,9 +42,9 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ success: false, error: "Sign in to search GIFs." }, { status: 401 })
   }
 
-  const apiKey = process.env.TENOR_API_KEY?.trim()
+  const apiKey = process.env.GIPHY_API_KEY?.trim()
   if (!apiKey) {
-    console.error("[SHOWCASE] TENOR_API_KEY is not set — GIF picker disabled")
+    console.error("[SHOWCASE] GIPHY_API_KEY is not set — GIF picker disabled")
     return NextResponse.json(
       { success: false, error: "GIF search is unavailable right now." },
       { status: 503 },
@@ -49,46 +52,42 @@ export async function GET(request: NextRequest) {
   }
 
   const query = request.nextUrl.searchParams.get("q")?.trim()
-  if (!query) {
-    return NextResponse.json({ success: false, error: "Missing search term" }, { status: 400 })
-  }
 
-  const url = new URL(TENOR_ENDPOINT)
-  url.searchParams.set("q", query.slice(0, 100))
-  url.searchParams.set("key", apiKey)
+  const url = new URL(query ? GIPHY_SEARCH_ENDPOINT : GIPHY_TRENDING_ENDPOINT)
+  url.searchParams.set("api_key", apiKey)
   url.searchParams.set("limit", String(RESULT_LIMIT))
-  url.searchParams.set("contentfilter", "high")
-  url.searchParams.set("media_filter", "gif,tinygif")
+  url.searchParams.set("rating", "g")
+  if (query) url.searchParams.set("q", query.slice(0, 100))
 
   try {
     const response = await fetch(url, { next: { revalidate: 300 } })
     if (!response.ok) {
-      console.error("[SHOWCASE] Tenor search failed:", response.status)
+      console.error("[SHOWCASE] GIPHY request failed:", response.status)
       return NextResponse.json(
         { success: false, error: "GIF search is unavailable right now." },
         { status: 502 },
       )
     }
 
-    const payload = (await response.json()) as { results?: TenorResult[] }
+    const payload = (await response.json()) as { data?: GiphyResult[] }
 
-    const results = (payload.results ?? []).flatMap((item) => {
-      const gif = item.media_formats.gif
-      const preview = item.media_formats.tinygif ?? gif
+    const results = (payload.data ?? []).flatMap((item) => {
+      const gif = item.images.fixed_height
+      const preview = item.images.preview_gif ?? item.images.fixed_height_small ?? gif
       if (!gif || !preview) return []
       return [{
         id: item.id,
         url: gif.url,
         previewUrl: preview.url,
-        width: gif.dims[0],
-        height: gif.dims[1],
-        description: item.content_description,
+        width: Number.parseInt(gif.width, 10) || 0,
+        height: Number.parseInt(gif.height, 10) || 0,
+        description: item.title,
       }]
     })
 
     return NextResponse.json({ success: true, data: { results } })
   } catch (error) {
-    console.error("[SHOWCASE] Tenor request threw:", error)
+    console.error("[SHOWCASE] GIPHY request threw:", error)
     return NextResponse.json(
       { success: false, error: "GIF search is unavailable right now." },
       { status: 502 },

--- a/src/app/api/showcase/route.ts
+++ b/src/app/api/showcase/route.ts
@@ -13,9 +13,9 @@ import {
 import { toSlug } from "@/lib/utils"
 import {
   isNeedKey,
-  isTenorUrl,
+  isGiphyUrl,
   MAX_MEDIA_PER_POST,
-  TENOR_KEY_PREFIX,
+  GIPHY_KEY_PREFIX,
 } from "@/lib/showcase/constants"
 import { publicUrl } from "@/lib/gallery/r2"
 
@@ -131,15 +131,15 @@ export async function POST(request: NextRequest) {
   // round trip to R2 for something finalize already checked.
   // A picked GIF is the one exception: it is never uploaded, so it has no R2
   // object and no key to check. It keeps its own URL, which means the host has
-  // to be pinned instead — otherwise `key: "tenor:anything"` becomes a way to
+  // to be pinned instead — otherwise `key: "giphy:anything"` becomes a way to
   // put any URL on the internet into an APPROVED post, which is the exact hole
   // the prefix check above exists to close.
   const pendingPrefix = `showcase/pending/${userId}/`
-  const isPickedGif = (key: string) => key.startsWith(TENOR_KEY_PREFIX)
+  const isPickedGif = (key: string) => key.startsWith(GIPHY_KEY_PREFIX)
 
   const badMedia = data.media.find(item =>
     isPickedGif(item.key)
-      ? item.kind !== "gif" || !isTenorUrl(item.url)
+      ? item.kind !== "gif" || !isGiphyUrl(item.url)
       : !item.key.startsWith(pendingPrefix),
   )
   if (badMedia) {

--- a/src/components/karibu/showcase/GifPicker.tsx
+++ b/src/components/karibu/showcase/GifPicker.tsx
@@ -4,20 +4,22 @@ import { useEffect, useRef, useState } from "react"
 import { useReducedMotion } from "framer-motion"
 import { Loader2, Search, ImageOff, ImageIcon } from "lucide-react"
 import type { MediaDescriptor } from "@/lib/showcase/media"
-import { TENOR_KEY_PREFIX } from "@/lib/showcase/constants"
+import { GIPHY_KEY_PREFIX } from "@/lib/showcase/constants"
 
 /**
- * GifPicker — searches Tenor via the server proxy and hands back a
- * MediaDescriptor for whatever the member picks.
+ * GifPicker — searches GIPHY via the server proxy and hands back a
+ * MediaDescriptor for whatever the member picks. An empty search box shows
+ * GIPHY's trending set, so the picker is never a dead input waiting for a
+ * query.
  *
- * The proxy returns 503 when TENOR_API_KEY isn't set and 502 when Tenor
+ * The proxy returns 503 when GIPHY_API_KEY isn't set and 502 when GIPHY
  * itself is down. Both degrade to a plain message rather than a spinner or
  * a crash — the composer stays usable with GIFs simply unavailable.
  */
 
 const SEARCH_DEBOUNCE_MS = 400
 
-interface TenorSearchResult {
+interface GifSearchResult {
   id: string
   url: string
   previewUrl: string
@@ -33,7 +35,7 @@ interface GifPickerProps {
 type SearchState =
   | { kind: "idle" }
   | { kind: "loading" }
-  | { kind: "results"; items: TenorSearchResult[] }
+  | { kind: "results"; items: GifSearchResult[] }
   | { kind: "empty" }
   | { kind: "unavailable"; message: string }
 
@@ -45,28 +47,17 @@ export function GifPicker({ onSelect }: GifPickerProps) {
 
   const term = query.trim()
 
-  // Derived, not stored. "Empty box means idle" is a fact about the current
-  // query, so reading it off `term` at render is both simpler and avoids the
-  // extra render pass that setting state inside the effect would cost.
-  const view: SearchState = term ? state : { kind: "idle" }
-
   useEffect(() => {
-    if (!term) {
-      // Invalidate any in-flight request so its response cannot land after the
-      // box has been cleared.
-      requestSeq.current++
-      return
-    }
-
+    // An empty box loads trending immediately; a typed term debounces. Both
+    // go through the same sequence guard so a stale response never lands
+    // after the query has changed.
     const timer = setTimeout(() => {
       const seq = ++requestSeq.current
       setState({ kind: "loading" })
 
-      fetch(`/api/showcase/gifs?q=${encodeURIComponent(term)}`)
+      fetch(term ? `/api/showcase/gifs?q=${encodeURIComponent(term)}` : "/api/showcase/gifs")
         .then(async (res) => {
           const json = await res.json().catch(() => null)
-          // A response for a query the user has since changed is stale — a
-          // later request may already be in flight or may have finished.
           if (seq !== requestSeq.current) return
 
           if (res.status === 503 || res.status === 502) {
@@ -78,7 +69,7 @@ export function GifPicker({ onSelect }: GifPickerProps) {
             return
           }
 
-          const items: TenorSearchResult[] = json.data.results
+          const items: GifSearchResult[] = json.data.results
           setState(items.length > 0 ? { kind: "results", items } : { kind: "empty" })
         })
         .catch(() => {
@@ -86,17 +77,17 @@ export function GifPicker({ onSelect }: GifPickerProps) {
             setState({ kind: "unavailable", message: "GIF search is unavailable right now." })
           }
         })
-    }, SEARCH_DEBOUNCE_MS)
+    }, term ? SEARCH_DEBOUNCE_MS : 0)
 
     return () => clearTimeout(timer)
   }, [term])
 
-  function handleSelect(item: TenorSearchResult) {
+  function handleSelect(item: GifSearchResult) {
     onSelect({
       // Not an R2 object — a picked GIF has no upload key. The server keys
       // off this prefix to skip the pending-upload check and pin the host
       // instead, so do not hand-write it.
-      key: `${TENOR_KEY_PREFIX}${item.id}`,
+      key: `${GIPHY_KEY_PREFIX}${item.id}`,
       url: item.url,
       width: item.width,
       height: item.height,
@@ -113,7 +104,7 @@ export function GifPicker({ onSelect }: GifPickerProps) {
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search GIFs..."
+          placeholder="Search GIFs, or pick from trending..."
           aria-label="Search GIFs"
           className="w-full rounded-lg border border-sand-2 bg-paper-card py-1.5 pl-8 pr-3 font-inter text-sm text-ink placeholder:text-ink-muted/70 focus:border-clay focus:outline-none focus:ring-2 focus:ring-clay/20"
         />
@@ -122,33 +113,33 @@ export function GifPicker({ onSelect }: GifPickerProps) {
       {/* One polite live region spanning every async state, so screen-reader
         * users hear the search resolve (or fail) after they stop typing. */}
       <div aria-live="polite">
-        {view.kind === "loading" && (
+        {state.kind === "loading" && (
           <div className="flex items-center gap-2 py-4 font-inter text-xs text-ink-muted">
-            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Searching...
+            <Loader2 className="h-3.5 w-3.5 animate-spin" /> {term ? "Searching..." : "Loading trending GIFs..."}
           </div>
         )}
 
-        {view.kind === "unavailable" && (
+        {state.kind === "unavailable" && (
           <div className="flex items-center gap-2 py-4 font-inter text-xs text-ink-muted">
-            <ImageOff className="h-3.5 w-3.5 shrink-0" /> {view.message}
+            <ImageOff className="h-3.5 w-3.5 shrink-0" /> {state.message}
           </div>
         )}
 
-        {view.kind === "empty" && (
+        {state.kind === "empty" && (
           <p className="py-4 font-inter text-xs text-ink-muted">No GIFs found for &ldquo;{query}&rdquo;.</p>
         )}
 
-        {view.kind === "results" && (
+        {state.kind === "results" && (
           <p className="sr-only">
-            {view.items.length} GIF{view.items.length === 1 ? "" : "s"} found.
+            {state.items.length} GIF{state.items.length === 1 ? "" : "s"} found.
           </p>
         )}
       </div>
 
-      {view.kind === "results" && (
+      {state.kind === "results" && (
         <>
           <div className="grid max-h-56 grid-cols-3 gap-2 overflow-y-auto">
-            {view.items.map((item) => (
+            {state.items.map((item) => (
               <button
                 key={item.id}
                 type="button"
@@ -165,16 +156,19 @@ export function GifPicker({ onSelect }: GifPickerProps) {
                     </span>
                   </span>
                 ) : (
-                  // eslint-disable-next-line @next/next/no-img-element -- a remote Tenor thumbnail, not a local asset next/image can optimise
+                  // eslint-disable-next-line @next/next/no-img-element -- a remote GIPHY thumbnail, not a local asset next/image can optimise
                   <img src={item.previewUrl} alt={item.description || "GIF"} className="h-20 w-full object-cover" />
                 )}
               </button>
             ))}
           </div>
-          {/* Required by Tenor's API terms whenever results are shown. */}
-          <p className="mt-2 font-inter text-[10px] uppercase tracking-[0.08em] text-ink-muted">
-            Powered by Tenor
-          </p>
+          {/* Required by GIPHY's API terms whenever results are shown. */}
+          {/* eslint-disable-next-line @next/next/no-img-element -- GIPHY's own attribution mark, served from their CDN per their terms */}
+          <img
+            src="https://giphy.com/static/img/poweredby_giphy.png"
+            alt="Powered by GIPHY"
+            className="mt-2 h-4 w-auto"
+          />
         </>
       )}
     </div>

--- a/src/lib/showcase/__tests__/constants.test.ts
+++ b/src/lib/showcase/__tests__/constants.test.ts
@@ -8,7 +8,7 @@ import {
   UPLOAD_CONTENT_TYPES,
   isUploadContentType,
   REPORT_REASONS,
-  isTenorUrl,
+  isGiphyUrl,
 } from "@/lib/showcase/constants"
 import { ReportReason } from "@/generated/prisma/client"
 
@@ -72,23 +72,24 @@ describe("REPORT_REASONS", () => {
   })
 })
 
-describe("isTenorUrl", () => {
-  it("accepts Tenor media hosts over https", () => {
-    expect(isTenorUrl("https://media.tenor.com/abc/x.gif")).toBe(true)
-    expect(isTenorUrl("https://c.tenor.com/abc/x.gif")).toBe(true)
+describe("isGiphyUrl", () => {
+  it("accepts GIPHY media hosts over https", () => {
+    expect(isGiphyUrl("https://media.giphy.com/media/abc/giphy.gif")).toBe(true)
+    expect(isGiphyUrl("https://media2.giphy.com/media/abc/200.gif")).toBe(true)
+    expect(isGiphyUrl("https://i.giphy.com/abc.gif")).toBe(true)
   })
 
   // The reason this parses the URL instead of using startsWith: both of these
-  // pass a naive prefix or substring check and neither is Tenor.
+  // pass a naive prefix or substring check and neither is GIPHY.
   it("rejects lookalike hosts", () => {
-    expect(isTenorUrl("https://media.tenor.com.evil.test/x.gif")).toBe(false)
-    expect(isTenorUrl("https://nottenor.com/x.gif")).toBe(false)
-    expect(isTenorUrl("https://evil.test/?u=https://media.tenor.com/x.gif")).toBe(false)
+    expect(isGiphyUrl("https://media.giphy.com.evil.test/x.gif")).toBe(false)
+    expect(isGiphyUrl("https://notgiphy.com/x.gif")).toBe(false)
+    expect(isGiphyUrl("https://evil.test/?u=https://media.giphy.com/x.gif")).toBe(false)
   })
 
   it("rejects non-https and unparseable values", () => {
-    expect(isTenorUrl("http://media.tenor.com/x.gif")).toBe(false)
-    expect(isTenorUrl("javascript:alert(1)")).toBe(false)
-    expect(isTenorUrl("not a url")).toBe(false)
+    expect(isGiphyUrl("http://media.giphy.com/x.gif")).toBe(false)
+    expect(isGiphyUrl("javascript:alert(1)")).toBe(false)
+    expect(isGiphyUrl("not a url")).toBe(false)
   })
 })

--- a/src/lib/showcase/constants.ts
+++ b/src/lib/showcase/constants.ts
@@ -92,25 +92,28 @@ export const REPORT_REASONS = [
 export type ReportReasonValue = (typeof REPORT_REASONS)[number]["value"]
 
 /**
- * Marker for a GIF picked from Tenor rather than uploaded to R2.
+ * Marker for a GIF picked from GIPHY rather than uploaded to R2.
  *
  * Every other media item is claimed by an R2 key under the poster's own pending
  * prefix, which is what proves it is theirs. A picked GIF has no object and no
  * key, so it carries this prefix instead and is pinned by host on the way in.
+ *
+ * (Tenor shut down 30 June 2026; no "tenor:" rows ever reached production —
+ * the key was never enabled there — so this is a clean swap, not a dual read.)
  */
-export const TENOR_KEY_PREFIX = "tenor:"
+export const GIPHY_KEY_PREFIX = "giphy:"
 
-/** Hosts Tenor actually serves media from. */
-const TENOR_HOSTS = ["media.tenor.com", "media1.tenor.com", "c.tenor.com", "tenor.com"]
+/** Hosts GIPHY actually serves media from (media0–media4 rotate under giphy.com). */
+const GIPHY_HOSTS = ["giphy.com"]
 
 /**
- * True only for a URL on a Tenor media host, over https.
+ * True only for a URL on a GIPHY media host, over https.
  *
- * Parsed rather than matched with `startsWith`: `https://media.tenor.com.evil
- * .test/x.gif` passes a prefix check and is not Tenor. Suffix matching is
- * anchored on a dot so `nottenor.com` cannot pass either.
+ * Parsed rather than matched with `startsWith`: `https://media.giphy.com.evil
+ * .test/x.gif` passes a prefix check and is not GIPHY. Suffix matching is
+ * anchored on a dot so `notgiphy.com` cannot pass either.
  */
-export function isTenorUrl(value: string): boolean {
+export function isGiphyUrl(value: string): boolean {
   let parsed: URL
   try {
     parsed = new URL(value)
@@ -118,5 +121,5 @@ export function isTenorUrl(value: string): boolean {
     return false
   }
   if (parsed.protocol !== "https:") return false
-  return TENOR_HOSTS.some(host => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`))
+  return GIPHY_HOSTS.some(host => parsed.hostname === host || parsed.hostname.endsWith(`.${host}`))
 }


### PR DESCRIPTION
## Why

Tenor's API shut down permanently on 30 June 2026 — every call returns 403, which is why the GIF picker has never worked in production.

## What

- **/api/showcase/gifs** now proxies GIPHY. With a `q` it searches; with no query it returns **trending**, so the picker shows a quick-pick grid before the member types anything. `rating=g` hard-coded (safety floor). Same members-only + rate-limit gates; the key never reaches the browser.
- Parsing: `data[].images.fixed_height` for display, `preview_gif` (fallback `fixed_height_small`) for thumbnails; GIPHY's string dims parsed to numbers.
- `TENOR_KEY_PREFIX`/`isTenorUrl` become `GIPHY_KEY_PREFIX`/`isGiphyUrl` (same anchored-hostname parsing; https only). Clean swap — no `tenor:` rows ever reached prod.
- Submit validation pins picked GIFs to GIPHY hosts.
- **Powered by GIPHY** attribution mark under results (required by GIPHY terms).
- `next/image` allowlist gains `*.giphy.com` (a picked GIF can be a card cover).
- `.env.example`: `TENOR_API_KEY` replaced by `GIPHY_API_KEY`. Emoji picker untouched.

## Deploy requirement

Set **`GIPHY_API_KEY`** (server-side, NOT `NEXT_PUBLIC_`) in Vercel > Settings > Environment Variables (Production + Preview), then redeploy. Locally: add it to `.env.local`.

## Verification

- `npx tsc --noEmit` clean; `npm test` 44/44 (isGiphyUrl suite replaces isTenorUrl)
- Post-deploy: open the composer, trending grid loads, search returns results, picking a GIF attaches it and submits.

@Spidey-Acer

https://claude.ai/code/session_01BQ8rdeMj8UvBxQKvBAN5B9
