### PR TITLE
fix(karibu): remove decorative Swahili from section kickers

### DIFF
--- a/src/components/karibu/KaribuAbout.tsx
+++ b/src/components/karibu/KaribuAbout.tsx
@@ -50,7 +50,7 @@ export function KaribuAbout({
       {/* Header */}
       <section className={`${WRAP} pb-8 pt-16`} aria-label="About hero">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>About · Kuhusu sisi</div>
+          <div className={`${KICKER} mb-4`}>About</div>
           <h1 className="max-w-[880px] font-newsreader text-[38px] font-normal leading-[1.12] tracking-[-0.02em] text-ink sm:text-[52px]">
             We&apos;re a free, founder-led community for anyone in Kenya{" "}
             <span className="italic text-clay">learning and building</span> with

--- a/src/components/karibu/KaribuAlbum.tsx
+++ b/src/components/karibu/KaribuAlbum.tsx
@@ -60,7 +60,7 @@ export function KaribuAlbum({
             <ArrowLeft className="h-3.5 w-3.5" aria-hidden="true" />
             All events
           </Link>
-          <div className={`${KICKER} mb-3`}>Gallery · Picha</div>
+          <div className={`${KICKER} mb-3`}>Gallery</div>
           <h1 className="mb-3 max-w-[820px] font-newsreader text-[38px] font-normal leading-[1.06] tracking-[-0.02em] text-ink sm:text-[48px]">
             {event.title}
           </h1>

--- a/src/components/karibu/KaribuBlog.tsx
+++ b/src/components/karibu/KaribuBlog.tsx
@@ -112,7 +112,7 @@ export function KaribuBlog({ posts }: { posts: readonly BlogPostView[] }) {
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Blog header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Blog · Blogu</div>
+          <div className={`${KICKER} mb-4`}>Blog</div>
           <h1 className="mb-4 max-w-[820px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Notes from the <span className="italic text-clay">community.</span>
           </h1>

--- a/src/components/karibu/KaribuCommunity.tsx
+++ b/src/components/karibu/KaribuCommunity.tsx
@@ -73,7 +73,7 @@ export function KaribuCommunity({
         <Reveal>
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <div className={`${KICKER} mb-4`}>Community · Jamii</div>
+              <div className={`${KICKER} mb-4`}>Community</div>
               <h1 className="mb-3 font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[52px]">
                 Built &amp; shared by the community.
               </h1>

--- a/src/components/karibu/KaribuEvents.tsx
+++ b/src/components/karibu/KaribuEvents.tsx
@@ -119,7 +119,7 @@ export function KaribuEvents({ events }: { events: Event[] }) {
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Events header">
         <Reveal>
           <div className="mb-4 font-inter text-xs font-semibold uppercase tracking-[0.22em] text-clay">
-            Events · Matukio
+            Events
           </div>
           <h1 className="mb-[18px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Where we meet.
@@ -208,7 +208,7 @@ export function KaribuEvents({ events }: { events: Event[] }) {
           <Reveal>
             <div className="mb-4 flex items-baseline justify-between gap-4 border-b border-sand pb-3">
               <div className="font-inter text-xs font-bold uppercase tracking-[0.14em] text-ink-faint">
-                Past · picha
+                Past
               </div>
               <div className="font-inter text-xs text-ink-faint">
                 {past.length} {past.length === 1 ? "event" : "events"}

--- a/src/components/karibu/KaribuFaq.tsx
+++ b/src/components/karibu/KaribuFaq.tsx
@@ -126,7 +126,7 @@ export function KaribuFaq({ faqs, categories }: { faqs: FAQ[]; categories: FaqCa
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="FAQ header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>FAQ · Maswali</div>
+          <div className={`${KICKER} mb-4`}>FAQ</div>
           <h1 className="mb-4 max-w-[820px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Questions, <span className="italic text-clay">answered.</span>
           </h1>

--- a/src/components/karibu/KaribuGallery.tsx
+++ b/src/components/karibu/KaribuGallery.tsx
@@ -53,7 +53,7 @@ export function KaribuGallery({ photos, eventChips = [], initialFilter = null }:
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Gallery header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Gallery · Picha</div>
+          <div className={`${KICKER} mb-4`}>Gallery</div>
           <h1 className="mb-4 max-w-[760px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Faces of the <span className="italic text-clay">community.</span>
           </h1>

--- a/src/components/karibu/KaribuGalleryIndex.tsx
+++ b/src/components/karibu/KaribuGalleryIndex.tsx
@@ -38,7 +38,7 @@ export function KaribuGalleryIndex({ albums }: { albums: GalleryAlbum[] }) {
     <>
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Gallery header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Gallery · Picha</div>
+          <div className={`${KICKER} mb-4`}>Gallery</div>
           <h1 className="mb-4 max-w-[760px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Faces of the <span className="italic text-clay">community.</span>
           </h1>

--- a/src/components/karibu/KaribuLearn.tsx
+++ b/src/components/karibu/KaribuLearn.tsx
@@ -75,7 +75,7 @@ export function KaribuLearn({ cards }: { cards: readonly LearnCard[] }) {
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Learn header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Learn · Jifunze</div>
+          <div className={`${KICKER} mb-4`}>Learn</div>
           <h1 className="mb-4 max-w-[820px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Start where you are. <span className="italic text-clay">Build from there.</span>
           </h1>

--- a/src/components/karibu/KaribuNewsletter.tsx
+++ b/src/components/karibu/KaribuNewsletter.tsx
@@ -160,7 +160,7 @@ export function KaribuNewsletter({ issues }: { issues: readonly NewsletterIssueV
       <section className={`${WRAP} pb-10 pt-16 text-center`} aria-label="Newsletter header">
         <Reveal>
           <div className={`${KICKER} mb-4 flex items-center justify-center gap-2`}>
-            <span>Newsletter · Jarida</span>
+            <span>Newsletter</span>
             {issues.length > 0 && (
               <span className="rounded-full bg-clay/10 px-2 py-0.5 text-[10px] font-semibold text-clay">
                 {issues.length} issue{issues.length !== 1 ? "s" : ""}

--- a/src/components/karibu/KaribuProjectsPage.tsx
+++ b/src/components/karibu/KaribuProjectsPage.tsx
@@ -26,7 +26,7 @@ export function KaribuProjectsPage({ projects }: { projects: ProjectView[] }) {
     <>
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Projects header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Projects · Miradi</div>
+          <div className={`${KICKER} mb-4`}>Projects</div>
           <h1 className="mb-4 font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[52px]">
             Built with Claude, in Kenya.
           </h1>

--- a/src/components/karibu/KaribuSpeak.tsx
+++ b/src/components/karibu/KaribuSpeak.tsx
@@ -122,7 +122,7 @@ export function KaribuSpeak() {
     <>
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Speak header">
-        <div className={`${KICKER} mb-4`}>Speak · Ongea</div>
+        <div className={`${KICKER} mb-4`}>Speak</div>
         <h1 className="mb-4 max-w-[720px] font-newsreader text-[40px] font-normal leading-[1.05] tracking-[-0.02em] text-ink sm:text-[48px]">
           Share your knowledge with{" "}
           <span className="italic text-clay">Kenya&apos;s AI community.</span>

--- a/src/components/karibu/KaribuSubmitIdea.tsx
+++ b/src/components/karibu/KaribuSubmitIdea.tsx
@@ -151,7 +151,7 @@ export function KaribuSubmitIdea() {
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Submit an idea header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Submit an idea · Wazo</div>
+          <div className={`${KICKER} mb-4`}>Submit an idea</div>
           <h1 className="mb-4 max-w-[720px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Building something? <span className="italic text-clay">Find your collaborators.</span>
           </h1>

--- a/src/components/karibu/KaribuSubmitProject.tsx
+++ b/src/components/karibu/KaribuSubmitProject.tsx
@@ -135,7 +135,7 @@ export function KaribuSubmitProject() {
       {/* Header */}
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Submit a project header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Submit a project · Mradi</div>
+          <div className={`${KICKER} mb-4`}>Submit a project</div>
           <h1 className="mb-4 max-w-[720px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Built something? <span className="italic text-clay">Share it.</span>
           </h1>

--- a/src/components/karibu/showcase/ShowcaseComposer.tsx
+++ b/src/components/karibu/showcase/ShowcaseComposer.tsx
@@ -321,7 +321,7 @@ function ComposerForm({ events }: { events: ComposerEventOption[] }) {
     <>
       <section className={`${WRAP} pb-6 pt-16`} aria-label="Post to the showcase header">
         <Reveal>
-          <div className={`${KICKER} mb-4`}>Showcase · Onyesho</div>
+          <div className={`${KICKER} mb-4`}>Showcase</div>
           <h1 className="mb-4 max-w-[720px] font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[56px]">
             Built something with <span className="italic text-clay">Claude?</span>
           </h1>

--- a/src/components/karibu/showcase/ShowcaseFeed.tsx
+++ b/src/components/karibu/showcase/ShowcaseFeed.tsx
@@ -76,7 +76,7 @@ export function ShowcaseFeed({
         <Reveal>
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <div className={`${KICKER} mb-4`}>Showcase · Maonyesho</div>
+              <div className={`${KICKER} mb-4`}>Showcase</div>
               <h1 className="mb-3 font-newsreader text-[44px] font-normal leading-[1.03] tracking-[-0.02em] text-ink sm:text-[52px]">
                 What the community is building.
               </h1>


### PR DESCRIPTION
## The problem

`Events · Matukio` and 16 siblings looked like a bilingual site. They weren't. **There is no i18n layer** — no locale routing, no dictionary, no switcher. `layout.tsx` hardcodes `lang="en"`.

The Swahili was 17 hand-typed strings, and it showed:

| Symptom | Evidence |
|---|---|
| Arbitrary coverage | 18 of 28 kickers bilingual. Join, The team, Volunteer, Upcoming, Featured, Made for you + 5 more were English-only with no rule |
| Contradictory translations | `Showcase · Onyesho` (Composer) vs `Showcase · Maonyesho` (Feed) — same word, two answers |
| A wrong one | `Past · picha` — lowercase, and *picha* means "photos", not "past" |
| Accessibility | Swahili inside `lang="en"` with no `lang="sw"` wrapper — screen readers say *Matukio* with English phonemes |
| Dead preference | The Karibu onboarding captures `language: "en" \| "sw"`, persists it, exposes it on `AudienceContext` — and **nothing reads it**. The onboarding system prompt never mentions Swahili either. A switch wired to nothing. |

## The change

Drops the Swahili half from all 17 kickers. Presentational only — no Swahili had reached any `<title>`, meta description, or OG tag, so there is no SEO or metadata impact.

## Kept on purpose

- **`KaribuHome` hero — `Karibu · Kenya's Claude Community`.** Brand identity, not a translation pair; the whole design system is named Karibu.
- **`OnboardingSession.language`.** Unread today, but left in place as the seed for a real switcher rather than deleted as dead code. Deleting it would be a migration for no gain.

## What this is *not*

This removes fake bilingualism; it does not build real bilingualism. A proper en/sw switcher is scoped separately: locale routing or `next-intl`, dictionary files, a nav toggle, `hreflang` + localized metadata, default locale seeded from `OnboardingSession.language` — and a hard dependency on **human-written Swahili copy** for ~28 pages, not machine translation.

## Verification

- `npx tsc --noEmit` — clean, exit 0
- Residual sweep of `src/` for Swahili terms — clean
- `npm run build` — compile + TypeScript phases pass; cannot complete locally because there is no `.env` on this machine (`supabaseUrl is required` at page-data collection for `/api/admin/photos/[id]`). Pre-existing environment gap, unrelated to these 17 string edits. Vercel has the vars.