### PR TITLE
fix(rate-limit): accept Vercel Upstash KV_REST_API_* env names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ EMAIL_TO_ADMIN="claudecommunitykenya@gmail.com"
 
 # ─── Rate Limiting (Upstash Redis) ───────────────────────────────────────────
 # Optional in development — required in production
+# Vercel Marketplace Upstash injects KV_REST_API_URL / KV_REST_API_TOKEN instead; both name pairs are accepted.
 UPSTASH_REDIS_REST_URL="https://xxx.upstash.io"
 UPSTASH_REDIS_REST_TOKEN="xxxxxxxxxxxx"
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -8,8 +8,11 @@ import { NextRequest, NextResponse } from "next/server"
 import { Redis } from "@upstash/redis"
 import { Ratelimit } from "@upstash/ratelimit"
 
-const UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL
-const UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN
+// The Vercel Marketplace "Upstash for Redis" integration injects KV_REST_API_*
+// names; a hand-configured Upstash database uses UPSTASH_REDIS_REST_*. Accept
+// either so provisioning through Vercel needs no manual alias vars.
+const UPSTASH_REDIS_REST_URL = process.env.UPSTASH_REDIS_REST_URL ?? process.env.KV_REST_API_URL
+const UPSTASH_REDIS_REST_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN ?? process.env.KV_REST_API_TOKEN
 const NODE_ENV = process.env.NODE_ENV || "development"
 const IS_BUILD_PHASE = process.env.NEXT_PHASE === "phase-production-build"
 
@@ -22,7 +25,7 @@ if (UPSTASH_REDIS_REST_URL && UPSTASH_REDIS_REST_TOKEN) {
   })
 } else if (NODE_ENV === "production" && !IS_BUILD_PHASE) {
   console.warn(
-    "WARNING: UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are not set. " +
+    "WARNING: neither UPSTASH_REDIS_REST_URL/TOKEN nor KV_REST_API_URL/TOKEN are set. " +
       "Rate limiting will use in-memory fallback which does not work in distributed environments."
   )
 }


### PR DESCRIPTION
Production had NO Upstash env vars, so every rate limit on the site has been running on the in-memory fallback (effectively off across lambdas). Provisioned "Upstash for Redis" (free, iad1, resource cck-rate-limit) through the Vercel Marketplace via CLI; it injects KV_REST_API_URL/KV_REST_API_TOKEN rather than UPSTASH_REDIS_REST_*. This reads either pair.

Verified: tsc clean, vitest 93/93. Merging this redeploys with SUBMISSION_IP_SALT + Redis both live; rate limiting fails closed if Redis is configured but unreachable, so a 429 storm after deploy means a bad token, not spam.

@Spidey-Acer

https://claude.ai/code/session_01BQ8rdeMj8UvBxQKvBAN5B9
