### PR TITLE
feat(images): frame system — square posters, declared ratios, honest sizes

### DIFF
--- a/src/app/events/loading.tsx
+++ b/src/app/events/loading.tsx
@@ -20,8 +20,8 @@ export default function EventsLoading() {
 
       {/* Featured "Next up" card */}
       <section className={`${WRAP} py-5`}>
-        <div className="grid overflow-hidden rounded-2xl border border-sand md:grid-cols-2">
-          <Skeleton className="aspect-[4/3] w-full md:aspect-auto md:min-h-[280px]" delay={0.24} />
+        <div className="grid overflow-hidden rounded-2xl border border-sand md:grid-cols-[minmax(0,300px)_1fr] lg:grid-cols-[380px_1fr]">
+          <Skeleton className="aspect-square w-full" delay={0.24} />
           <div className="p-8 md:p-[34px]">
             <div className="mb-3.5 flex gap-2">
               <Skeleton className="h-6 w-16 rounded-full" delay={0.28} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -910,3 +910,52 @@ body::before {
 :root[data-theme="dark"] .anthropic-mark {
   filter: invert(1);
 }
+
+/* ─────────────────────── Frame tokens ───────────────────────
+ * The site used to carry seven different image ratios across surfaces
+ * showing the same kind of content, and several frames had no declared
+ * ratio at all — a fixed pixel height on a fluid-width box encodes a
+ * ratio nobody wrote down and nobody can review. The event detail hero
+ * was the worst of them: it drifted 1.43 -> 2.02 -> 3.24 across
+ * breakpoints and threw away 69% of a square poster.
+ *
+ * The rule these tokens enforce: a frame takes the shape its content's
+ * author intended. Assets composed in a canvas (posters, screenshots,
+ * avatars) are square, so they get square frames and lose nothing.
+ * Photographs are shot through a lens at 3:2-ish, so they get a
+ * landscape frame — forcing those square would cut 44% off the portrait
+ * shots, which is the same injury, just moved onto people's faces.
+ *
+ * Two standing rules ride with these: no frame ships without a declared
+ * ratio, and `sizes` moves whenever the ratio does — it is part of the
+ * frame, not an afterthought. */
+
+@utility frame-base {
+  position: relative;
+  overflow: hidden;
+}
+
+/** 1:1, object-cover. Grid thumbnails of square-composed assets. */
+@utility frame-tile {
+  aspect-ratio: 1 / 1;
+}
+
+/** 1:1, object-contain on a matte. Display frames >=300px where the
+  * source shape is not guaranteed — a future off-ratio poster survives
+  * instead of losing most of itself. The matte is mixed off Karibu
+  * tokens so it inverts with the theme; --scrim would not. */
+@utility frame-plate {
+  aspect-ratio: 1 / 1;
+  background: color-mix(in oklab, var(--clay) 5%, var(--paper-alt));
+}
+
+/** 4:3, object-cover. Photographs. The uncut view is the lightbox. */
+@utility frame-photo {
+  aspect-ratio: 4 / 3;
+}
+
+/** 1:1 round, object-cover. People. */
+@utility frame-avatar {
+  aspect-ratio: 1 / 1;
+  border-radius: 9999px;
+}

--- a/src/components/karibu/EventCoverPlaceholder.tsx
+++ b/src/components/karibu/EventCoverPlaceholder.tsx
@@ -121,7 +121,16 @@ export function EventCoverPlaceholder({
   return (
     <div
       aria-hidden="true"
-      className={cn("absolute inset-0 flex flex-col justify-center overflow-hidden", tone, className)}
+      className={cn(
+        // The frames these sit in are square now, and a square affords a top
+        // and a bottom. Centring the block the way the 3:2 box needed leaves
+        // dead bands above and below it; pinning the eyebrow to the top and
+        // the copy to the bottom is what makes it read as a printed bill.
+        "absolute inset-0 flex flex-col justify-between overflow-hidden",
+        size === "lg" ? "p-7 md:p-9" : "p-5",
+        tone,
+        className,
+      )}
     >
       {/* Motif sits under the type, faint enough that the words stay the subject. */}
       <div
@@ -139,32 +148,47 @@ export function EventCoverPlaceholder({
         height={64}
         className={cn(
           "pointer-events-none absolute opacity-40",
-          size === "lg" ? "bottom-6 right-6 h-11 w-11" : "bottom-3.5 right-3.5 h-7 w-7",
+          size === "lg" ? "right-6 top-6 h-11 w-11" : "right-4 top-4 h-7 w-7",
         )}
       />
 
-      <div className={cn("relative", size === "lg" ? "p-7 pr-20 md:p-10 md:pr-28" : "p-5 pr-12")}>
-        <div
-          className={cn(
-            "mb-2 font-inter font-semibold uppercase tracking-[0.18em] text-clay",
-            size === "lg" ? "text-[11.5px]" : "text-[10px]",
-          )}
-        >
-          {[TYPE_EYEBROW[event.type], size === "lg" ? event.city : null]
-            .filter(Boolean)
-            .join(" · ")}
-        </div>
+      {/* Top: eyebrow. Only this needs clearance for the stamp. */}
+      <div
+        className={cn(
+          "relative font-inter font-semibold uppercase tracking-[0.18em] text-clay",
+          size === "lg" ? "pr-16 text-[11.5px]" : "pr-10 text-[10px]",
+        )}
+      >
+        {[TYPE_EYEBROW[event.type], size === "lg" ? event.city : null]
+          .filter(Boolean)
+          .join(" · ")}
+      </div>
+
+      {/* Bottom: the copy block. */}
+      <div className="relative">
         {size === "lg" && dateParts ? (
           <>
-            <div className="font-newsreader leading-[0.9] tracking-[-0.02em] text-ink text-[56px] md:text-[76px]">
+            <div className="font-newsreader text-[64px] leading-[0.88] tracking-[-0.02em] text-ink md:text-[84px]">
               {dateParts.day}
             </div>
-            <div className="mt-1.5 font-inter text-[15px] font-medium text-ink-soft md:text-[17px]">
+            <div className="mt-1 font-inter text-[15px] font-medium text-ink-soft md:text-[17px]">
               {dateParts.month}
+            </div>
+            {/* The large variant can carry its title again. It was dropped
+              * when this sat in a 340px strip beside a 32px heading, where
+              * it read as an echo. In the rail the plate is 400px tall and
+              * the h1 is in the other column, so a small title under a rule
+              * is a caption on the bill — and the cover stops reading as a
+              * date widget that forgot which event it belongs to. */}
+            <div className="mt-4 h-px w-10 bg-clay/40" />
+            <div className="mt-3 line-clamp-2 font-newsreader text-[20px] leading-[1.15] text-ink md:text-[23px]">
+              {coverTitle(event.title, event.city)}
             </div>
           </>
         ) : (
-          <div className="line-clamp-3 font-newsreader text-[26px] leading-[1.06] tracking-[-0.01em] text-ink">
+          // The square tile is taller than the 3:2 it replaces, so the title
+          // gets another line rather than leaving a dead band under it.
+          <div className="line-clamp-4 font-newsreader text-[28px] leading-[1.06] tracking-[-0.01em] text-ink">
             {coverTitle(event.title, event.city)}
           </div>
         )}

--- a/src/components/karibu/KaribuEventDetail.tsx
+++ b/src/components/karibu/KaribuEventDetail.tsx
@@ -85,37 +85,59 @@ export function KaribuEventDetail({
       {/* Header */}
       <section className={`${WRAP} pb-8 pt-5`} aria-label="Event header">
         <Reveal>
-          <div className="mb-4 flex flex-wrap gap-2">
-            <Badge tone="clay">{event.city}</Badge>
-            <Badge tone="sand">{TYPE_LABEL[event.type]}</Badge>
-            {event.audiences?.includes("all-levels") && <Badge tone="sand">All levels</Badge>}
-          </div>
-          <h1 className="mb-4 max-w-[760px] font-newsreader text-[40px] font-normal leading-[1.05] tracking-[-0.02em] text-ink sm:text-[52px]">
-            {event.title}
-          </h1>
-          <p className="mb-6 max-w-[640px] font-inter text-[17px] leading-[1.6] text-ink-soft">
-            {event.description}
-          </p>
-          <div className="relative h-[240px] overflow-hidden rounded-[14px] border border-sand-2 sm:h-[340px]">
-            {cover ? (
-              <Image
-                src={cover}
-                alt={event.title}
-                fill
-                priority
-                sizes="(max-width: 1180px) 100vw, 1100px"
-                className="object-cover"
-              />
-            ) : (
-              <EventCoverPlaceholder event={event} size="lg" />
-            )}
+          {/*
+            The poster used to be a full-width band under the title, at a
+            fixed pixel height on a fluid-width box — so its ratio drifted
+            1.43 -> 2.02 -> 3.24 across breakpoints and a 1100x1100 poster
+            landed in a 1098x338 slot with 69% of it cut away. Organisers
+            author these posters square, so the frame is square now and the
+            whole poster is visible.
+
+            It lives in a rail rather than full-bleed because a 1:1 poster
+            at the 1100px content width would be a 1100px wall of image
+            before you reach the date. The rail is the same 400px column the
+            body grid uses, so poster and Register button read as one
+            continuous column — what you look at and what you act on.
+            Source order gives text-then-poster when it collapses.
+          */}
+          <div className="grid items-start gap-8 lg:grid-cols-[1fr_400px] lg:gap-10">
+            <div className="min-w-0">
+              <div className="mb-4 flex flex-wrap gap-2">
+                <Badge tone="clay">{event.city}</Badge>
+                <Badge tone="sand">{TYPE_LABEL[event.type]}</Badge>
+                {event.audiences?.includes("all-levels") && <Badge tone="sand">All levels</Badge>}
+              </div>
+              <h1 className="mb-4 font-newsreader text-[34px] font-normal leading-[1.05] tracking-[-0.02em] text-ink sm:text-[44px] lg:text-[52px]">
+                {event.title}
+              </h1>
+              <p className="font-inter text-[17px] leading-[1.6] text-ink-soft">
+                {event.description}
+              </p>
+            </div>
+
+            <div className="w-full max-w-[420px] lg:max-w-none">
+              <div className="frame-base frame-plate rounded-2xl border border-sand-2">
+                {cover ? (
+                  <Image
+                    src={cover}
+                    alt={event.title}
+                    fill
+                    priority
+                    sizes="(min-width: 1024px) 400px, (min-width: 480px) 420px, 100vw"
+                    className="object-contain"
+                  />
+                ) : (
+                  <EventCoverPlaceholder event={event} size="lg" />
+                )}
+              </div>
+            </div>
           </div>
         </Reveal>
       </section>
 
       {/* Body: main + sidebar */}
       <section
-        className={`${WRAP} grid grid-cols-1 items-start gap-10 pb-12 lg:grid-cols-[1fr_340px]`}
+        className={`${WRAP} grid grid-cols-1 items-start gap-10 pb-12 lg:grid-cols-[1fr_400px]`}
         aria-label="Event details"
       >
         <Reveal className="min-w-0">

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -254,27 +254,34 @@ function FeaturedCard({ event }: { event: Event }) {
   return (
     <Link
       href={`/events/${event.slug}`}
-      className="group grid overflow-hidden rounded-2xl border border-sand bg-paper-card transition-colors hover:border-clay md:grid-cols-2"
+      className="group grid overflow-hidden rounded-2xl border border-sand bg-paper-card transition-colors hover:border-clay md:grid-cols-[minmax(0,300px)_1fr] lg:grid-cols-[380px_1fr]"
     >
-      <div className="relative min-h-[220px] overflow-hidden md:min-h-[280px]">
+      <div className="frame-base frame-plate border-b border-sand md:border-b-0 md:border-r">
         {cover ? (
           <Image
             src={cover}
             alt={event.title}
             fill
             priority
-            sizes="(max-width: 768px) 100vw, 590px"
-            className="object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+            sizes="(min-width: 1024px) 380px, (min-width: 768px) 300px, 100vw"
+            className="object-contain"
           />
         ) : (
           <EventCoverPlaceholder event={event} size="lg" />
         )}
-        <span className="absolute left-4 top-4 rounded-full bg-clay px-3 py-1.5 font-inter text-xs font-semibold uppercase tracking-[0.08em] text-paper-card">
-          Next up
-        </span>
       </div>
       <div className="p-8 md:p-[34px]">
+        {/*
+          "Next up" used to sit on the poster as an absolute pill. Two reasons
+          it moved here: it covered part of a poster this card now shows whole,
+          and on a poster-less event it landed directly on top of the
+          placeholder's own eyebrow. It is a status flag, so it belongs with
+          the other status badges.
+        */}
         <div className="mb-3.5 flex flex-wrap gap-2">
+          <span className="rounded-full bg-clay px-2.5 py-1 font-inter text-xs font-semibold uppercase tracking-[0.08em] text-paper-card">
+            Next up
+          </span>
           <Badge tone="clay">{event.city}</Badge>
           <Badge tone="sand">{TYPE_LABEL[event.type]}</Badge>
         </div>
@@ -348,15 +355,18 @@ function PastCard({ event }: { event: Event }) {
   const label = dt ? fmt(dt, { month: "short", year: "numeric" }) : event.date;
   const cover = eventCover(event.posterUrl);
   return (
-    <Link href={`/events/${event.slug}`} className="group block">
-      <div className="relative mb-2.5 aspect-[3/2] overflow-hidden rounded-xl border border-sand transition-colors group-hover:border-clay">
+    <Link
+      href={`/events/${event.slug}`}
+      className="group block transition-transform duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1 motion-reduce:transform-none"
+    >
+      <div className="frame-base frame-tile mb-2.5 rounded-xl border border-sand transition-colors duration-150 ease-[var(--ease-reversible)] group-hover:border-clay">
         {cover ? (
           <Image
             src={cover}
             alt={event.title}
             fill
-            sizes="(max-width: 640px) 100vw, 380px"
-            className="object-cover transition-transform duration-500 group-hover:scale-105"
+            sizes="(min-width: 1024px) 360px, (min-width: 640px) 50vw, 100vw"
+            className="object-cover"
           />
         ) : (
           <EventCoverPlaceholder event={event} />

--- a/src/components/karibu/KaribuHome.tsx
+++ b/src/components/karibu/KaribuHome.tsx
@@ -213,7 +213,7 @@ function Hero({ nextEvent }: { nextEvent?: Event }) {
         <div
           data-hero-rise
           style={{ "--i": 1 } as React.CSSProperties}
-          className="relative h-[300px] overflow-hidden rounded-2xl border border-sand-2 lg:h-[460px]"
+          className="frame-base frame-photo rounded-2xl border border-sand-2"
         >
           <Image
             src={HERO_PHOTO}
@@ -561,14 +561,14 @@ function EventsSection({ events }: { events: Event[] }) {
               key={ev.slug}
               href={`/events/${ev.slug}`}
               className={`group overflow-hidden rounded-2xl border border-sand bg-paper-card transition-colors hover:border-clay active:border-clay active:-translate-y-0.5 ${
-                single ? "md:grid md:grid-cols-2" : "block"
+                single ? "md:grid md:grid-cols-[minmax(0,300px)_1fr]" : "block"
               }`}
             >
               <div
-                className={`relative overflow-hidden border-sand ${
+                className={`frame-base border-sand ${
                   single
-                    ? "h-[220px] border-b md:h-full md:min-h-[280px] md:border-b-0 md:border-r"
-                    : "aspect-[3/2] border-b"
+                    ? "frame-plate border-b md:border-b-0 md:border-r"
+                    : "frame-tile border-b"
                 }`}
               >
                 {cover ? (
@@ -576,8 +576,12 @@ function EventsSection({ events }: { events: Event[] }) {
                     src={cover}
                     alt={ev.title}
                     fill
-                    sizes={single ? "(max-width: 768px) 100vw, 590px" : "(max-width: 768px) 100vw, 380px"}
-                    className="object-cover transition-transform duration-500 group-hover:scale-105"
+                    sizes={
+                      single
+                        ? "(min-width: 768px) 300px, 100vw"
+                        : "(min-width: 1024px) 240px, (min-width: 768px) 33vw, 100vw"
+                    }
+                    className={single ? "object-contain" : "object-cover"}
                   />
                 ) : (
                   <EventCoverPlaceholder event={ev} size={single ? "lg" : "sm"} />
@@ -623,7 +627,7 @@ function CommunityInAction() {
       </Reveal>
       <Reveal className="grid items-stretch gap-6 lg:grid-cols-2">
         {/* Real member & event photos. */}
-        <div className="grid min-h-[380px] grid-cols-2 grid-rows-2 gap-3">
+        <div className="grid aspect-[4/3] grid-cols-2 grid-rows-2 gap-3">
           <div className="relative row-span-2 overflow-hidden rounded-xl">
             <Image src={GALLERY_PHOTOS.tall} alt="CCK members building with Claude" fill sizes="(max-width: 1024px) 50vw, 280px" className="object-cover" />
           </div>

--- a/src/components/karibu/showcase/ShowcaseCard.tsx
+++ b/src/components/karibu/showcase/ShowcaseCard.tsx
@@ -32,14 +32,18 @@ export function ShowcaseCard({ post }: ShowcaseCardProps) {
       href={`/showcase/${post.slug}`}
       className="group flex h-full flex-col overflow-hidden rounded-2xl border border-sand bg-paper-card transition-[transform,border-color] duration-150 ease-[var(--ease-reversible)] hover:-translate-y-1 hover:border-clay focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-clay focus-visible:ring-offset-2"
     >
-      <div className="relative aspect-[16/9] w-full shrink-0 overflow-hidden bg-paper-alt">
+      {/* Showcase covers are whatever a member uploaded — usually a
+        * near-square screenshot. A 16:9 crop was taking 44% off a square
+        * source and 55% off a phone photo, which is the worst crop on the
+        * public site. Contained on the matte, nothing is destroyed. */}
+      <div className="frame-base frame-plate w-full shrink-0">
         {post.coverImageUrl ? (
           <Image
             src={post.coverImageUrl}
             alt=""
             fill
-            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-            className="object-cover transition-transform duration-500 group-hover:scale-[1.03]"
+            sizes="(min-width: 1024px) 360px, (min-width: 640px) 50vw, 100vw"
+            className="object-contain"
           />
         ) : (
           <div className="flex h-full w-full items-center justify-center">


### PR DESCRIPTION
## The complaint

Click any event and the poster looks destroyed. It is:

```
poster 1100×1100  →  frame 1098×338  →  69% thrown away
```

You see a horizontal sliver of the word "Nairobi".

## Why it was happening

**One frame system was applied to two different classes of image.** Measured the real assets before touching anything:

| Asset class | Count | Real shape |
|---|---|---|
| Event posters | 4 | **all perfectly square** — 400², 1080², 2160²×2 |
| Team avatars | 3 | **all square** — 1000², 480², 1000² |
| Community photographs | 16 | **none square** — 7×3:2, 3×4:3, 2×16:9, 2×9:16, 1×3:4, 1×1.91:1 |

Organisers author posters square. Every event frame on the site was shaped for photography, so every poster was being cut to fit a shape it was never drawn for.

## The rule

> **A frame takes the shape its content's author intended.** Composed assets (posters, screenshots, avatars) get square frames. Photographs keep a landscape frame.

A reviewer can apply that to any new component in five seconds: *did a human compose this in a canvas, or point a camera at something?*

### On "one ratio for everything"

The instinct was right for posters and would have backfired on photography. A uniform site-wide 1:1 would cut **44% off the portrait shots of members' faces** — the same injury being reported, just moved from the poster onto people. So: square for composed assets, 4:3 for photographs. Uniform *per asset class*.

## Frame tokens (`globals.css`)

| Token | Shape · fit | Use when |
|---|---|---|
| `frame-tile` | 1:1 · cover | Grid thumbnails of square-composed assets |
| `frame-plate` | 1:1 · contain on matte | Display frames ≥300px where source shape isn't guaranteed |
| `frame-photo` | 4:3 · cover | Photographs — uncut view lives in the lightbox |
| `frame-avatar` | 1:1 round · cover | People |

The matte is `color-mix(in oklab, var(--clay) 5%, var(--paper-alt))` so it inverts with the theme. `--scrim` would have stayed near-black in light mode and read as a passe-partout from a different design system.

## The detail hero

The poster moves into the same **400px rail** the body grid already uses, so poster and Register button are one continuous column — what you look at and what you act on. Full-bleed wasn't an option: a 1:1 poster at 1100px content width is a wall of image before you reach the date. Body rail widens 340→400 to match, which drops the reading measure to 660px as a bonus.

Source order gives text-then-poster when it collapses on mobile — no `order-*` utilities, no duplicated `<Image>`.

## Four more bugs, same root cause

1. **Ratios that drifted across breakpoints.** Hero `1.43→2.02→3.24`, featured `1.56→1.23→1.96`, home `2.28→1.46→2.37` — the crop shifted as you resized. A fixed pixel height on a fluid-width box encodes a ratio nobody wrote down and nobody can review. All declared and constant now.
2. **`sizes` lying about box size.** The hero declared `1100px` for what is now a 400px box; home cards declared `380px` for a **~219px** column — a 74% oversized download above the fold.
3. **Hover zoom re-cropping the poster.** Every poster card scaled the image 5% on hover, cropping the poster the square frame had just finished uncropping. Removed; the lift moved to the card.
4. **"Next up" pill overlapping the placeholder.** Measured `OVERLAP: true` — on a poster-less event the pill landed exactly on the placeholder's own eyebrow. It also covered part of a poster now shown whole. Moved into the badge row where it belongs as a status flag.

Plus `ShowcaseCard` 16:9 → plate (was taking 44% off a square upload, 55% off a phone photo — worst crop on the public site), and the `events/loading.tsx` skeleton follows the new featured shape **in the same commit** so the page doesn't shift when the real card lands.

## Verification

Rendered the real components against live event data (preview DB has no events, so this was measured locally):

| Frame | Box | Ratio | Source | Crop |
|---|---|---|---|---|
| Detail hero plate | 400×400 | 1.000 | 400×400 poster | **0%** |
| Featured plate | 380×380 | 1.000 | — | 0% |
| Past tiles | 356×356 | 1.000 | — | 0% |

Every `sizes` matches its measured box. Dark-mode matte inverts (`oklab(0.28 0.011 0.020)`, distinct from page background). Zero overlays remaining on any frame. `npx tsc --noEmit` clean; `next build` compiles clean (page-data collection still fails on the pre-existing missing-`.env` for `/api/admin/photos`).

## Deliberately not in this PR

- **Photo galleries stay 4:3.** Moving them to 3:2 would take **63%** off a 9:16 portrait versus 44% at 4:3 — it would regress the exact problem. The place a portrait is shown whole is the lightbox, which is already `object-contain`.
- **6 dead Terminal Noir files** (`EventsContent`, `EventDetailContent`, `HomeContent`, `EventCard`, `GalleryGrid`, `MediaFrame`) — independently verified zero importers. Separate cleanup PR, as agreed.
- **Gallery frame tokenisation** — rename-only, no visual change. Dropped because those files carry unrelated in-progress edits in the working tree; not worth entangling.
- Admin surfaces, per scope.
