### PR TITLE
fix(showcase): text Powered-by-GIPHY mark (hosted PNG 404s)

### DIFF
--- a/src/components/karibu/showcase/GifPicker.tsx
+++ b/src/components/karibu/showcase/GifPicker.tsx
@@ -162,13 +162,12 @@ export function GifPicker({ onSelect }: GifPickerProps) {
               </button>
             ))}
           </div>
-          {/* Required by GIPHY's API terms whenever results are shown. */}
-          {/* eslint-disable-next-line @next/next/no-img-element -- GIPHY's own attribution mark, served from their CDN per their terms */}
-          <img
-            src="https://giphy.com/static/img/poweredby_giphy.png"
-            alt="Powered by GIPHY"
-            className="mt-2 h-4 w-auto"
-          />
+          {/* Required by GIPHY's API terms whenever results are shown. Text
+            * mark rather than their hosted PNG — the old static asset URL
+            * 404s, and a broken image is worse attribution than none. */}
+          <p className="mt-2 font-inter text-[10px] font-semibold uppercase tracking-[0.08em] text-ink-muted">
+            Powered by GIPHY
+          </p>
         </>
       )}
     </div>


### PR DESCRIPTION
GIPHY's static poweredby PNG no longer resolves, so the picker showed a broken-image icon under results. Replaced with a styled text mark — same attribution GIPHY's terms require, cannot break.

Live-verified on prod after #127: trending loads, search works, selection attaches the GIF to Media. tsc clean.

@Spidey-Acer

https://claude.ai/code/session_01BQ8rdeMj8UvBxQKvBAN5B9