### PR TITLE
fix(conversations): force-dynamic on the live page (prod 500)

### DIFF
--- a/src/app/conversations/[slug]/page.tsx
+++ b/src/app/conversations/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { BreadcrumbSchema } from "@/components/schema/BreadcrumbSchema";
-import { getConversationsEvents, getConversationsPageBySlug } from "@/lib/conversations/queries";
+import { getConversationsPageBySlug } from "@/lib/conversations/queries";
 import { SITE_CONFIG } from "@/lib/constants";
 import { ConversationsHero } from "@/components/karibu/conversations/ConversationsHero";
 import { StatWall } from "@/components/karibu/conversations/StatWall";
@@ -10,14 +10,16 @@ import { ContributionForm } from "@/components/karibu/conversations/Contribution
 import { SeedDrawer } from "@/components/karibu/conversations/SeedDrawer";
 import { ResultBanner } from "@/components/karibu/conversations/ResultBanner";
 
-export const revalidate = 60;
+// Rendered on every request, not ISR. The root layout reads cookies (a dynamic
+// API) on every page; routes prerendered at build discover that and become
+// dynamic automatically, but this route had no slugs at build time, so Next
+// classified it static and every on-demand render then died with
+// DYNAMIC_SERVER_USAGE (prod 500, 28 Aug). Forcing dynamic matches how every
+// other public page actually runs, and the live-result flip needs freshness
+// anyway.
+export const dynamic = "force-dynamic";
 
 const WRAP = "mx-auto max-w-[1180px] px-6 md:px-10";
-
-export async function generateStaticParams() {
-  const events = await getConversationsEvents().catch(() => []);
-  return events.map((event) => ({ slug: event.slug }));
-}
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
Prod /conversations/[slug] returns 500 with digest DYNAMIC_SERVER_USAGE (Vercel runtime logs, cache=MISS, 15:34-15:35 UTC).

Root cause: the root layout calls cookies() (ensureVisitorId) on every page. Routes that had params at build time hit that during prerender and were classified dynamic. /conversations/[slug] had no ConversationsPage rows at build (seeded after deploy), generateStaticParams returned [], Next never rendered it, classified it static ISR, and every on-demand render trips the dynamic-API bail-out as a hard error.

Fix: export const dynamic = "force-dynamic"; drop revalidate + generateStaticParams. Matches how every other public page actually runs, and the Saturday live-result flip wants request-time freshness anyway.

Same latent trap exists on /events/[slug] for any event created after a build; not changed here, flagged.

Verified: tsc clean, eslint clean, vitest 93/93. Prod verification after merge: curl the slug for 200 + seeded content.

@Spidey-Acer

https://claude.ai/code/session_01BQ8rdeMj8UvBxQKvBAN5B9
